### PR TITLE
Release 1.0.0 beta5

### DIFF
--- a/azure-android-client-authentication/build.gradle
+++ b/azure-android-client-authentication/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 23
         versionCode 1
-        versionName "1.0.0-beta5-SNAPSHOT"
+        versionName "1.0.0-beta5"
     }
 
     buildTypes {

--- a/azure-android-client-authentication/build.gradle
+++ b/azure-android-client-authentication/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 23
         versionCode 1
-        versionName "1.0.0-beta5"
+        versionName "1.0.0-beta6-SNAPSHOT"
     }
 
     buildTypes {

--- a/azure-client-authentication/build.gradle
+++ b/azure-client-authentication/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'checkstyle'
 
-version = '1.0.0-beta5-SNAPSHOT'
+version = '1.0.0-beta5'
 
 checkstyle {
     toolVersion = "6.18"
@@ -21,7 +21,7 @@ checkstyle {
 
 dependencies {
     compile 'com.microsoft.azure:adal4j:1.1.2'
-    compile 'com.microsoft.azure:azure-client-runtime:1.0.0-beta5-SNAPSHOT'
+    compile 'com.microsoft.azure:azure-client-runtime:1.0.0-beta5'
     testCompile 'junit:junit:4.12'
     testCompile 'junit:junit-dep:4.11'
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.10"

--- a/azure-client-authentication/build.gradle
+++ b/azure-client-authentication/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'checkstyle'
 
-version = '1.0.0-beta5'
+version = '1.0.0-beta6-SNAPSHOT'
 
 checkstyle {
     toolVersion = "6.18"
@@ -21,7 +21,7 @@ checkstyle {
 
 dependencies {
     compile 'com.microsoft.azure:adal4j:1.1.2'
-    compile 'com.microsoft.azure:azure-client-runtime:1.0.0-beta5'
+    compile 'com.microsoft.azure:azure-client-runtime:1.0.0-beta6-SNAPSHOT'
     testCompile 'junit:junit:4.12'
     testCompile 'junit:junit-dep:4.11'
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.10"

--- a/azure-client-authentication/pom.xml
+++ b/azure-client-authentication/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
-    <version>1.0.0-beta5-SNAPSHOT</version>
+    <version>1.0.0-beta5</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-client-runtime</artifactId>
-      <version>1.0.0-beta5-SNAPSHOT</version>
+      <version>1.0.0-beta5</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>

--- a/azure-client-authentication/pom.xml
+++ b/azure-client-authentication/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
-    <version>1.0.0-beta5</version>
+    <version>1.0.0-beta6-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-client-runtime</artifactId>
-      <version>1.0.0-beta5</version>
+      <version>1.0.0-beta6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>

--- a/azure-client-runtime/build.gradle
+++ b/azure-client-runtime/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'checkstyle'
 
-version = '1.0.0-beta5'
+version = '1.0.0-beta6-SNAPSHOT'
 
 checkstyle {
     toolVersion = "6.18"
@@ -20,7 +20,7 @@ checkstyle {
 }
 
 dependencies {
-    compile 'com.microsoft.rest:client-runtime:1.0.0-beta5'
+    compile 'com.microsoft.rest:client-runtime:1.0.0-beta6-SNAPSHOT'
     testCompile 'junit:junit:4.12'
     testCompile 'junit:junit-dep:4.11'
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.10"

--- a/azure-client-runtime/build.gradle
+++ b/azure-client-runtime/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'checkstyle'
 
-version = '1.0.0-beta5-SNAPSHOT'
+version = '1.0.0-beta5'
 
 checkstyle {
     toolVersion = "6.18"
@@ -20,7 +20,7 @@ checkstyle {
 }
 
 dependencies {
-    compile 'com.microsoft.rest:client-runtime:1.0.0-beta5-SNAPSHOT'
+    compile 'com.microsoft.rest:client-runtime:1.0.0-beta5'
     testCompile 'junit:junit:4.12'
     testCompile 'junit:junit-dep:4.11'
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.10"

--- a/azure-client-runtime/pom.xml
+++ b/azure-client-runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
-    <version>1.0.0-beta5-SNAPSHOT</version>
+    <version>1.0.0-beta5</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.microsoft.rest</groupId>
       <artifactId>client-runtime</artifactId>
-      <version>1.0.0-beta5-SNAPSHOT</version>
+      <version>1.0.0-beta5</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/azure-client-runtime/pom.xml
+++ b/azure-client-runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
-    <version>1.0.0-beta5</version>
+    <version>1.0.0-beta6-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.microsoft.rest</groupId>
       <artifactId>client-runtime</artifactId>
-      <version>1.0.0-beta5</version>
+      <version>1.0.0-beta6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
-    <version>1.0.0-beta5-SNAPSHOT</version>
+    <version>1.0.0-beta5</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
-    <version>1.0.0-beta5</version>
+    <version>1.0.0-beta6-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/client-runtime/build.gradle
+++ b/client-runtime/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'checkstyle'
 
 group = 'com.microsoft.rest'
-version = '1.0.0-beta5-SNAPSHOT'
+version = '1.0.0-beta5'
 
 checkstyle {
     toolVersion = "6.18"

--- a/client-runtime/build.gradle
+++ b/client-runtime/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'checkstyle'
 
 group = 'com.microsoft.rest'
-version = '1.0.0-beta5'
+version = '1.0.0-beta6-SNAPSHOT'
 
 checkstyle {
     toolVersion = "6.18"

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
-    <version>1.0.0-beta5-SNAPSHOT</version>
+    <version>1.0.0-beta5</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
-    <version>1.0.0-beta5</version>
+    <version>1.0.0-beta6-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.microsoft.azure</groupId>
   <artifactId>autorest-clientruntime-for-java</artifactId>
-  <version>1.0.0-beta5-SNAPSHOT</version>
+  <version>1.0.0-beta5</version>
   <packaging>pom</packaging>
 
   <name>AutoRest Client Runtimes for Java</name>
@@ -137,7 +137,7 @@
           <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>autorest-build-tools</artifactId>
-            <version>1.0.0-beta5-SNAPSHOT</version>
+            <version>1.0.0-beta5</version>
           </dependency>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.microsoft.azure</groupId>
   <artifactId>autorest-clientruntime-for-java</artifactId>
-  <version>1.0.0-beta5</version>
+  <version>1.0.0-beta6-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>AutoRest Client Runtimes for Java</name>
@@ -137,7 +137,7 @@
           <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>autorest-build-tools</artifactId>
-            <version>1.0.0-beta5</version>
+            <version>1.0.0-beta6-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>


### PR DESCRIPTION
After merge:

1. Publish following runtime 1.0.0-beta6-SNAPSHOT(s) to sonatype

    azure-client-runtime [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/microsoft/azure/azure-client-runtime/)
    azure-client-authentication [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/microsoft/azure/azure-client-authentication/)
    autorest-build-tools [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/microsoft/azure/autorest-build-tools/)
    rest client runtime  [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/microsoft/rest/client-runtime/)

2. Re-run CI for the PR https://github.com/Azure/azure-sdk-for-java/pull/1444 that requires the above snapshots.