### PR TITLE
Better handling of CloudError 

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
@@ -260,7 +260,7 @@ final class PollingState<T> {
      *
      * @param error the cloud error.
      */
-    private PollingState<T> withErrorBody(CloudError error) {
+    PollingState<T> withErrorBody(CloudError error) {
         this.error = error;
         return this;
     }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
@@ -52,7 +52,7 @@ final class CloudErrorDeserializer extends JsonDeserializer<CloudError> {
         if (errorNode == null) {
             return null;
         }
-        if(errorNode.get("error") != null) {
+        if (errorNode.get("error") != null) {
             errorNode = errorNode.get("error");
         }
         JsonParser parser = new JsonFactory().createParser(errorNode.toString());

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.serializer;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -48,12 +47,8 @@ final class CloudErrorDeserializer extends JsonDeserializer<CloudError> {
     }
 
     @Override
-    public CloudError deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        JsonNode topNode = p.readValueAsTree();
-        if (topNode == null) {
-            return null;
-        }
-        JsonNode errorNode = topNode.get("error");
+    public CloudError deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode errorNode = p.readValueAsTree();
         if (errorNode == null) {
             return null;
         }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
@@ -52,6 +52,9 @@ final class CloudErrorDeserializer extends JsonDeserializer<CloudError> {
         if (errorNode == null) {
             return null;
         }
+        if(errorNode.get("error") != null) {
+            errorNode = errorNode.get("error");
+        }
         JsonParser parser = new JsonFactory().createParser(errorNode.toString());
         parser.setCodec(mapper);
         return parser.readValueAs(CloudError.class);


### PR DESCRIPTION
Following are the issues addressed in this PR.

1. The `CloudErrorDeserializer` was not correctly deserializing CloudError from the response of a LRO Azure-AsyncOperation Query. An unsuccessful response looks like
```
{
  "startTime": "2017-06-21T20:34:18.679743+00:00",
  "endTime": "2017-06-21T20:38:10.607023+00:00",
  "status": "Canceled",
  "error": {
    "code": "OperationPreempted",
    "message": "The operation has been preempted by a more recent operation."
  },
  "name": "59e17e11-aa27-4052-8ab1-d3d93092f8f7"
}
```

In CloudErrorDeserializer::deserialize(..) the [topNode](https://github.com/Azure/autorest-clientruntime-for-java/blob/a7f9826fef1c45d507b2a7abb5fd8ccb83a7b429/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java#L52) variable is already pointing to the value of error node i.e. ```{  "code": "OperationPreempted", "message": "The operation has been preempted by a more recent operation." },```, but we are again looking for "error" node within this value which seems wrong in this case.

2. Above is the case where `CloudError` is composed inside the `AzureAsyncOperation` and we deserialize response to `AzureAsyncOperation` as below:

```java
body = restClient().serializerAdapter().deserialize(bodyString, AzureAsyncOperation.class);
``` 

There are cases where CloudError are in top level. For example the error returned when a PUT fails because of not registering provider looks like:

```json
{
     "error":
     {
       "code":"MissingSubscriptionRegistration",
       "message":"The subscription is not registered to use namespace 'Microsoft.Cache'. See https://aka.ms/rps-not-found for how to register subscriptions."
     }
}
```

We use following code to deserialize this -

```java
body = restClient().serializerAdapter().deserialize(bodyString, CloudError.class);
``` 

In this case, the  CloudErrorDeserializer::deserialize(..) the [topNode](https://github.com/Azure/autorest-clientruntime-for-java/blob/a7f9826fef1c45d507b2a7abb5fd8ccb83a7b429/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java#L52) variable is pointing to ```{ error: {  "code": "OperationPreempted", "message": "The operation has been preempted by a more recent operation." } }```, hence we need to look into error node (This is currently handled). 


3. The pollingState object can optionally contain value for errorBody (which is of type CloudError), we are not including this in the CloudException that we throw. 