### PR TITLE
Add "Serializable" to some classes (#194)

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureEnvironment.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureEnvironment.java
@@ -8,6 +8,7 @@ package com.microsoft.azure;
 
 import com.microsoft.rest.protocol.Environment;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +17,9 @@ import java.util.Map;
 /**
  * An instance of this class describes an environment in Azure.
  */
-public final class AzureEnvironment implements Environment {
+public final class AzureEnvironment implements Environment, Serializable {
+    private static final long serialVersionUID = 2419074576693L;
+
     /** the map of all endpoints. */
     private final Map<String, String> endpoints;
 

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/CloudError.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/CloudError.java
@@ -6,13 +6,16 @@
 
 package com.microsoft.azure;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * An instance of this class provides additional information about an http error response.
  */
-public final class CloudError {
+public final class CloudError implements Serializable {
+    private static final long serialVersionUID = -987489719074576123L;
+
     /**
      * The error code parsed from the body of the http error response.
      */

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PollingState.java
@@ -25,6 +25,7 @@ import okhttp3.ResponseBody;
 import retrofit2.Response;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.reflect.Type;
 
 /**
@@ -32,7 +33,9 @@ import java.lang.reflect.Type;
  *
  * @param <T> the type of the resource the operation returns.
  */
-public class PollingState<T> {
+public class PollingState<T> implements Serializable {
+    private static final long serialVersionUID = 9874897190735754L;
+
     /** The HTTP method used to initiate the long running operation. **/
     private String initialHttpMethod;
     /** The polling status. */

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/Resource.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/Resource.java
@@ -8,12 +8,15 @@ package com.microsoft.azure;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /**
  * The Resource model.
  */
-public class Resource {
+public class Resource implements Serializable {
+    private static final long serialVersionUID = -123489719074576693L;
+
     /**
      * Resource Id.
      */

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/SubResource.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/SubResource.java
@@ -6,10 +6,14 @@
 
 package com.microsoft.azure;
 
+import java.io.Serializable;
+
 /**
  * The SubResource model.
  */
-public class SubResource {
+public class SubResource implements Serializable {
+    private static final long serialVersionUID = 1189719074576693L;
+
     /**
      * Resource Id.
      */


### PR DESCRIPTION
During app development using the Azure Java SDK, certain errors were not handled
properly, causing NotSerializable exceptions. This changes adds the interface
marker to appropriate classes.