### PR TITLE
Default to AzureEnvironment.AZURE if environment is set to null

### DIFF
--- a/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/ApplicationTokenCredentials.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/ApplicationTokenCredentials.java
@@ -52,7 +52,7 @@ public class ApplicationTokenCredentials extends TokenCredentials implements Azu
      */
     public ApplicationTokenCredentials(String clientId, String domain, String secret, AzureEnvironment environment) {
         super(null, null); // defer token acquisition
-        this.environment = environment;
+        this.environment = (environment == null) ? AzureEnvironment.AZURE : environment;
         this.clientId = clientId;
         this.domain = domain;
         this.secret = secret;

--- a/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/UserTokenCredentials.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/UserTokenCredentials.java
@@ -53,7 +53,7 @@ public class UserTokenCredentials extends TokenCredentials implements AzureToken
         this.domain = domain;
         this.username = username;
         this.password = password;
-        this.environment = environment;
+        this.environment = (environment == null) ? AzureEnvironment.AZURE : environment;
         this.tokens = new HashMap<>();
     }
 


### PR DESCRIPTION
Based on the documentation for the class constructor, if environment is
null it should default to AzureEnvironment.AZURE.