### PR TITLE
Add ExpectedResponse and UnexpectedResponseExceptionType annotations

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/RestException.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/RestException.java
@@ -6,6 +6,7 @@
 
 package com.microsoft.rest;
 
+import com.microsoft.rest.v2.http.HttpResponse;
 import okhttp3.ResponseBody;
 import retrofit2.Response;
 
@@ -16,7 +17,12 @@ public class RestException extends RuntimeException {
     /**
      * Information about the associated HTTP response.
      */
-    private Response<ResponseBody> response;
+    private Response<ResponseBody> responseOkHttp;
+
+    /**
+     * Information about the associated HTTP response.
+     */
+    private HttpResponse responseV2;
 
     /**
      * The HTTP response body.
@@ -31,7 +37,7 @@ public class RestException extends RuntimeException {
      */
     public RestException(String message, Response<ResponseBody> response) {
         super(message);
-        this.response = response;
+        this.responseOkHttp = response;
     }
 
     /**
@@ -43,7 +49,31 @@ public class RestException extends RuntimeException {
      */
     public RestException(String message, Response<ResponseBody> response, Object body) {
         super(message);
-        this.response = response;
+        this.responseOkHttp = response;
+        this.body = body;
+    }
+
+    /**
+     * Initializes a new instance of the RestException class.
+     *
+     * @param message the exception message or the response content if a message is not available
+     * @param response the HTTP response
+     */
+    public RestException(String message, HttpResponse response) {
+        super(message);
+        this.responseV2 = response;
+    }
+
+    /**
+     * Initializes a new instance of the RestException class.
+     *
+     * @param message the exception message or the response content if a message is not available
+     * @param response the HTTP response
+     * @param body the deserialized response body
+     */
+    public RestException(String message, HttpResponse response, Object body) {
+        super(message);
+        this.responseV2 = response;
         this.body = body;
     }
 
@@ -51,7 +81,14 @@ public class RestException extends RuntimeException {
      * @return information about the associated HTTP response
      */
     public Response<ResponseBody> response() {
-        return response;
+        return responseOkHttp;
+    }
+
+    /**
+     * @return information about the associated HTTP response
+     */
+    public HttpResponse responseV2() {
+        return responseV2;
     }
 
     /**

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/EncodedParameter.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/EncodedParameter.java
@@ -40,34 +40,4 @@ class EncodedParameter {
     public String encodedValue() {
         return encodedValue;
     }
-
-    /**
-     * Get whether or not this value equals the provided rhs value.
-     * @param rhs The value to compare against this value.
-     * @return Whether or not this value equals the provided rhs value.
-     */
-    @Override
-    public boolean equals(Object rhs) {
-        return rhs instanceof EncodedParameter ? equals((EncodedParameter) rhs) : false;
-    }
-
-    /**
-     * Get whether or not this value equals the provided rhs value.
-     * @param rhs The value to compare against this value.
-     * @return Whether or not this value equals the provided rhs value.
-     */
-    public boolean equals(EncodedParameter rhs) {
-        return rhs != null
-                && name.equals(rhs.name)
-                && encodedValue.equals(rhs.encodedValue);
-    }
-
-    /**
-     * Get the unique hash code for this value.
-     * @return The unique hash code for this value.
-     */
-    @Override
-    public int hashCode() {
-        return name.hashCode() ^ encodedValue.hashCode();
-    }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -8,6 +8,7 @@ package com.microsoft.rest.v2;
 
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.RestClient;
+import com.microsoft.rest.RestException;
 import com.microsoft.rest.protocol.SerializerAdapter;
 import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpHeader;
@@ -21,7 +22,9 @@ import rx.functions.Func1;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
@@ -43,7 +46,7 @@ public final class RestProxy implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, final Method method, Object[] args) throws Throwable {
+    public Object invoke(Object proxy, final Method method, Object[] args) throws IOException {
         final SwaggerMethodParser methodParser = interfaceParser.methodParser(method);
 
         final UrlBuilder urlBuilder = new UrlBuilder()
@@ -109,6 +112,28 @@ public final class RestProxy implements InvocationHandler {
         }
         else {
             final HttpResponse response = httpClient.sendRequest(request);
+
+            final int responseStatusCode = response.statusCode();
+            if (!methodParser.isExpectedResponseStatusCode(responseStatusCode)) {
+                final Class<? extends RestException> exceptionType = methodParser.exceptionType();
+                try {
+                    final Class<?> exceptionBodyType = methodParser.exceptionBodyType();
+                    final Constructor<? extends RestException> exceptionConstructor = exceptionType.getConstructor(String.class, HttpResponse.class, exceptionBodyType);
+
+                    String responseContent = null;
+                    try {
+                        responseContent = response.bodyAsString();
+                    } catch (IOException ignored) {
+                    }
+
+                    final Object exceptionBody = responseContent == null ? null : serializer.deserialize(responseContent, exceptionBodyType);
+
+                    throw exceptionConstructor.newInstance("Status code " + responseStatusCode + ", " + responseContent, response, exceptionBody);
+                } catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException e) {
+                    throw new IOException("Status code " + responseStatusCode + ", but an instance of " + exceptionType.getCanonicalName() + " cannot be created.", e);
+                }
+            }
+
             if (returnType.equals(Void.TYPE) || methodParser.httpMethod().equalsIgnoreCase("HEAD")) {
                 result = null;
             } else if (returnTypeToken.isSubtypeOf(InputStream.class)) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -11,8 +11,8 @@ import com.google.common.net.UrlEscapers;
 import com.microsoft.rest.RestException;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
+import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import com.microsoft.rest.v2.annotations.ExpectedResponse;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HEAD;
 import com.microsoft.rest.v2.annotations.HeaderParam;
@@ -25,10 +25,8 @@ import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.http.HttpHeader;
 import com.microsoft.rest.v2.http.HttpHeaders;
-import com.microsoft.rest.v2.http.HttpResponse;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -106,7 +104,7 @@ class SwaggerMethodParser {
             }
         }
 
-        expectedStatusCodes = swaggerMethod.getAnnotation(ExpectedResponse.class).value();
+        expectedStatusCodes = swaggerMethod.getAnnotation(ExpectedResponses.class).value();
 
         if (swaggerMethod.isAnnotationPresent(UnexpectedResponseExceptionType.class)) {
             exceptionType = swaggerMethod.getAnnotation(UnexpectedResponseExceptionType.class).value();
@@ -172,8 +170,7 @@ class SwaggerMethodParser {
      * Swagger method.
      * @return The expected HTTP response status codes for this Swagger method.
      */
-    public int[] expectedStatusCodes()
-    {
+    public int[] expectedStatusCodes() {
         return expectedStatusCodes;
     }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/annotations/ExpectedResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/annotations/ExpectedResponse.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A list of HTTP status codes that are expected for this API.
+ *
+ * Example:
+ *   {@literal @}ExpectedResponse({200, 201})
+ *   {@literal @}POST("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/images/getEntityTypeImageUploadUrl")
+ *   void getUploadUrlForEntityType(@Path("resourceGroupName") String resourceGroupName, @Path("hubName") String hubName, @Path("subscriptionId") String subscriptionId, @Body GetImageUploadUrlInputInner parameters);
+ *
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface ExpectedResponse {
+    /**
+     * The status code that will trigger that an error of type errorType should be returned.
+     * @return The status code that will trigger than an error of type errorType should be returned.
+     */
+    int[] value();
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/annotations/ExpectedResponses.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/annotations/ExpectedResponses.java
@@ -16,14 +16,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * A list of HTTP status codes that are expected for this API.
  *
  * Example:
- *   {@literal @}ExpectedResponse({200, 201})
+ *   {@literal @}ExpectedResponses({200, 201})
  *   {@literal @}POST("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/images/getEntityTypeImageUploadUrl")
  *   void getUploadUrlForEntityType(@Path("resourceGroupName") String resourceGroupName, @Path("hubName") String hubName, @Path("subscriptionId") String subscriptionId, @Body GetImageUploadUrlInputInner parameters);
  *
  */
 @Retention(RUNTIME)
 @Target(METHOD)
-public @interface ExpectedResponse {
+public @interface ExpectedResponses {
     /**
      * The status code that will trigger that an error of type errorType should be returned.
      * @return The status code that will trigger than an error of type errorType should be returned.

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/annotations/UnexpectedResponseExceptionType.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/annotations/UnexpectedResponseExceptionType.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2.annotations;
+
+import com.microsoft.rest.RestException;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The error type that will be thrown/returned when an unexpected status code is returned from an
+ * API.
+ *
+ * Example:
+ *   {@literal @}UnexpectedResponseExceptionType(MyCustomException.class)
+ *   {@literal @}POST("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/images/getEntityTypeImageUploadUrl")
+ *   void getUploadUrlForEntityType(@Path("resourceGroupName") String resourceGroupName, @Path("hubName") String hubName, @Path("subscriptionId") String subscriptionId, @Body GetImageUploadUrlInputInner parameters);
+ *
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface UnexpectedResponseExceptionType {
+    /**
+     * The type of RestException that should be thrown/returned when the API returns an unrecognized
+     * status code.
+     * @return The type of RestException that should be thrown/returned.
+     */
+    Class<? extends RestException> value();
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpHeader.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpHeader.java
@@ -54,6 +54,15 @@ public class HttpHeader {
      * @param value The value to add to the end of this Header.
      */
     public void addValue(String value) {
-        value += "," + value;
+        this.value += "," + value;
+    }
+
+    /**
+     * Get the String representation of this HttpHeader.
+     * @return The String representation of this HttpHeader.
+     */
+    public String toString()
+    {
+        return name + ":" + value;
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpHeader.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpHeader.java
@@ -61,8 +61,7 @@ public class HttpHeader {
      * Get the String representation of this HttpHeader.
      * @return The String representation of this HttpHeader.
      */
-    public String toString()
-    {
+    public String toString() {
         return name + ":" + value;
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpResponse.java
@@ -17,6 +17,12 @@ import java.io.InputStream;
  */
 public abstract class HttpResponse {
     /**
+     * Get this response object's HTTP status code.
+     * @return This response object's HTTP status code.
+     */
+    public abstract int statusCode();
+
+    /**
      * Get this response object's body as an InputStream. If this response object doesn't have a
      * body, then null will be returned.
      * @return This response object's body as an InputStream. If this response object doesn't have a

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/OkHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/OkHttpResponse.java
@@ -27,6 +27,11 @@ class OkHttpResponse extends HttpResponse {
     }
 
     @Override
+    public int statusCode() {
+        return response.code();
+    }
+
+    @Override
     public Single<? extends InputStream> bodyAsInputStreamAsync() {
         return Single.just(response.body().byteStream());
     }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/RxNettyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/RxNettyResponse.java
@@ -28,6 +28,11 @@ class RxNettyResponse extends HttpResponse {
         this.rxnRes = rxnRes;
     }
 
+    @Override
+    public int statusCode() {
+        return rxnRes.getStatus().code();
+    }
+
     private Single<ByteBuf> collectContent() {
         // Reading entire response into memory-- not sure if this is OK
         int contentLength = (int) rxnRes.getContentLength();

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/MyRestException.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/MyRestException.java
@@ -1,0 +1,15 @@
+package com.microsoft.rest.v2;
+
+import com.microsoft.rest.RestException;
+import com.microsoft.rest.v2.http.HttpResponse;
+
+public class MyRestException extends RestException {
+    public MyRestException(String message, HttpResponse response, HttpBinJSON body) {
+        super(message, response, body);
+    }
+
+    @Override
+    public HttpBinJSON body() {
+        return (HttpBinJSON) super.body();
+    }
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -5,7 +5,7 @@ import com.microsoft.rest.protocol.SerializerAdapter;
 import com.microsoft.rest.serializer.JacksonAdapter;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
-import com.microsoft.rest.v2.annotations.ExpectedResponse;
+import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HEAD;
 import com.microsoft.rest.v2.annotations.HeaderParam;
@@ -21,7 +21,6 @@ import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
 import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpHeaders;
 import org.junit.Test;
-import retrofit2.http.Path;
 import rx.Completable;
 import rx.Single;
 
@@ -42,11 +41,11 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service1 {
         @GET("bytes/100")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         byte[] getByteArray();
 
         @GET("bytes/100")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<byte[]> getByteArrayAsync();
     }
 
@@ -70,11 +69,11 @@ public abstract class RestProxyTests {
     @Host("http://{hostName}.org")
     private interface Service2 {
         @GET("bytes/{numberOfBytes}")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         byte[] getByteArray(@HostParam("hostName") String host, @PathParam("numberOfBytes") int numberOfBytes);
 
         @GET("bytes/{numberOfBytes}")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<byte[]> getByteArrayAsync(@HostParam("hostName") String host, @PathParam("numberOfBytes") int numberOfBytes);
     }
 
@@ -98,11 +97,11 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service3 {
         @GET("bytes/2")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         void getNothing();
 
         @GET("bytes/2")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Completable getNothingAsync();
     }
 
@@ -121,11 +120,11 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service4 {
         @GET("bytes/2")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         InputStream getByteStream();
 
         @GET("bytes/2")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<InputStream> getByteStreamAsync();
     }
 
@@ -151,23 +150,23 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service5 {
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON getAnything();
 
         @GET("anything/with+plus")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON getAnythingWithPlus();
 
         @GET("anything/{path}")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON getAnythingWithPathParam(@PathParam("path") String pathParam);
 
         @GET("anything/{path}")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON getAnythingWithEncodedPathParam(@PathParam(value="path", encoded=true) String pathParam);
 
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<HttpBinJSON> getAnythingAsync();
     }
 
@@ -247,15 +246,15 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service6 {
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON getAnything(@QueryParam("a") String a, @QueryParam("b") int b);
 
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON getAnythingWithEncoded(@QueryParam(value="a", encoded=true) String a, @QueryParam("b") int b);
 
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<HttpBinJSON> getAnythingAsync(@QueryParam("a") String a, @QueryParam("b") int b);
     }
 
@@ -295,11 +294,11 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service7 {
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON getAnything(@HeaderParam("a") String a, @HeaderParam("b") int b);
 
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<HttpBinJSON> getAnythingAsync(@HeaderParam("a") String a, @HeaderParam("b") int b);
     }
 
@@ -335,11 +334,11 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service8 {
         @POST("post")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON post(@BodyParam String postBody);
 
         @POST("post")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<HttpBinJSON> postAsync(@BodyParam String postBody);
     }
 
@@ -363,19 +362,19 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service9 {
         @PUT("put")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON put(@BodyParam int putBody);
 
         @PUT("put")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<HttpBinJSON> putAsync(@BodyParam int putBody);
 
         @PUT("put")
-        @ExpectedResponse({201})
+        @ExpectedResponses({201})
         HttpBinJSON putWithUnexpectedResponse(@BodyParam String putBody);
 
         @PUT("put")
-        @ExpectedResponse({201})
+        @ExpectedResponses({201})
         @UnexpectedResponseExceptionType(MyRestException.class)
         HttpBinJSON putWithUnexpectedResponseAndExceptionType(@BodyParam String putBody);
     }
@@ -429,19 +428,19 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service10 {
         @HEAD("get")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON head();
 
         @HEAD("get")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         void voidHead();
 
         @HEAD("get")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<HttpBinJSON> headAsync();
 
         @HEAD("get")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Completable completableHeadAsync();
     }
 
@@ -476,11 +475,11 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service11 {
         @DELETE("delete")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON delete(@BodyParam boolean bodyBoolean);
 
         @DELETE("delete")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<HttpBinJSON> deleteAsync(@BodyParam boolean bodyBoolean);
     }
 
@@ -504,11 +503,11 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service12 {
         @PATCH("patch")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         HttpBinJSON patch(@BodyParam String bodyString);
 
         @PATCH("patch")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         Single<HttpBinJSON> patchAsync(@BodyParam String bodyString);
     }
 
@@ -532,12 +531,12 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     private interface Service13 {
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         @Headers({ "MyHeader:MyHeaderValue", "MyOtherHeader:My,Header,Value" })
         HttpBinJSON get();
 
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         @Headers({ "MyHeader:MyHeaderValue", "MyOtherHeader:My,Header,Value" })
         Single<HttpBinJSON> getAsync();
     }
@@ -572,12 +571,12 @@ public abstract class RestProxyTests {
     @Host("https://httpbin.org")
     private interface Service14 {
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         @Headers({ "MyHeader:MyHeaderValue" })
         HttpBinJSON get();
 
         @GET("anything")
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         @Headers({ "MyHeader:MyHeaderValue" })
         Single<HttpBinJSON> getAsync();
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerInterfaceParserTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerInterfaceParserTests.java
@@ -1,5 +1,6 @@
 package com.microsoft.rest.v2;
 
+import com.microsoft.rest.v2.annotations.ExpectedResponse;
 import com.microsoft.rest.v2.annotations.Host;
 import org.junit.Test;
 
@@ -29,17 +30,22 @@ public class SwaggerInterfaceParserTests {
         assertEquals("https://management.azure.com", interfaceParser.host());
     }
 
+    interface TestInterface3 {
+        @ExpectedResponse({200})
+        void testMethod3();
+    }
+
     @Test
     public void methodParser() {
-        final SwaggerInterfaceParser interfaceParser = new SwaggerInterfaceParser(TestInterface1.class);
-        final Method testMethod1 = TestInterface1.class.getDeclaredMethods()[0];
-        assertEquals("testMethod1", testMethod1.getName());
+        final SwaggerInterfaceParser interfaceParser = new SwaggerInterfaceParser(TestInterface3.class);
+        final Method testMethod3 = TestInterface3.class.getDeclaredMethods()[0];
+        assertEquals("testMethod3", testMethod3.getName());
 
-        final SwaggerMethodParser methodParser = interfaceParser.methodParser(testMethod1);
+        final SwaggerMethodParser methodParser = interfaceParser.methodParser(testMethod3);
         assertNotNull(methodParser);
-        assertEquals("com.microsoft.rest.v2.SwaggerInterfaceParserTests.TestInterface1.testMethod1", methodParser.fullyQualifiedMethodName());
+        assertEquals("com.microsoft.rest.v2.SwaggerInterfaceParserTests.TestInterface3.testMethod3", methodParser.fullyQualifiedMethodName());
 
-        final SwaggerMethodParser methodDetails2 = interfaceParser.methodParser(testMethod1);
+        final SwaggerMethodParser methodDetails2 = interfaceParser.methodParser(testMethod3);
         assertSame(methodParser, methodDetails2);
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerInterfaceParserTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerInterfaceParserTests.java
@@ -1,6 +1,6 @@
 package com.microsoft.rest.v2;
 
-import com.microsoft.rest.v2.annotations.ExpectedResponse;
+import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.Host;
 import org.junit.Test;
 
@@ -31,7 +31,7 @@ public class SwaggerInterfaceParserTests {
     }
 
     interface TestInterface3 {
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         void testMethod3();
     }
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerMethodParserTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerMethodParserTests.java
@@ -1,15 +1,11 @@
 package com.microsoft.rest.v2;
 
 import com.microsoft.rest.RestException;
-import com.microsoft.rest.v2.annotations.ExpectedResponse;
-import com.microsoft.rest.v2.annotations.Host;
+import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
-import okhttp3.ResponseBody;
 import org.junit.Test;
-import retrofit2.Response;
 
 import java.lang.reflect.Method;
-import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
@@ -28,7 +24,7 @@ public class SwaggerMethodParserTests {
     }
 
     interface TestInterface2 {
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         void testMethod2();
     }
 
@@ -49,7 +45,7 @@ public class SwaggerMethodParserTests {
     }
 
     interface TestInterface3 {
-        @ExpectedResponse({200})
+        @ExpectedResponses({200})
         @UnexpectedResponseExceptionType(MyRestException.class)
         void testMethod3();
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerMethodParserTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerMethodParserTests.java
@@ -1,7 +1,12 @@
 package com.microsoft.rest.v2;
 
+import com.microsoft.rest.RestException;
+import com.microsoft.rest.v2.annotations.ExpectedResponse;
 import com.microsoft.rest.v2.annotations.Host;
+import com.microsoft.rest.v2.annotations.UnexpectedResponseExceptionType;
+import okhttp3.ResponseBody;
 import org.junit.Test;
+import retrofit2.Response;
 
 import java.lang.reflect.Method;
 import java.util.Iterator;
@@ -14,14 +19,52 @@ public class SwaggerMethodParserTests {
         void testMethod1();
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void withNoAnnotations() {
         final Method testMethod1 = TestInterface1.class.getDeclaredMethods()[0];
         assertEquals("testMethod1", testMethod1.getName());
 
-        final SwaggerMethodParser methodParser = new SwaggerMethodParser(testMethod1, "https://raw.host.com");
-        assertEquals("com.microsoft.rest.v2.SwaggerMethodParserTests.TestInterface1.testMethod1", methodParser.fullyQualifiedMethodName());
+        new SwaggerMethodParser(testMethod1, "https://raw.host.com");
+    }
+
+    interface TestInterface2 {
+        @ExpectedResponse({200})
+        void testMethod2();
+    }
+
+    @Test
+    public void withOnlyExpectedResponse() {
+        final Method testMethod2 = TestInterface2.class.getDeclaredMethods()[0];
+        assertEquals("testMethod2", testMethod2.getName());
+
+        final SwaggerMethodParser methodParser = new SwaggerMethodParser(testMethod2, "https://raw.host.com");
+        assertEquals("com.microsoft.rest.v2.SwaggerMethodParserTests.TestInterface2.testMethod2", methodParser.fullyQualifiedMethodName());
         assertEquals(null, methodParser.httpMethod());
+        assertArrayEquals(new int[] { 200 }, methodParser.expectedStatusCodes());
+        assertEquals(RestException.class, methodParser.exceptionType());
+        assertEquals(Object.class, methodParser.exceptionBodyType());
+        assertEquals(false, methodParser.headers(null).iterator().hasNext());
+        assertEquals("https", methodParser.scheme(null));
+        assertEquals("raw.host.com", methodParser.host(null));
+    }
+
+    interface TestInterface3 {
+        @ExpectedResponse({200})
+        @UnexpectedResponseExceptionType(MyRestException.class)
+        void testMethod3();
+    }
+
+    @Test
+    public void withExpectedResponseAndUnexpectedResponseExceptionType() {
+        final Method testMethod3 = TestInterface3.class.getDeclaredMethods()[0];
+        assertEquals("testMethod3", testMethod3.getName());
+
+        final SwaggerMethodParser methodParser = new SwaggerMethodParser(testMethod3, "https://raw.host.com");
+        assertEquals("com.microsoft.rest.v2.SwaggerMethodParserTests.TestInterface3.testMethod3", methodParser.fullyQualifiedMethodName());
+        assertEquals(null, methodParser.httpMethod());
+        assertArrayEquals(new int[] { 200 }, methodParser.expectedStatusCodes());
+        assertEquals(MyRestException.class, methodParser.exceptionType());
+        assertEquals(HttpBinJSON.class, methodParser.exceptionBodyType());
         assertEquals(false, methodParser.headers(null).iterator().hasNext());
         assertEquals("https", methodParser.scheme(null));
         assertEquals("raw.host.com", methodParser.host(null));

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpHeaderTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpHeaderTests.java
@@ -1,0 +1,15 @@
+package com.microsoft.rest.v2.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HttpHeaderTests {
+    @Test
+    public void addValue()
+    {
+        final HttpHeader header = new HttpHeader("a", "b");
+        header.addValue("c");
+        assertEquals("a:b,c", header.toString());
+    }
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpHeadersTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpHeadersTests.java
@@ -1,0 +1,19 @@
+package com.microsoft.rest.v2.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HttpHeadersTests {
+    @Test
+    public void add()
+    {
+        final HttpHeaders headers = new HttpHeaders();
+
+        headers.add("a", "b");
+        assertEquals("b", headers.value("a"));
+
+        headers.add("a", "c");
+        assertEquals("b,c", headers.value("a"));
+    }
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpRequestTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpRequestTests.java
@@ -1,0 +1,15 @@
+package com.microsoft.rest.v2.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HttpRequestTests {
+    @Test
+    public void constructor() {
+        final HttpRequest request = new HttpRequest("request caller method", "request http method", "request url");
+        assertEquals("request caller method", request.callerMethod());
+        assertEquals("request http method", request.httpMethod());
+        assertEquals("request url", request.url());
+    }
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
@@ -37,38 +37,38 @@ public class MockHttpClient extends HttpClient {
                             // This is just to mimic the behavior we've seen with httpbin.org.
                             .replace("%20", " ");
                     json.headers = toMap(request.headers());
-                    response = new MockHttpResponse(json);
+                    response = new MockHttpResponse(200, json);
                 }
                 else if (requestPathLower.startsWith("/bytes/")) {
                     final String byteCountString = requestPath.substring("/bytes/".length());
                     final int byteCount = Integer.parseInt(byteCountString);
-                    response = new MockHttpResponse(new byte[byteCount]);
+                    response = new MockHttpResponse(200, new byte[byteCount]);
                 }
                 else if (requestPathLower.equals("/delete")) {
                     final HttpBinJSON json = new HttpBinJSON();
                     json.data = bodyToString(request);
-                    response = new MockHttpResponse(json);
+                    response = new MockHttpResponse(200, json);
                 }
                 else if (requestPathLower.equals("/get")) {
                     final HttpBinJSON json = new HttpBinJSON();
                     json.url = request.url();
                     json.headers = toMap(request.headers());
-                    response = new MockHttpResponse(json);
+                    response = new MockHttpResponse(200, json);
                 }
                 else if (requestPathLower.equals("/patch")) {
                     final HttpBinJSON json = new HttpBinJSON();
                     json.data = bodyToString(request);
-                    response = new MockHttpResponse(json);
+                    response = new MockHttpResponse(200, json);
                 }
                 else if (requestPathLower.equals("/post")) {
                     final HttpBinJSON json = new HttpBinJSON();
                     json.data = bodyToString(request);
-                    response = new MockHttpResponse(json);
+                    response = new MockHttpResponse(200, json);
                 }
                 else if (requestPathLower.equals("/put")) {
                     final HttpBinJSON json = new HttpBinJSON();
                     json.data = bodyToString(request);
-                    response = new MockHttpResponse(json);
+                    response = new MockHttpResponse(200, json);
                 }
             }
         }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
@@ -17,31 +17,46 @@ import java.io.InputStream;
 public class MockHttpResponse extends HttpResponse {
     private final static SerializerAdapter<?> serializer = new JacksonAdapter();
 
+    private final int statusCode;
+
     private final boolean hasBody;
     private byte[] byteArray;
     private String string;
 
     public MockHttpResponse() {
+        this(200);
+    }
+
+    public MockHttpResponse(int statusCode) {
+        this.statusCode = statusCode;
         hasBody = false;
     }
 
-    public MockHttpResponse(byte[] byteArray) {
+    public MockHttpResponse(int statusCode, byte[] byteArray) {
+        this.statusCode = statusCode;
         hasBody = true;
         this.byteArray = byteArray;
     }
 
-    public MockHttpResponse(String string) {
+    public MockHttpResponse(int statusCode, String string) {
+        this.statusCode = statusCode;
         hasBody = true;
         this.string = string;
     }
 
-    public MockHttpResponse(Object serializable) {
+    public MockHttpResponse(int statusCode, Object serializable) {
+        this.statusCode = statusCode;
         hasBody = true;
         try {
             this.string = serializer.serialize(serializable);
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @Override
+    public int statusCode() {
+        return statusCode;
     }
 
     @Override


### PR DESCRIPTION
This pull request addresses [this issue](https://github.com/Azure/autorest-clientruntime-for-java/issues/202).

I added ExpectedResponse and UnexpectedResponseExceptionType annotations. I chose to use UnexpectedResponseExceptionType instead of ErrorResponse because I felt that it better described what the annotation was actually doing.

I also added some tests to improve test coverage and to ensure that RestProxy was doing what we expected.