### PR TITLE
Add ability to use proxy authentication in java rest client

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/RestClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/RestClient.java
@@ -14,6 +14,7 @@ import com.microsoft.rest.UserAgentInterceptor;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
 import com.microsoft.rest.retry.RetryHandler;
 import com.microsoft.rest.serializer.JacksonMapperAdapter;
+import okhttp3.Authenticator;
 import okhttp3.ConnectionPool;
 import okhttp3.Interceptor;
 import okhttp3.JavaNetCookieJar;
@@ -332,6 +333,17 @@ public final class RestClient {
          */
         public Builder withProxy(Proxy proxy) {
             httpClientBuilder.proxy(proxy);
+            return this;
+        }
+
+        /**
+         * Sets the proxy authenticator for the HTTP client.
+         *
+         * @param proxyAuthenticator the proxy authenticator to use
+         * @return the builder itself for chaining
+         */
+        public Builder withProxyAuthenticator(Authenticator proxyAuthenticator) {
+            httpClientBuilder.proxyAuthenticator(proxyAuthenticator);
             return this;
         }
 


### PR DESCRIPTION
To be able to use proxy servers with authentication in azure java sdk we need to set proxy authenticator for the rest client.

Issue: Azure/azure-sdk-for-java#1225