### PR TITLE
[After 1.0.4] Enabling user to poll long running operations

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperation.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperation.java
@@ -6,6 +6,11 @@
 
 package com.microsoft.azure;
 
+import com.microsoft.rest.protocol.SerializerAdapter;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -107,24 +112,43 @@ final class AzureAsyncOperation {
     }
 
     /**
-     * The delay in seconds that should be used when checking
-     * for the status of the operation.
+     * Async operation in string format
      */
-    private int retryAfter;
+    private String rawString;
 
     /**
-     * @return the delay in seconds
+     * @return the raw string
      */
-    int retryAfter() {
-        return this.retryAfter;
+    String rawString() {
+        return this.rawString;
     }
 
     /**
-     * Sets the delay in seconds.
+     * Creates AzureAsyncOperation from the given HTTP response.
      *
-     * @param retryAfter the delay in seconds.
+     * @param serializerAdapter the adapter to use for deserialization
+     * @param response the response
+     * @return the async operation object
+     * @throws CloudException if the deserialization fails or response contains invalid body
      */
-    void setRetryAfter(int retryAfter) {
-        this.retryAfter = retryAfter;
+    static AzureAsyncOperation fromResponse(SerializerAdapter<?> serializerAdapter, Response<ResponseBody> response) throws CloudException {
+        AzureAsyncOperation asyncOperation = null;
+        String rawString = null;
+        if (response.body() != null) {
+            try {
+                rawString = response.body().string();
+                asyncOperation = serializerAdapter.deserialize(rawString, AzureAsyncOperation.class);
+                asyncOperation.rawString = rawString;
+            } catch (IOException exception) {
+                // Exception will be handled below
+            }
+            finally {
+                response.body().close();
+            }
+        }
+        if (asyncOperation == null || asyncOperation.status() == null) {
+            throw new CloudException("polling response does not contain a valid body: " + rawString, response);
+        }
+        return asyncOperation;
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperation.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperation.java
@@ -112,7 +112,7 @@ final class AzureAsyncOperation {
     }
 
     /**
-     * Async operation in string format
+     * Async operation in string format.
      */
     private String rawString;
 

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
@@ -14,6 +14,8 @@ import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.Url;
 import rx.Observable;
+import rx.Single;
+import rx.exceptions.Exceptions;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 
@@ -79,7 +81,7 @@ public final class AzureClient extends AzureServiceClient {
      *
      * @param observable  the initial observable from the PUT or PATCH operation.
      * @param <T>       the return type of the caller
-     * @param resourceType the type of the resource
+     * @param resourceType the java.lang.reflect.Type of the resource.
      * @return          the terminal response for the operation.
      * @throws CloudException REST exception
      * @throws InterruptedException interrupted exception
@@ -95,7 +97,7 @@ public final class AzureClient extends AzureServiceClient {
      * the status of the operation until the long running operation terminates.
      *
      * @param observable  the initial observable from the PUT or PATCH operation.
-     * @param resourceType the type of the resource
+     * @param resourceType the java.lang.reflect.Type of the resource.
      * @param headerType the type of the response header
      * @param <T>       the return type of the caller
      * @param <THeader> the type of the response header
@@ -107,104 +109,155 @@ public final class AzureClient extends AzureServiceClient {
     public <T, THeader> ServiceResponseWithHeaders<T, THeader> getPutOrPatchResultWithHeaders(Observable<Response<ResponseBody>> observable, Type resourceType, Class<THeader> headerType) throws CloudException, InterruptedException, IOException {
         ServiceResponse<T> bodyResponse = getPutOrPatchResult(observable, resourceType);
         return new ServiceResponseWithHeaders<>(
-            bodyResponse.body(),
-            restClient().serializerAdapter().<THeader>deserialize(restClient().serializerAdapter().serialize(bodyResponse.response().headers()), headerType),
-            bodyResponse.response()
+                bodyResponse.body(),
+                restClient().serializerAdapter().<THeader>deserialize(restClient().serializerAdapter().serialize(bodyResponse.response().headers()), headerType),
+                bodyResponse.response()
         );
     }
 
     /**
-     * Handles an initial response from a PUT or PATCH operation response by polling
-     * the status of the operation asynchronously, calling the user provided callback
-     * when the operation terminates.
+     * Handles an initial response from a PUT or PATCH operation response by polling the status of the operation
+     * asynchronously, once the operation finishes emits the final response.
      *
-     * @param observable  the initial observable from the PUT or PATCH operation.
+     * @param observable the initial observable from the PUT or PATCH operation.
+     * @param resourceType the java.lang.reflect.Type of the resource.
      * @param <T>       the return type of the caller.
-     * @param resourceType the type of the resource.
      * @return          the observable of which a subscription will lead to a final response.
      */
     public <T> Observable<ServiceResponse<T>> getPutOrPatchResultAsync(Observable<Response<ResponseBody>> observable, final Type resourceType) {
-        return observable
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<T>>>() {
-                @Override
-                public Observable<ServiceResponse<T>> call(Response<ResponseBody> response) {
-                    RuntimeException exception = createExceptionFromResponse(response, 200, 201, 202);
-                    if (exception != null) {
-                        return Observable.error(exception);
+        return this.<T>beginPutOrPatchAsync(observable, resourceType)
+                .toObservable()
+                .flatMap(new Func1<PollingState<T>, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(PollingState<T> pollingState) {
+                        return pollPutOrPatchAsync(pollingState, resourceType);
                     }
-
-                    try {
-                        final PollingState<T> pollingState = new PollingState<>(response, longRunningOperationRetryTimeout(), resourceType, restClient().serializerAdapter());
-                        final String url = response.raw().request().url().toString();
-
-                        // Task runner will take it from here
-                        return Observable.just(pollingState)
-                            .subscribeOn(Schedulers.io())
-                            // Emit a polling task intermittently
-                            .repeatWhen(new Func1<Observable<? extends Void>, Observable<?>>() {
-                                @Override
-                                public Observable<?> call(Observable<? extends Void> observable) {
-                                    return observable.delay(pollingState.delayInMilliseconds(), TimeUnit.MILLISECONDS);
-                                }
-                            })
-                            // Conditionally polls if it's not a terminal status
-                            .flatMap(new Func1<PollingState<T>, Observable<PollingState<T>>>() {
-                                @Override
-                                public Observable<PollingState<T>> call(PollingState<T> pollingState) {
-                                    for (String terminalStatus : AzureAsyncOperation.terminalStatuses()) {
-                                        if (terminalStatus.equalsIgnoreCase(pollingState.status())) {
-                                            return Observable.just(pollingState);
-                                        }
-                                    }
-                                    return putOrPatchPollingDispatcher(pollingState, url);
-                                }
-                            })
-                            // The above process continues until this filter passes
-                            .filter(new Func1<PollingState<T>, Boolean>() {
-                                @Override
-                                public Boolean call(PollingState<T> pollingState) {
-                                    for (String terminalStatus : AzureAsyncOperation.terminalStatuses()) {
-                                        if (terminalStatus.equalsIgnoreCase(pollingState.status())) {
-                                            return true;
-                                        }
-                                    }
-                                    return false;
-                                }
-                            })
-                            .first()
-                            // Possible extra get to receive the actual resource
-                            .flatMap(new Func1<PollingState<T>, Observable<PollingState<T>>>() {
-                                @Override
-                                public Observable<PollingState<T>> call(PollingState<T> pollingState) {
-                                    if (AzureAsyncOperation.SUCCESS_STATUS.equalsIgnoreCase(pollingState.status()) && pollingState.resource() == null) {
-                                        return updateStateFromGetResourceOperationAsync(pollingState, url);
-                                    }
-                                    for (String failedStatus : AzureAsyncOperation.failedStatuses()) {
-                                        if (failedStatus.equalsIgnoreCase(pollingState.status())) {
-                                            if (pollingState.errorBody() != null) {
-                                                return Observable.error(new CloudException("Async operation failed with provisioning state: " + pollingState.status(),
-                                                        pollingState.response(),
-                                                        pollingState.errorBody()));
-                                            } else {
-                                                return Observable.error(new CloudException("Async operation failed with provisioning state: " + pollingState.status(),
-                                                        pollingState.response()));
-                                            }
-                                        }
-                                    }
-                                    return Observable.just(pollingState);
-                                }
-                            })
-                            .map(new Func1<PollingState<T>, ServiceResponse<T>>() {
-                                @Override
-                                public ServiceResponse<T> call(PollingState<T> pollingState) {
-                                    return new ServiceResponse<>(pollingState.resource(), pollingState.response());
-                                }
-                            });
-                    } catch (IOException e) {
-                        return Observable.error(e);
+                })
+                .last()
+                .map(new Func1<PollingState<T>, ServiceResponse<T>>() {
+                    @Override
+                    public ServiceResponse<T> call(PollingState<T> pollingState) {
+                        return new ServiceResponse<>(pollingState.resource(), pollingState.response());
                     }
+                });
+    }
+
+    /**
+     * Given an observable representing a deferred PUT or PATCH action, this method returns {@link Single} object,
+     * when subscribed to it, the deferred action will be performed and emits the polling state containing information
+     * to track the progress of the action.
+     *
+     * Note: this method does not implicitly introduce concurrency, by default the deferred action will be executed
+     * in scheduler (if any) set for the provided observable.
+     *
+     * @param observable an observable representing a deferred PUT or PATCH operation.
+     * @param resourceType the java.lang.reflect.Type of the resource.
+     * @param <T> the type of the resource
+     * @return the observable of which a subscription will lead PUT or PATCH action.
+     */
+    public <T> Single<PollingState<T>> beginPutOrPatchAsync(Observable<Response<ResponseBody>> observable, final Type resourceType) {
+        return observable.map(new Func1<Response<ResponseBody>, PollingState<T>>() {
+            @Override
+            public PollingState<T> call(Response<ResponseBody> response) {
+                RuntimeException exception = createExceptionFromResponse(response, 200, 201, 202);
+                if (exception != null) {
+                    throw  exception;
                 }
-            });
+                try {
+                    final PollingState<T> pollingState = new PollingState<>(response, longRunningOperationRetryTimeout(), resourceType, restClient().serializerAdapter());
+                    pollingState.withPollingUrlFromResponse(response);
+                    pollingState.withPollingRetryTimeoutFromResponse(response);
+                    pollingState.withPutOrPatchResourceUri(response.raw().request().url().toString());
+                    return pollingState;
+                } catch (IOException ioException) {
+                    throw Exceptions.propagate(ioException);
+                }
+            }
+        }).toSingle();
+    }
+
+    /**
+     * Given a polling state representing state of a PUT or PATCH operation, this method returns {@link Single} object,
+     * when subscribed to it, a single poll will be performed and emits the latest polling state. A poll will be
+     * performed only if the current polling state is not in terminal state.
+     *
+     * Note: this method does not implicitly introduce concurrency, by default the deferred action will be executed
+     * in scheduler (if any) set for the provided observable.
+     *
+     * @param pollingState the current polling state
+     * @param <T> the type of the resource
+     * @param resourceType the java.lang.reflect.Type of the resource.
+     * @return the observable of which a subscription will lead single polling action.
+     */
+    private <T> Single<PollingState<T>> pollPutOrPatchSingleAsync(final PollingState<T> pollingState, final Type resourceType) {
+        pollingState.withResourceType(resourceType);
+        pollingState.withSerializerAdapter(restClient().serializerAdapter());
+        if (pollingState.isStatusTerminal()) {
+            if (pollingState.isStatusSucceeded() && pollingState.resource() == null) {
+                return updateStateFromGetResourceOperationAsync(pollingState, pollingState.putOrPatchResourceUri()).toSingle();
+            }
+            return Single.just(pollingState);
+        }
+        return putOrPatchPollingDispatcher(pollingState, pollingState.putOrPatchResourceUri())
+                .map(new Func1<PollingState<T>, PollingState<T>>() {
+                    @Override
+                    public PollingState<T> call(PollingState<T> tPollingState) {
+                        tPollingState.throwCloudExceptionIfInFailedState();
+                        return tPollingState;
+                    }
+                })
+                .flatMap(new Func1<PollingState<T>, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(PollingState<T> tPollingState) {
+                        if (pollingState.isStatusSucceeded() && pollingState.resource() == null) {
+                            return updateStateFromGetResourceOperationAsync(pollingState, pollingState.putOrPatchResourceUri());
+                        }
+                        return Observable.just(tPollingState);
+                    }
+                })
+                .toSingle();
+    }
+
+    /**
+     * Given a polling state representing state of a PUT or PATCH operation, this method returns {@link Observable} object,
+     * when subscribed to it, a series of polling will be performed and emits each polling state to downstream.
+     * Polling will completes when the operation finish with success, failure or exception.
+     *
+     * Note: this method implicitly runs the polling on rx IO scheduler.
+     *
+     * @param pollingState the current polling state
+     * @param <T> the type of the resource
+     * @param resourceType the java.lang.reflect.Type of the resource.
+     * @return the observable of which a subscription will lead multiple polling action.
+     */
+    private <T> Observable<PollingState<T>> pollPutOrPatchAsync(final PollingState<T> pollingState, final Type resourceType) {
+        pollingState.withResourceType(resourceType);
+        pollingState.withSerializerAdapter(restClient().serializerAdapter());
+        return Observable.just(true)
+                .subscribeOn(Schedulers.io())
+                .flatMap(new Func1<Boolean, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(Boolean aBoolean) {
+                        return pollPutOrPatchSingleAsync(pollingState, resourceType).toObservable();
+                    }
+                }).repeatWhen(new Func1<Observable<? extends Void>, Observable<?>>() {
+                    @Override
+                    public Observable<?> call(Observable<? extends Void> observable) {
+                        return observable.flatMap(new Func1<Void, Observable<Long>>() {
+                            @Override
+                            public Observable<Long> call(Void aVoid) {
+                                return Observable.timer(pollingState.delayInMilliseconds(),
+                                        TimeUnit.MILLISECONDS,
+                                        Schedulers.io());
+                            }
+                        });
+                    }
+                }).takeUntil(new Func1<PollingState<T>, Boolean>() {
+                    @Override
+                    public Boolean call(PollingState<T> tPollingState) {
+                        return pollingState.isStatusTerminal();
+                    }
+                });
     }
 
     /**
@@ -215,26 +268,26 @@ public final class AzureClient extends AzureServiceClient {
      * @param observable  the initial response from the PUT or PATCH operation.
      * @param <T>       the return type of the caller
      * @param <THeader> the type of the response header
-     * @param resourceType the type of the resource.
+     * @param resourceType the java.lang.reflect.Type of the resource.
      * @param headerType the type of the response header
      * @return          the task describing the asynchronous polling.
      */
     public <T, THeader> Observable<ServiceResponseWithHeaders<T, THeader>> getPutOrPatchResultWithHeadersAsync(Observable<Response<ResponseBody>> observable, Type resourceType, final Class<THeader> headerType) {
         Observable<ServiceResponse<T>> bodyResponse = getPutOrPatchResultAsync(observable, resourceType);
         return bodyResponse
-            .flatMap(new Func1<ServiceResponse<T>, Observable<ServiceResponseWithHeaders<T, THeader>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<T, THeader>> call(ServiceResponse<T> serviceResponse) {
-                    try {
-                        return Observable
-                            .just(new ServiceResponseWithHeaders<>(serviceResponse.body(),
-                                restClient().serializerAdapter().<THeader>deserialize(restClient().serializerAdapter().serialize(serviceResponse.response().headers()), headerType),
-                                serviceResponse.response()));
-                    } catch (IOException e) {
-                        return Observable.error(e);
+                .flatMap(new Func1<ServiceResponse<T>, Observable<ServiceResponseWithHeaders<T, THeader>>>() {
+                    @Override
+                    public Observable<ServiceResponseWithHeaders<T, THeader>> call(ServiceResponse<T> serviceResponse) {
+                        try {
+                            return Observable
+                                    .just(new ServiceResponseWithHeaders<>(serviceResponse.body(),
+                                            restClient().serializerAdapter().<THeader>deserialize(restClient().serializerAdapter().serialize(serviceResponse.response().headers()), headerType),
+                                            serviceResponse.response()));
+                        } catch (IOException e) {
+                            return Observable.error(e);
+                        }
                     }
-                }
-            });
+                });
     }
 
     /**
@@ -259,7 +312,7 @@ public final class AzureClient extends AzureServiceClient {
      * the status of the operation until the long running operation terminates.
      *
      * @param observable  the initial observable from the POST or DELETE operation.
-     * @param resourceType the type of the resource
+     * @param resourceType the java.lang.reflect.Type of the resource.
      * @param headerType the type of the response header
      * @param <T>       the return type of the caller
      * @param <THeader> the type of the response header
@@ -271,9 +324,9 @@ public final class AzureClient extends AzureServiceClient {
     public <T, THeader> ServiceResponseWithHeaders<T, THeader> getPostOrDeleteResultWithHeaders(Observable<Response<ResponseBody>> observable, Type resourceType, Class<THeader> headerType) throws CloudException, InterruptedException, IOException {
         ServiceResponse<T> bodyResponse = getPostOrDeleteResult(observable, resourceType);
         return new ServiceResponseWithHeaders<>(
-            bodyResponse.body(),
-            restClient().serializerAdapter().<THeader>deserialize(restClient().serializerAdapter().serialize(bodyResponse.response().headers()), headerType),
-            bodyResponse.response()
+                bodyResponse.body(),
+                restClient().serializerAdapter().<THeader>deserialize(restClient().serializerAdapter().serialize(bodyResponse.response().headers()), headerType),
+                bodyResponse.response()
         );
     }
 
@@ -284,77 +337,121 @@ public final class AzureClient extends AzureServiceClient {
      *
      * @param observable  the initial response from the POST or DELETE operation.
      * @param <T>       the return type of the caller.
-     * @param resourceType the type of the resource.
+     * @param resourceType the java.lang.reflect.Type of the resource.
      * @return          the task describing the asynchronous polling.
      */
     public <T> Observable<ServiceResponse<T>> getPostOrDeleteResultAsync(Observable<Response<ResponseBody>> observable, final Type resourceType) {
-        return observable
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponse<T>>>() {
-                @Override
-                public Observable<ServiceResponse<T>> call(Response<ResponseBody> response) {
-                    RuntimeException exception = createExceptionFromResponse(response, 200, 202, 204);
-                    if (exception != null) {
-                        return Observable.error(exception);
+        return this.<T>beginPostOrDeleteAsync(observable, resourceType)
+                .toObservable()
+                .flatMap(new Func1<PollingState<T>, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(PollingState<T> pollingState) {
+                        return pollPostOrDeleteAsync(pollingState, resourceType);
                     }
+                })
+                .last()
+                .map(new Func1<PollingState<T>, ServiceResponse<T>>() {
+                    @Override
+                    public ServiceResponse<T> call(PollingState<T> pollingState) {
+                        return new ServiceResponse<>(pollingState.resource(), pollingState.response());
+                    }
+                });
+    }
 
-                    try {
-                        final PollingState<T> pollingState = new PollingState<>(response, longRunningOperationRetryTimeout(), resourceType, restClient().serializerAdapter());
-                        return Observable.just(pollingState)
-                            .subscribeOn(Schedulers.io())
-                            // Emit a polling task intermittently
-                            .repeatWhen(new Func1<Observable<? extends Void>, Observable<?>>() {
-                                @Override
-                                public Observable<?> call(Observable<? extends Void> observable) {
-                                    return observable.delay(pollingState.delayInMilliseconds(), TimeUnit.MILLISECONDS);
-                                }
-                            })
-                            // Conditionally polls if it's not a terminal status
-                            .flatMap(new Func1<PollingState<T>, Observable<PollingState<T>>>() {
-                                @Override
-                                public Observable<PollingState<T>> call(PollingState<T> pollingState) {
-                                    for (String terminalStatus : AzureAsyncOperation.terminalStatuses()) {
-                                        if (terminalStatus.equalsIgnoreCase(pollingState.status())) {
-                                            return Observable.just(pollingState);
-                                        }
-                                    }
-                                    return postOrDeletePollingDispatcher(pollingState);
-                                }
-                            })
-                            // The above process continues until this filter passes
-                            .filter(new Func1<PollingState<T>, Boolean>() {
-                                @Override
-                                public Boolean call(PollingState<T> pollingState) {
-                                    for (String terminalStatus : AzureAsyncOperation.terminalStatuses()) {
-                                        if (terminalStatus.equalsIgnoreCase(pollingState.status())) {
-                                            return true;
-                                        }
-                                    }
-                                    return false;
-                                }
-                            })
-                            .first()
-                            .flatMap(new Func1<PollingState<T>, Observable<ServiceResponse<T>>>() {
-                                @Override
-                                public Observable<ServiceResponse<T>> call(PollingState<T> pollingState) {
-                                    for (String failedStatus : AzureAsyncOperation.failedStatuses()) {
-                                        if (failedStatus.equalsIgnoreCase(pollingState.status())) {
-                                            if (pollingState.errorBody() != null) {
-                                                return Observable.error(new CloudException("Async operation failed with provisioning state: " + pollingState.status(),
-                                                        pollingState.response(),
-                                                        pollingState.errorBody()));
-                                            } else {
-                                                return Observable.error(new CloudException("Async operation failed with provisioning state: " + pollingState.status(),
-                                                        pollingState.response()));
-                                            }                                        }
-                                    }
-                                    return Observable.just(new ServiceResponse<>(pollingState.resource(), pollingState.response()));
-                                }
-                            });
-                    } catch (IOException e) {
-                        return Observable.error(e);
-                    }
+    /**
+     * Given an observable representing a deferred POST or DELETE action, this method returns {@link Single} object,
+     * when subscribed to it, the deferred action will be performed and emits the polling state containing information
+     * to track the progress of the action.
+     *
+     * @param observable an observable representing a deferred PUT or PATCH operation.
+     * @param resourceType the java.lang.reflect.Type of the resource.
+     * @param <T> the type of the resource
+     * @return the observable of which a subscription will lead POST or DELETE action.
+     */
+    public <T> Single<PollingState<T>> beginPostOrDeleteAsync(Observable<Response<ResponseBody>> observable, final Type resourceType) {
+        return observable.map(new Func1<Response<ResponseBody>, PollingState<T>>() {
+            @Override
+            public PollingState<T> call(Response<ResponseBody> response) {
+                RuntimeException exception = createExceptionFromResponse(response, 200, 202, 204);
+                if (exception != null) {
+                    throw  exception;
                 }
-            });
+                try {
+                    final PollingState<T> pollingState = new PollingState<>(response, longRunningOperationRetryTimeout(), resourceType, restClient().serializerAdapter());
+                    pollingState.withPollingUrlFromResponse(response);
+                    pollingState.withPollingRetryTimeoutFromResponse(response);
+                    return pollingState;
+                } catch (IOException ioException) {
+                    throw Exceptions.propagate(ioException);
+                }
+            }
+        }).toSingle();
+    }
+
+    /**
+     * Given a polling state representing state of a POST or DELETE operation, this method returns {@link Single} object,
+     * when subscribed to it, a single poll will be performed and emits the latest polling state. A poll will be
+     * performed only if the current polling state is not in terminal state.
+     *
+     * @param pollingState the current polling state
+     * @param resourceType the java.lang.reflect.Type of the resource.
+     * @param <T> the type of the resource
+     * @return the observable of which a subscription will lead single polling action.
+     */
+    private <T> Single<PollingState<T>> pollPostOrDeleteSingleAsync(final PollingState<T> pollingState, final Type resourceType) {
+        pollingState.withResourceType(resourceType);
+        pollingState.withSerializerAdapter(restClient().serializerAdapter());
+        if (pollingState.isStatusTerminal()) {
+            return Single.just(pollingState);
+        }
+        return postOrDeletePollingDispatcher(pollingState)
+                .map(new Func1<PollingState<T>, PollingState<T>>() {
+                    @Override
+                    public PollingState<T> call(PollingState<T> tPollingState) {
+                        tPollingState.throwCloudExceptionIfInFailedState();
+                        return tPollingState;
+                    }
+                })
+                .toSingle();
+    }
+
+    /**
+     * Given a polling state representing state of a POST or DELETE operation, this method returns {@link Observable} object,
+     * when subscribed to it, a series of polling will be performed and emits each polling state to downstream.
+     * Polling will completes when the operation finish with success, failure or exception.
+     *
+     * @param pollingState the current polling state
+     * @param resourceType the java.lang.reflect.Type of the resource.
+     * @param <T> the type of the resource
+     * @return the observable of which a subscription will lead multiple polling action.
+     */
+    private <T> Observable<PollingState<T>> pollPostOrDeleteAsync(final PollingState<T> pollingState, final Type resourceType) {
+        pollingState.withResourceType(resourceType);
+        pollingState.withSerializerAdapter(restClient().serializerAdapter());
+        return Observable.just(true)
+                .flatMap(new Func1<Boolean, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(Boolean aBoolean) {
+                        return pollPostOrDeleteSingleAsync(pollingState, resourceType).toObservable();
+                    }
+                }).repeatWhen(new Func1<Observable<? extends Void>, Observable<?>>() {
+                    @Override
+                    public Observable<?> call(Observable<? extends Void> observable) {
+                        return observable.flatMap(new Func1<Void, Observable<Long>>() {
+                            @Override
+                            public Observable<Long> call(Void aVoid) {
+                                return Observable.timer(pollingState.delayInMilliseconds(),
+                                        TimeUnit.MILLISECONDS,
+                                        Schedulers.io());
+                            }
+                        });
+                    }
+                }).takeUntil(new Func1<PollingState<T>, Boolean>() {
+                    @Override
+                    public Boolean call(PollingState<T> tPollingState) {
+                        return pollingState.isStatusTerminal();
+                    }
+                });
     }
 
     /**
@@ -365,26 +462,73 @@ public final class AzureClient extends AzureServiceClient {
      * @param observable  the initial observable from the POST or DELETE operation.
      * @param <T>       the return type of the caller
      * @param <THeader> the type of the response header
-     * @param resourceType the type of the resource.
+     * @param resourceType the java.lang.reflect.Type of the resource.
      * @param headerType the type of the response header
      * @return          the task describing the asynchronous polling.
      */
     public <T, THeader> Observable<ServiceResponseWithHeaders<T, THeader>> getPostOrDeleteResultWithHeadersAsync(Observable<Response<ResponseBody>> observable, Type resourceType, final Class<THeader> headerType) {
         Observable<ServiceResponse<T>> bodyResponse = getPostOrDeleteResultAsync(observable, resourceType);
         return bodyResponse
-            .flatMap(new Func1<ServiceResponse<T>, Observable<ServiceResponseWithHeaders<T, THeader>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<T, THeader>> call(ServiceResponse<T> serviceResponse) {
-                    try {
-                        return Observable
-                            .just(new ServiceResponseWithHeaders<>(serviceResponse.body(),
-                                restClient().serializerAdapter().<THeader>deserialize(restClient().serializerAdapter().serialize(serviceResponse.response().headers()), headerType),
-                                serviceResponse.response()));
-                    } catch (IOException e) {
-                        return Observable.error(e);
+                .flatMap(new Func1<ServiceResponse<T>, Observable<ServiceResponseWithHeaders<T, THeader>>>() {
+                    @Override
+                    public Observable<ServiceResponseWithHeaders<T, THeader>> call(ServiceResponse<T> serviceResponse) {
+                        try {
+                            return Observable
+                                    .just(new ServiceResponseWithHeaders<>(serviceResponse.body(),
+                                            restClient().serializerAdapter().<THeader>deserialize(restClient().serializerAdapter().serialize(serviceResponse.response().headers()), headerType),
+                                            serviceResponse.response()));
+                        } catch (IOException e) {
+                            return Observable.error(e);
+                        }
                     }
-                }
-            });
+                });
+    }
+
+    /**
+     * Given a polling state representing state of a LRO operation, this method returns {@link Single} object,
+     * when subscribed to it, a single poll will be performed and emits the latest polling state. A poll will be
+     * performed only if the current polling state is not in terminal state.
+     *
+     * Note: this method does not implicitly introduce concurrency, by default the deferred action will be executed
+     * in scheduler (if any) set for the provided observable.
+     *
+     * @param pollingState the current polling state
+     * @param <T> the type of the resource
+     * @param resourceType the java.lang.reflect.Type of the resource.
+     * @return the observable of which a subscription will lead single polling action.
+     */
+    public <T> Single<PollingState<T>> pollSingleAsync(final PollingState<T> pollingState, final Type resourceType) {
+        if (pollingState.initialHttpMethod().equalsIgnoreCase("PUT")
+                || pollingState.initialHttpMethod().equalsIgnoreCase("PATCH")) {
+            return this.pollPutOrPatchSingleAsync(pollingState, resourceType);
+        }
+        if (pollingState.initialHttpMethod().equalsIgnoreCase("POST")
+                || pollingState.initialHttpMethod().equalsIgnoreCase("DELETE")) {
+            return this.pollPostOrDeleteSingleAsync(pollingState, resourceType);
+        }
+        throw new IllegalArgumentException("PollingState contains unsupported http method:" + pollingState.initialHttpMethod());
+    }
+
+    /**
+     * Given a polling state representing state of an LRO operation, this method returns {@link Observable} object,
+     * when subscribed to it, a series of polling will be performed and emits each polling state to downstream.
+     * Polling will completes when the operation finish with success, failure or exception.
+     *
+     * @param pollingState the current polling state
+     * @param resourceType the java.lang.reflect.Type of the resource.
+     * @param <T> the type of the resource
+     * @return the observable of which a subscription will lead multiple polling action.
+     */
+    public <T> Observable<PollingState<T>> pollAsync(final PollingState<T> pollingState, final Type resourceType) {
+        if (pollingState.initialHttpMethod().equalsIgnoreCase("PUT")
+                || pollingState.initialHttpMethod().equalsIgnoreCase("PATCH")) {
+            return this.pollPutOrPatchAsync(pollingState, resourceType);
+        }
+        if (pollingState.initialHttpMethod().equalsIgnoreCase("POST")
+                || pollingState.initialHttpMethod().equalsIgnoreCase("DELETE")) {
+            return this.pollPostOrDeleteAsync(pollingState, resourceType);
+        }
+        throw new IllegalArgumentException("PollingState contains unsupported http method:" + pollingState.initialHttpMethod());
     }
 
     /**
@@ -396,23 +540,23 @@ public final class AzureClient extends AzureServiceClient {
      */
     private <T> Observable<PollingState<T>> updateStateFromLocationHeaderOnPutAsync(final PollingState<T> pollingState) {
         return pollAsync(pollingState.locationHeaderLink(), pollingState.response().raw().request().header(LOGGING_HEADER))
-            .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
-                @Override
-                public Observable<PollingState<T>> call(Response<ResponseBody> response) {
-                    int statusCode = response.code();
-                    if (statusCode == 202) {
-                        pollingState.withResponse(response);
-                        pollingState.withStatus(AzureAsyncOperation.IN_PROGRESS_STATUS);
-                    } else if (statusCode == 200 || statusCode == 201) {
-                        try {
-                            pollingState.updateFromResponseOnPutPatch(response);
-                        } catch (CloudException | IOException e) {
-                            return Observable.error(e);
+                .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(Response<ResponseBody> response) {
+                        int statusCode = response.code();
+                        if (statusCode == 202) {
+                            pollingState.withResponse(response);
+                            pollingState.withStatus(AzureAsyncOperation.IN_PROGRESS_STATUS);
+                        } else if (statusCode == 200 || statusCode == 201) {
+                            try {
+                                pollingState.updateFromResponseOnPutPatch(response);
+                            } catch (CloudException | IOException e) {
+                                return Observable.error(e);
+                            }
                         }
+                        return Observable.just(pollingState);
                     }
-                    return Observable.just(pollingState);
-                }
-            });
+                });
     }
 
     /**
@@ -424,23 +568,23 @@ public final class AzureClient extends AzureServiceClient {
      */
     private <T> Observable<PollingState<T>> updateStateFromLocationHeaderOnPostOrDeleteAsync(final PollingState<T> pollingState) {
         return pollAsync(pollingState.locationHeaderLink(), pollingState.response().raw().request().header(LOGGING_HEADER))
-            .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
-                @Override
-                public Observable<PollingState<T>> call(Response<ResponseBody> response) {
-                    int statusCode = response.code();
-                    if (statusCode == 202) {
-                        pollingState.withResponse(response);
-                        pollingState.withStatus(AzureAsyncOperation.IN_PROGRESS_STATUS);
-                    } else if (statusCode == 200 || statusCode == 201 || statusCode == 204) {
-                        try {
-                            pollingState.updateFromResponseOnDeletePost(response);
-                        } catch (IOException e) {
-                            return Observable.error(e);
+                .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(Response<ResponseBody> response) {
+                        int statusCode = response.code();
+                        if (statusCode == 202) {
+                            pollingState.withResponse(response);
+                            pollingState.withStatus(AzureAsyncOperation.IN_PROGRESS_STATUS);
+                        } else if (statusCode == 200 || statusCode == 201 || statusCode == 204) {
+                            try {
+                                pollingState.updateFromResponseOnDeletePost(response);
+                            } catch (IOException e) {
+                                return Observable.error(e);
+                            }
                         }
+                        return Observable.just(pollingState);
                     }
-                    return Observable.just(pollingState);
-                }
-            });
+                });
     }
 
     /**
@@ -453,17 +597,17 @@ public final class AzureClient extends AzureServiceClient {
      */
     private <T> Observable<PollingState<T>> updateStateFromGetResourceOperationAsync(final PollingState<T> pollingState, String url) {
         return pollAsync(url, pollingState.response().raw().request().header(LOGGING_HEADER))
-            .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
-                @Override
-                public Observable<PollingState<T>> call(Response<ResponseBody> response) {
-                    try {
-                        pollingState.updateFromResponseOnPutPatch(response);
-                        return Observable.just(pollingState);
-                    } catch (CloudException | IOException e) {
-                        return Observable.error(e);
+                .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(Response<ResponseBody> response) {
+                        try {
+                            pollingState.updateFromResponseOnPutPatch(response);
+                            return Observable.just(pollingState);
+                        } catch (CloudException | IOException e) {
+                            return Observable.error(e);
+                        }
                     }
-                }
-            });
+                });
     }
 
     /**
@@ -475,33 +619,22 @@ public final class AzureClient extends AzureServiceClient {
      */
     private <T> Observable<PollingState<T>> updateStateFromAzureAsyncOperationHeaderOnPutAsync(final PollingState<T> pollingState) {
         return pollAsync(pollingState.azureAsyncOperationHeaderLink(), pollingState.response().raw().request().header(LOGGING_HEADER))
-            .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
-                @Override
-                public Observable<PollingState<T>> call(Response<ResponseBody> response) {
-                    AzureAsyncOperation body = null;
-                    String bodyString = "";
-                    if (response.body() != null) {
+                .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(Response<ResponseBody> response) {
+                        final AzureAsyncOperation asyncOperation;
                         try {
-                            bodyString = response.body().string();
-                            body = restClient().serializerAdapter().deserialize(bodyString, AzureAsyncOperation.class);
-                        } catch (IOException e) {
-                            // null body will be handled later
-                        } finally {
-                            response.body().close();
+                            asyncOperation = AzureAsyncOperation.fromResponse(restClient().serializerAdapter(), response);
+                        } catch (CloudException exception) {
+                            return Observable.error(exception);
                         }
+                        pollingState.withStatus(asyncOperation.status());
+                        pollingState.withErrorBody(asyncOperation.getError());
+                        pollingState.withResponse(response);
+                        pollingState.withResource(null);
+                        return Observable.just(pollingState);
                     }
-
-                    if (body == null || body.status() == null) {
-                        CloudException exception = new CloudException("polling response does not contain a valid body: " + bodyString, response);
-                        return Observable.error(exception);
-                    }
-                    pollingState.withStatus(body.status());
-                    pollingState.withErrorBody(body.getError()); // If async response contains CloudError then set it
-                    pollingState.withResponse(response);
-                    pollingState.withResource(null);
-                    return Observable.just(pollingState);
-                }
-            });
+                });
     }
 
     /**
@@ -513,40 +646,27 @@ public final class AzureClient extends AzureServiceClient {
      */
     private <T> Observable<PollingState<T>> updateStateFromAzureAsyncOperationHeaderOnPostOrDeleteAsync(final PollingState<T> pollingState) {
         return pollAsync(pollingState.azureAsyncOperationHeaderLink(), pollingState.response().raw().request().header(LOGGING_HEADER))
-            .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
-                @Override
-                public Observable<PollingState<T>> call(Response<ResponseBody> response) {
-                    AzureAsyncOperation body = null;
-                    String bodyString = "";
-                    if (response.body() != null) {
+                .flatMap(new Func1<Response<ResponseBody>, Observable<PollingState<T>>>() {
+                    @Override
+                    public Observable<PollingState<T>> call(Response<ResponseBody> response) {
+                        final AzureAsyncOperation asyncOperation;
                         try {
-                            bodyString = response.body().string();
-                            body = restClient().serializerAdapter().deserialize(bodyString, AzureAsyncOperation.class);
-                        } catch (IOException e) {
-                            // null body will be handled later
-                        } finally {
-                            response.body().close();
+                            asyncOperation = AzureAsyncOperation.fromResponse(restClient().serializerAdapter(), response);
+                        } catch (CloudException exception) {
+                            return Observable.error(exception);
                         }
+                        pollingState.withStatus(asyncOperation.status());
+                        pollingState.withErrorBody(asyncOperation.getError());
+                        pollingState.withResponse(response);
+                        try {
+                            T resource = restClient().serializerAdapter().deserialize(asyncOperation.rawString(), pollingState.resourceType());
+                            pollingState.withResource(resource);
+                        } catch (IOException e) {
+                            // Ignore and let resource be null
+                        }
+                        return Observable.just(pollingState);
                     }
-
-                    if (body == null || body.status() == null) {
-                        CloudException exception = new CloudException("polling response does not contain a valid body: " + bodyString, response);
-                        return Observable.error(exception);
-                    }
-
-                    pollingState.withStatus(body.status());
-                    pollingState.withErrorBody(body.getError()); // If async response contains CloudError then set it
-                    pollingState.withResponse(response);
-                    T resource = null;
-                    try {
-                        resource = restClient().serializerAdapter().deserialize(bodyString, pollingState.resourceType());
-                    } catch (IOException e) {
-                        // Ignore and let resource be null
-                    }
-                    pollingState.withResource(resource);
-                    return Observable.just(pollingState);
-                }
-            });
+                });
     }
 
     /**
@@ -562,26 +682,22 @@ public final class AzureClient extends AzureServiceClient {
         } catch (MalformedURLException e) {
             return Observable.error(e);
         }
-        int port = endpoint.getPort();
-        if (port == -1) {
-            port = endpoint.getDefaultPort();
-        }
         AsyncService service = restClient().retrofit().create(AsyncService.class);
         if (!loggingContext.endsWith(" (poll)")) {
             loggingContext += " (poll)";
         }
         return service.get(endpoint.getFile(), serviceClientUserAgent, loggingContext)
-            .flatMap(new Func1<Response<ResponseBody>, Observable<Response<ResponseBody>>>() {
-                @Override
-                public Observable<Response<ResponseBody>> call(Response<ResponseBody> response) {
-                    RuntimeException exception = createExceptionFromResponse(response, 200, 201, 202, 204);
-                    if (exception != null) {
-                        return Observable.error(exception);
-                    } else {
-                        return Observable.just(response);
+                .flatMap(new Func1<Response<ResponseBody>, Observable<Response<ResponseBody>>>() {
+                    @Override
+                    public Observable<Response<ResponseBody>> call(Response<ResponseBody> response) {
+                        RuntimeException exception = createExceptionFromResponse(response, 200, 201, 202, 204);
+                        if (exception != null) {
+                            return Observable.error(exception);
+                        } else {
+                            return Observable.just(response);
+                        }
                     }
-                }
-            });
+                });
     }
 
     private RuntimeException createExceptionFromResponse(Response<ResponseBody> response, Integer... allowedStatusCodes) {
@@ -600,7 +716,7 @@ public final class AzureClient extends AzureServiceClient {
                 if (errorBody != null) {
                     exception = new CloudException(errorBody.message(), response, errorBody);
                 } else {
-                    exception = new CloudException("Unknown error with status code " + statusCode + " and body " + bodyString, response, errorBody);
+                    exception = new CloudException("Unknown error with status code " + statusCode + " and body " + bodyString, response, null);
                 }
                 return exception;
             } catch (IOException e) {
@@ -613,10 +729,10 @@ public final class AzureClient extends AzureServiceClient {
 
     private <T> Observable<PollingState<T>> putOrPatchPollingDispatcher(PollingState<T> pollingState, String url) {
         if (pollingState.azureAsyncOperationHeaderLink() != null
-            && !pollingState.azureAsyncOperationHeaderLink().isEmpty()) {
+                && !pollingState.azureAsyncOperationHeaderLink().isEmpty()) {
             return updateStateFromAzureAsyncOperationHeaderOnPutAsync(pollingState);
         } else if (pollingState.locationHeaderLink() != null
-            && !pollingState.locationHeaderLink().isEmpty()) {
+                && !pollingState.locationHeaderLink().isEmpty()) {
             return updateStateFromLocationHeaderOnPutAsync(pollingState);
         } else {
             return updateStateFromGetResourceOperationAsync(pollingState, url);
@@ -625,10 +741,10 @@ public final class AzureClient extends AzureServiceClient {
 
     private <T> Observable<PollingState<T>> postOrDeletePollingDispatcher(PollingState<T> pollingState) {
         if (pollingState.azureAsyncOperationHeaderLink() != null
-            && !pollingState.azureAsyncOperationHeaderLink().isEmpty()) {
+                && !pollingState.azureAsyncOperationHeaderLink().isEmpty()) {
             return updateStateFromAzureAsyncOperationHeaderOnPostOrDeleteAsync(pollingState);
         } else if (pollingState.locationHeaderLink() != null
-            && !pollingState.locationHeaderLink().isEmpty()) {
+                && !pollingState.locationHeaderLink().isEmpty()) {
             return updateStateFromLocationHeaderOnPostOrDeleteAsync(pollingState);
         } else {
             CloudException exception = new CloudException("Response does not contain an Azure-AsyncOperation or Location header.", pollingState.response(), pollingState.errorBody());

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureServiceClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureServiceClient.java
@@ -29,6 +29,7 @@ public abstract class AzureServiceClient extends ServiceClient {
      * Initializes a new instance of the ServiceClient class.
      *
      * @param baseUrl the service base uri
+     * @param credentials the credentials
      * @param clientBuilder the http client builder
      * @param restBuilder the retrofit rest client builder
      */

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
@@ -47,13 +47,13 @@ public class PollingState<T> {
     private int retryTimeout;
     /** The resource uri on which PUT or PATCH operation is applied. **/
     private String putOrPatchResourceUri;
-    /** The logging context **/
+    /** The logging context. **/
     private String loggingContext;
 
 
     // Non-serializable properties
     //
-    /** The logging context header name **/
+    /** The logging context header name. **/
     @JsonIgnore
     private static final String LOGGING_HEADER = "x-ms-logging-context";
     /** The Retrofit response object. */
@@ -85,6 +85,8 @@ public class PollingState<T> {
      * @param defaultRetryTimeout the long running operation retry timeout.
      * @param resourceType the type of the resource the long running operation returns
      * @param serializerAdapter the adapter for the Jackson object mapper
+     * @param <T> the result type
+     * @return the polling state
      * @throws IOException thrown by deserialization
      */
     public static <T> PollingState<T> create(Response<ResponseBody> response, int defaultRetryTimeout, Type resourceType, SerializerAdapter<?> serializerAdapter) throws IOException {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
@@ -21,7 +21,7 @@ import java.lang.reflect.Type;
  * @param <T> the type of the resource the operation returns.
  */
 public class PollingState<T> {
-    /** The HTTP method used to initiate the long running operation **/
+    /** The HTTP method used to initiate the long running operation. **/
     private String initialHttpMethod;
     /** The polling status. */
     private String status;

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
@@ -6,6 +6,7 @@
 
 package com.microsoft.azure;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.rest.protocol.SerializerAdapter;
 import okhttp3.ResponseBody;
@@ -15,41 +16,56 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 
 /**
- * An instance of this class defines the state of a long running operation.
+ * An instance of this class defines polling status of a long running operation.
  *
  * @param <T> the type of the resource the operation returns.
  */
-final class PollingState<T> {
-    /** The Retrofit response object. */
-    private Response<ResponseBody> response;
+public class PollingState<T> {
+    /** The HTTP method used to initiate the long running operation **/
+    private String initialHttpMethod;
     /** The polling status. */
     private String status;
     /** The link in 'Azure-AsyncOperation' header. */
     private String azureAsyncOperationHeaderLink;
     /** The link in 'Location' Header. */
     private String locationHeaderLink;
-    /** The timeout interval between two polling operations. */
+    /** The default timeout interval between two polling operations. */
+    private final int defaultRetryTimeout;
+    /** The timeout interval between two polling operation. **/
     private int retryTimeout;
+    /** The resource uri on which PUT or PATCH operation is applied. **/
+    private String putOrPatchResourceUri;
+
+    // Non-serializable properties
+    //
+    /** The Retrofit response object. */
+    @JsonIgnore
+    private Response<ResponseBody> response;
     /** The response resource object. */
+    @JsonIgnore
     private T resource;
     /** The type of the response resource object. */
+    @JsonIgnore
     private Type resourceType;
     /** The error during the polling operations. */
+    @JsonIgnore
     private CloudError error;
     /** The adapter for a custom serializer. */
+    @JsonIgnore
     private SerializerAdapter<?> serializerAdapter;
 
     /**
      * Initializes an instance of {@link PollingState}.
      *
-     * @param response the response from Retrofit REST call.
-     * @param retryTimeout the long running operation retry timeout.
+     * @param response the response from Retrofit REST call that initiate the long running operation.
+     * @param defaultRetryTimeout the long running operation retry timeout.
      * @param resourceType the type of the resource the long running operation returns
      * @param serializerAdapter the adapter for the Jackson object mapper
      * @throws IOException thrown by deserialization
      */
-    PollingState(Response<ResponseBody> response, int retryTimeout, Type resourceType, SerializerAdapter<?> serializerAdapter) throws IOException {
-        this.retryTimeout = retryTimeout;
+    PollingState(Response<ResponseBody> response, int defaultRetryTimeout, Type resourceType, SerializerAdapter<?> serializerAdapter) throws IOException {
+        this.initialHttpMethod = response.raw().request().method();
+        this.defaultRetryTimeout = defaultRetryTimeout;
         this.withResponse(response);
         this.resourceType = resourceType;
         this.serializerAdapter = serializerAdapter;
@@ -81,6 +97,51 @@ final class PollingState<T> {
                     withStatus(AzureAsyncOperation.FAILED_STATUS);
             }
         }
+    }
+
+    /**
+     * Gets the resource.
+     *
+     * @return the resource.
+     */
+    public T resource() {
+        return resource;
+    }
+
+    /**
+     * Gets the operation response.
+     *
+     * @return the operation response.
+     */
+    public Response<ResponseBody> response() {
+        return this.response;
+    }
+
+    /**
+     * Gets the polling status.
+     *
+     * @return the polling status.
+     */
+    public String status() {
+        return status;
+    }
+
+    /**
+     * Gets the value captured from Azure-AsyncOperation header.
+     *
+     * @return the link in the header.
+     */
+    public String azureAsyncOperationHeaderLink() {
+        return azureAsyncOperationHeaderLink;
+    }
+
+    /**
+     * Gets the value captured from Location header.
+     *
+     * @return the link in the header.
+     */
+    public String locationHeaderLink() {
+        return locationHeaderLink;
     }
 
     /**
@@ -141,28 +202,50 @@ final class PollingState<T> {
      */
     int delayInMilliseconds() {
         if (this.retryTimeout >= 0) {
-            return this.retryTimeout * 1000;
+            return this.retryTimeout;
         }
-        if (this.response != null && response.headers().get("Retry-After") != null) {
-            return Integer.parseInt(response.headers().get("Retry-After")) * 1000;
+        if (this.defaultRetryTimeout >= 0) {
+            return this.defaultRetryTimeout * 1000;
         }
         return AzureAsyncOperation.DEFAULT_DELAY * 1000;
     }
 
     /**
-     * Gets the polling status.
-     *
-     * @return the polling status.
+     * @return the uri of the resource on which the LRO PUT or PATCH applied.
      */
-    String status() {
-        return status;
+    String putOrPatchResourceUri() {
+        return this.putOrPatchResourceUri;
     }
 
     /**
-     * @return the resource type
+     * @return true if the status this state hold represents terminal status.
      */
-    Type resourceType() {
-        return resourceType;
+    boolean isStatusTerminal() {
+        for (String terminalStatus : AzureAsyncOperation.terminalStatuses()) {
+            if (terminalStatus.equalsIgnoreCase(this.status())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return true if the status this state hold is represents failed status.
+     */
+    boolean isStatusFailed() {
+        for (String failedStatus : AzureAsyncOperation.failedStatuses()) {
+            if (failedStatus.equalsIgnoreCase(this.status())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return true if the status this state represents is succeeded status.
+     */
+    boolean isStatusSucceeded() {
+        return AzureAsyncOperation.SUCCESS_STATUS.equalsIgnoreCase(this.status());
     }
 
     /**
@@ -180,22 +263,18 @@ final class PollingState<T> {
     }
 
     /**
-     * Gets the last operation response.
-     *
-     * @return the last operation response.
-     */
-    Response<ResponseBody> response() {
-        return this.response;
-    }
-
-
-    /**
      * Sets the last operation response.
      *
      * @param response the last operation response.
      */
     PollingState<T> withResponse(Response<ResponseBody> response) {
         this.response = response;
+        withPollingUrlFromResponse(response);
+        withPollingRetryTimeoutFromResponse(response);
+        return this;
+    }
+
+    PollingState<T> withPollingUrlFromResponse(Response<ResponseBody> response) {
         if (response != null) {
             String asyncHeader = response.headers().get("Azure-AsyncOperation");
             String locationHeader = response.headers().get("Location");
@@ -209,31 +288,18 @@ final class PollingState<T> {
         return this;
     }
 
-    /**
-     * Gets the latest value captured from Azure-AsyncOperation header.
-     *
-     * @return the link in the header.
-     */
-    String azureAsyncOperationHeaderLink() {
-        return azureAsyncOperationHeaderLink;
+    PollingState<T> withPollingRetryTimeoutFromResponse(Response<ResponseBody> response) {
+        if (this.response != null && response.headers().get("Retry-After") != null) {
+            retryTimeout = Integer.parseInt(response.headers().get("Retry-After")) * 1000;
+            return this;
+        }
+        this.retryTimeout = -1;
+        return this;
     }
 
-    /**
-     * Gets the latest value captured from Location header.
-     *
-     * @return the link in the header.
-     */
-    String locationHeaderLink() {
-        return locationHeaderLink;
-    }
-
-    /**
-     * Gets the resource.
-     *
-     * @return the resource.
-     */
-    T resource() {
-        return resource;
+    PollingState<T> withPutOrPatchResourceUri(final String uri) {
+        this.putOrPatchResourceUri = uri;
+        return this;
     }
 
     /**
@@ -243,6 +309,23 @@ final class PollingState<T> {
      */
     PollingState<T> withResource(T resource) {
         this.resource = resource;
+        return this;
+    }
+
+    /**
+     * @return the resource type
+     */
+    Type resourceType() {
+        return resourceType;
+    }
+
+    /**
+     * Sets resource type.
+     *
+     * param resourceType the resource type
+     */
+    PollingState<T> withResourceType(Type resourceType) {
+        this.resourceType = resourceType;
         return this;
     }
 
@@ -263,6 +346,36 @@ final class PollingState<T> {
     PollingState<T> withErrorBody(CloudError error) {
         this.error = error;
         return this;
+    }
+
+    /**
+     * Sets the serializer adapter.
+     *
+     * @param serializerAdapter the serializer adapter.
+     */
+    PollingState<T> withSerializerAdapter(SerializerAdapter<?> serializerAdapter) {
+        this.serializerAdapter = serializerAdapter;
+        return this;
+    }
+
+    /**
+     * @return the http method used to initiate the long running operation.
+     */
+    String initialHttpMethod() {
+        return this.initialHttpMethod;
+    }
+
+    /**
+     * If status is in failed state then throw CloudException.
+     */
+    void throwCloudExceptionIfInFailedState() {
+        if (this.isStatusFailed()) {
+            if (this.errorBody() != null) {
+                throw new CloudException("Async operation failed with provisioning state: " + this.status(), this.response(), this.errorBody());
+            } else {
+                throw new CloudException("Async operation failed with provisioning state: " + this.status(), this.response());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
**What is changed in AzureClient?**

***Following methods are added.***

**beginPutOrPatchAsync**

```java
AzureClient.<T> Single<PollingState<T>> 
        beginPutOrPatchAsync(Observable<Response<ResponseBody>> observable, 
                             final Type resourceType)
```

Initiate a LRO PUT or PATCH operation and returns serializable PollingState representing the LRO. This state can be used later to resume the polling.

**beginPostOrDeleteAsync**

```java
AzureClient.<T> Single<PollingState<T>>  
        beginPostOrDeleteAsync(Observable<Response<ResponseBody>> observable, 
                               final Type resourceType)
```

Initiate a LRO POST or DELETE operation and returns serializable PollingState representing the LRO. This state can be used later to resume the polling.

**pollSingleAsync**

```java
AzureClient.<T> Single<PollingState<T>> 
        pollSingleAsync(final PollingState<T> pollingState, 
                        final Type resourceType)
```

Given a pollingState (state of PUT_PATCH or POST_DELETE) this method poll once and returns the current polling state

**pollAsync**

```java
AzureClient.<T> Observable<PollingState<T>> 
        pollAsync(final PollingState<T> pollingState, final Type resourceType)
```

Given a pollingState (of state of PUT_PATCH or POST_DELETE) this method keeps on polling and emits each pollingState. Since the return type is Observable, user can apply all operators to have further control (poll n times, timeout etc..)

***How this affects the auto generated code?***

The `begin[Action]Async` methods in the inner collection will eventually return `Single<PollingState<T>>` (i.e. they internally calls `beginPostOrDeleteAsync` or `beginPutOrPatchAsync`). Now user can use the above other methods in the AzureClient to do polling.
