### PR TITLE
Long running operations

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
@@ -128,20 +128,4 @@ public class AzureProxy {
 
         return retryAfterSeconds;
     }
-
-    private static class Value<T> {
-        private T value;
-
-        Value(T value) {
-            set(value);
-        }
-
-        public T get() {
-            return value;
-        }
-
-        public void set(T value) {
-            this.value = value;
-        }
-    }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
@@ -6,19 +6,24 @@
 
 package com.microsoft.azure.v2;
 
+import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.RestException;
 import com.microsoft.rest.protocol.SerializerAdapter;
+import com.microsoft.rest.v2.InvalidReturnTypeException;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.SwaggerMethodParser;
 import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
+import rx.Completable;
 import rx.Observable;
 import rx.Single;
 import rx.functions.Func0;
 import rx.functions.Func1;
 
 import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -46,64 +51,146 @@ public class AzureProxy {
     public static <A> A create(Class<A> swaggerInterface, final HttpClient httpClient, SerializerAdapter<?> serializer) {
         return RestProxy.create(swaggerInterface, httpClient, serializer, new RestProxy.ResponseHandler() {
             @Override
-            public Object handleSyncResponse(HttpResponse response, SwaggerMethodParser methodParser, SerializerAdapter<?> serializer) throws IOException, RestException {
-                while (response.statusCode() == 202) {
+            public Object handleSyncResponse(HttpResponse response, SwaggerMethodParser methodParser, Type returnType, SerializerAdapter<?> serializer) throws IOException, RestException {
+                while (!isDonePolling(response)) {
                     final String location = response.headerValue("Location");
-                    final HttpRequest pollRequest = new HttpRequest(methodParser.fullyQualifiedMethodName(), "GET", location);
+                    final HttpRequest pollRequest = createPollRequest(methodParser.fullyQualifiedMethodName(), location);
                     response = httpClient.sendRequest(pollRequest);
                 }
-                return RestProxy.DEFAULT_RESPONSE_HANDLER.handleSyncResponse(response, methodParser, serializer);
+                return RestProxy.DEFAULT_RESPONSE_HANDLER.handleSyncResponse(response, methodParser, returnType, serializer);
             }
 
             @Override
-            public Object handleAsyncResponse(Single<HttpResponse> asyncResponse, final SwaggerMethodParser methodParser, SerializerAdapter<?> serializer) {
-                asyncResponse = asyncResponse
-                        .flatMap(new Func1<HttpResponse, Single<? extends HttpResponse>>() {
-                            @Override
-                            public Single<? extends HttpResponse> call(HttpResponse response) {
-                                Single<? extends HttpResponse> result;
-                                if (response.statusCode() != 202) {
-                                    result = Single.just(response);
-                                }
-                                else {
-                                    final Value<String> pollUrl = new Value<>(getPollUrl(response, null));
-                                    final Value<Long> retryAfterSeconds = new Value<>(getRetryAfterSeconds(response, null));
+            public Object handleAsyncResponse(Single<HttpResponse> asyncResponse, final SwaggerMethodParser methodParser, final SerializerAdapter<?> serializer) {
+                Object result = null;
 
-                                    result = Observable.defer(new Func0<Observable<HttpResponse>>() {
-                                                @Override
-                                                public Observable<HttpResponse> call() {
-                                                    final HttpRequest pollRequest = new HttpRequest(methodParser.fullyQualifiedMethodName(), "GET", pollUrl.get());
-                                                    return httpClient.sendRequestAsync(pollRequest).toObservable();
-                                                }
-                                            })
-                                            .repeatWhen(new Func1<Observable<? extends Void>, Observable<?>>() {
-                                                @Override
-                                                public Observable<?> call(Observable<? extends Void> observable) {
-                                                    return retryAfterSeconds.get() == null ? observable : observable.delay(retryAfterSeconds.get(), TimeUnit.SECONDS);
-                                                }
-                                            })
-                                            .filter(new Func1<HttpResponse, Boolean>() {
-                                                @Override
-                                                public Boolean call(HttpResponse response) {
-                                                    final boolean result = response.statusCode() != 202;
-                                                    if (!result) {
-                                                        pollUrl.set(getPollUrl(response, pollUrl.get()));
-                                                        retryAfterSeconds.set(getRetryAfterSeconds(response, retryAfterSeconds.get()));
-                                                    }
-                                                    return result;
-                                                }
-                                            })
-                                            .first()
-                                            .toSingle();
+                final Type returnType = methodParser.returnType();
+                final TypeToken returnTypeToken = TypeToken.of(returnType);
+
+                if (returnTypeToken.isSubtypeOf(Completable.class) || returnTypeToken.isSubtypeOf(Single.class)) {
+                    asyncResponse = asyncResponse
+                            .flatMap(new Func1<HttpResponse, Single<? extends HttpResponse>>() {
+                                @Override
+                                public Single<? extends HttpResponse> call(HttpResponse response) {
+                                    Single<HttpResponse> result;
+                                    if (isDonePolling(response)) {
+                                        result = Single.just(response);
+                                    }
+                                    else {
+                                        final Value<String> pollUrl = new Value<>(getPollUrl(response, null));
+                                        final Value<Long> retryAfterSeconds = new Value<>(getRetryAfterSeconds(response, null));
+
+                                        result = sendPollRequestWithDelay(methodParser, httpClient, pollUrl, retryAfterSeconds)
+                                                    .repeat()
+                                                    .takeUntil(new Func1<HttpResponse, Boolean>() {
+                                                        @Override
+                                                        public Boolean call(HttpResponse response) {
+                                                            pollUrl.set(getPollUrl(response, pollUrl.get()));
+                                                            retryAfterSeconds.set(getRetryAfterSeconds(response, retryAfterSeconds.get()));
+                                                            return isDonePolling(response);
+                                                        }
+                                                    })
+                                                    .last()
+                                                    .toSingle();
+                                    }
+                                    return result;
                                 }
-                                return result;
-                            }
-                        });
-                return RestProxy.DEFAULT_RESPONSE_HANDLER.handleAsyncResponse(asyncResponse, methodParser, serializer);
+                            });
+                    result = RestProxy.DEFAULT_RESPONSE_HANDLER.handleAsyncResponse(asyncResponse, methodParser, serializer);
+                }
+                else if (returnTypeToken.isSubtypeOf(Observable.class)) {
+                    final Type operationStatusType = ((ParameterizedType) returnType).getActualTypeArguments()[0];
+                    final TypeToken operationStatusTypeToken = TypeToken.of(operationStatusType);
+                    if (!operationStatusTypeToken.isSubtypeOf(OperationStatus.class)) {
+                        throw new InvalidReturnTypeException("AzureProxy only supports swagger interface methods that return Observable (such as " + methodParser.fullyQualifiedMethodName() + "()) if the Observable's inner type that is OperationStatus (not " + returnType.toString() + ").");
+                    }
+                    else {
+                        final Type operationStatusResultType = ((ParameterizedType) operationStatusType).getActualTypeArguments()[0];
+                        result = asyncResponse
+                                .toObservable()
+                                .flatMap(new Func1<HttpResponse, Observable<OperationStatus<Object>>>() {
+                                    @Override
+                                    public Observable<OperationStatus<Object>> call(HttpResponse response) {
+                                        Observable<OperationStatus<Object>> result;
+                                        if (isDonePolling(response)) {
+                                            return toOperationStatusObservable(response, methodParser, operationStatusResultType, serializer);
+                                        } else {
+                                            final Value<String> pollUrl = new Value<>(getPollUrl(response, null));
+                                            final Value<Long> retryAfterSeconds = new Value<>(getRetryAfterSeconds(response, null));
+                                            final Value<OperationStatus<Object>> lastOperationStatus = new Value<>();
+
+                                            result = sendPollRequestWithDelay(methodParser, httpClient, pollUrl, retryAfterSeconds)
+                                                        .flatMap(new Func1<HttpResponse, Observable<OperationStatus<Object>>>() {
+                                                            @Override
+                                                            public Observable<OperationStatus<Object>> call(HttpResponse httpResponse) {
+                                                                pollUrl.set(getPollUrl(httpResponse, pollUrl.get()));
+                                                                retryAfterSeconds.set(getRetryAfterSeconds(httpResponse, retryAfterSeconds.get()));
+
+                                                                Observable<OperationStatus<Object>> result;
+                                                                if (isDonePolling(httpResponse)) {
+                                                                    result = toOperationStatusObservable(httpResponse, methodParser, operationStatusResultType, serializer);
+                                                                }
+                                                                else {
+                                                                    result = Observable.just(OperationStatus.inProgress());
+                                                                }
+                                                                return result;
+                                                            }
+                                                        })
+                                                        .repeat()
+                                                        .takeUntil(new Func1<OperationStatus<Object>, Boolean>() {
+                                                            @Override
+                                                            public Boolean call(OperationStatus<Object> operationStatus) {
+                                                                final boolean stop = operationStatus.isDone();
+                                                                if (stop) {
+                                                                    // Take until will not return the operationStatus that is
+                                                                    // marked as done, so we set it here and then concatWith() it
+                                                                    // later to force the Observable to return the operationStatus
+                                                                    // that is done.
+                                                                    lastOperationStatus.set(operationStatus);
+                                                                }
+                                                                return stop;
+                                                            }
+                                                        })
+                                                        .concatWith(Observable.defer(new Func0<Observable<OperationStatus<Object>>>() {
+                                                            @Override
+                                                            public Observable<OperationStatus<Object>> call() {
+                                                                return Observable.just(lastOperationStatus.get());
+                                                            }
+                                                        }));
+                                        }
+                                        return result;
+                                    }
+                                });
+                    }
+                }
+
+                return result;
             }
         });
     }
 
+    private static Observable<OperationStatus<Object>> toOperationStatusObservable(HttpResponse httpResponse, SwaggerMethodParser methodParser, Type operationStatusResultType, SerializerAdapter<?> serializer) {
+        Observable<OperationStatus<Object>> result;
+        try {
+            final Object resultObject = RestProxy.DEFAULT_RESPONSE_HANDLER.handleSyncResponse(httpResponse, methodParser, operationStatusResultType, serializer);
+            final OperationStatus<Object> operationStatus = OperationStatus.completed(resultObject);
+            result = Observable.just(operationStatus);
+        } catch (IOException e) {
+            result = Observable.error(e);
+        }
+        return result;
+    }
+
+    /**
+     * Get the URL from the provided HttpResponse that should be requested in order to poll the
+     * status of a long running operation.
+     * @param response The HttpResponse that contains the poll URL.
+     * @param currentPollUrl The poll URL that was previously used. Sometimes a HttpResponse may not
+     *                       have an updated poll URL, so in those cases we should just use the
+     *                       previous one.
+     * @return The URL that should be requested in order to poll the status of a long running
+     * operation.
+     */
     static String getPollUrl(HttpResponse response, String currentPollUrl) {
         String pollUrl = currentPollUrl;
 
@@ -113,6 +200,31 @@ public class AzureProxy {
         }
 
         return pollUrl;
+    }
+
+    private static Observable<HttpResponse> sendPollRequestWithDelay(SwaggerMethodParser methodParser, final HttpClient httpClient, final Value<String> pollUrl, final Value<Long> retryAfterSeconds) {
+        final String fullyQualifiedMethodName = methodParser.fullyQualifiedMethodName();
+
+        return Observable.defer(new Func0<Observable<HttpResponse>>() {
+            @Override
+            public Observable<HttpResponse> call() {
+                final HttpRequest pollRequest = createPollRequest(fullyQualifiedMethodName, pollUrl.get());
+
+                Single<HttpResponse> pollResponse = httpClient.sendRequestAsync(pollRequest);
+                if (retryAfterSeconds.get() != null) {
+                    pollResponse = pollResponse.delay(retryAfterSeconds.get(), TimeUnit.SECONDS);
+                }
+                return pollResponse.toObservable();
+            }
+        });
+    }
+
+    private static HttpRequest createPollRequest(String fullyQualifiedMethodName, String pollUrl) {
+        return new HttpRequest(fullyQualifiedMethodName, "GET", pollUrl);
+    }
+
+    private static boolean isDonePolling(HttpResponse response) {
+        return response.statusCode() != 202;
     }
 
     static Long getRetryAfterSeconds(HttpResponse response, Long currentRetryAfterSeconds) {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/OperationStatus.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/OperationStatus.java
@@ -1,0 +1,27 @@
+package com.microsoft.azure.v2;
+
+public class OperationStatus<T> {
+    private final boolean isDone;
+    private final T result;
+
+    private OperationStatus(boolean isDone, T result) {
+        this.isDone = isDone;
+        this.result = result;
+    }
+
+    public boolean isDone() {
+        return isDone;
+    }
+
+    public T result() {
+        return result;
+    }
+
+    public static <T> OperationStatus<T> inProgress() {
+        return new OperationStatus<>(false, null);
+    }
+
+    public static <T> OperationStatus<T> completed(T result) {
+        return new OperationStatus<>(true, result);
+    }
+}

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/OperationStatus.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/OperationStatus.java
@@ -1,6 +1,17 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
 package com.microsoft.azure.v2;
 
-public class OperationStatus<T> {
+/**
+ * The status of a long running operation. This generally is created from the result of polling for
+ * whether a long running operation is done or not.
+ * @param <T>
+ */
+public final class OperationStatus<T> {
     private final boolean isDone;
     private final T result;
 
@@ -9,18 +20,39 @@ public class OperationStatus<T> {
         this.result = result;
     }
 
+    /**
+     * Get whether or not the long running operation is done.
+     * @return Whether or not the long running operation is done.
+     */
     public boolean isDone() {
         return isDone;
     }
 
+    /**
+     * If the long running operation is done, get the result of the operation. If the operation is
+     * not done, then return null.
+     * @return The result of the operation, or null if the operation isn't done yet.
+     */
     public T result() {
         return result;
     }
 
+    /**
+     * Get an OperationStatus that represents a long running operation that is still in progress.
+     * @param <T> The type of result that the long running operation will return.
+     * @return An OperationStatus that represents a long running operation that is still in
+     * progress.
+     */
     public static <T> OperationStatus<T> inProgress() {
         return new OperationStatus<>(false, null);
     }
 
+    /**
+     * Get an OperationStatus that represents a long running operation that has completed.
+     * @param result The result of the long running operation.
+     * @param <T> The type of result that the long running operation will return.
+     * @return An OperationStatus that represents a long running operation that has completed.
+     */
     public static <T> OperationStatus<T> completed(T result) {
         return new OperationStatus<>(true, result);
     }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/Value.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/Value.java
@@ -1,0 +1,20 @@
+package com.microsoft.azure.v2;
+
+class Value<T> {
+    private T value;
+
+    Value() {
+    }
+
+    Value(T value) {
+        set(value);
+    }
+
+    public T get() {
+        return value;
+    }
+
+    public void set(T value) {
+        this.value = value;
+    }
+}

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/Value.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/Value.java
@@ -1,20 +1,50 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
 package com.microsoft.azure.v2;
 
+/**
+ * A container for a generic type. Serves a similar purpose as pointers in C/C++.
+ * @param <T>
+ */
 class Value<T> {
     private T value;
 
+    /**
+     * Create a new Value with inner value.
+     */
     Value() {
     }
 
+    /**
+     * Create a new Value with the provided inner value.
+     * @param value
+     */
     Value(T value) {
         set(value);
     }
 
+    /**
+     * Get the inner value of this Value.
+     * @return The inner value of this Value.
+     */
     public T get() {
         return value;
     }
 
+    /**
+     * Set the inner value of this Value.
+     * @param value The new inner value of this Value.
+     */
     public void set(T value) {
         this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/Value.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/Value.java
@@ -7,7 +7,8 @@
 package com.microsoft.azure.v2;
 
 /**
- * A container for a generic type. Serves a similar purpose as pointers in C/C++.
+ * A container for a generic type. Serves a similar purpose as pointers in C/C++. It's a workaround
+ * for the fact that Java doesn't allow mutation of local variables in closure.
  * @param <T>
  */
 class Value<T> {

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyTests.java
@@ -4,12 +4,15 @@ import com.microsoft.azure.v2.http.MockAzureHttpClient;
 import com.microsoft.azure.v2.http.MockAzureHttpResponse;
 import com.microsoft.rest.protocol.SerializerAdapter;
 import com.microsoft.rest.serializer.JacksonAdapter;
+import com.microsoft.rest.v2.InvalidReturnTypeException;
+import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.Host;
 import com.microsoft.rest.v2.annotations.PUT;
 import com.microsoft.rest.v2.annotations.PathParam;
 import org.junit.Test;
+import rx.Completable;
 import rx.Observable;
 import rx.Single;
 import rx.functions.Action1;
@@ -61,104 +64,392 @@ public class AzureProxyTests {
 
         @PUT("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}?PollType=Location&PollsRemaining={pollsRemaining}")
         @ExpectedResponses({200})
+        Observable<MockResource> beginCreateAsyncWithBadReturnType(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName, @PathParam("pollsRemaining") int pollsUntilResource);
+
+        @PUT("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}?PollType=Location&PollsRemaining={pollsRemaining}")
+        @ExpectedResponses({200})
         Observable<OperationStatus<MockResource>> beginCreateAsyncWithLocationAndPolls(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName, @PathParam("pollsRemaining") int pollsUntilResource);
+
+        @DELETE("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}")
+        @ExpectedResponses({200})
+        void delete(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName);
+
+        @DELETE("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}?PollType=Location")
+        @ExpectedResponses({200})
+        void deleteWithLocation(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName);
+
+        @DELETE("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}?PollType=Location&PollsRemaining={pollsRemaining}")
+        @ExpectedResponses({200})
+        void deleteWithLocationAndPolls(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName, @PathParam("pollsRemaining") int pollsUntilResource);
+
+        @DELETE("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}")
+        @ExpectedResponses({200})
+        Completable deleteAsync(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName);
+
+        @DELETE("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}?PollType=Location")
+        @ExpectedResponses({200})
+        Completable deleteAsyncWithLocation(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName);
+
+        @DELETE("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}?PollType=Location&PollsRemaining={pollsRemaining}")
+        @ExpectedResponses({200})
+        Completable deleteAsyncWithLocationAndPolls(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName, @PathParam("pollsRemaining") int pollsUntilResource);
+
+        @DELETE("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}?PollType=Location&PollsRemaining={pollsRemaining}")
+        @ExpectedResponses({200})
+        Observable<OperationStatus<Void>> beginDeleteAsyncWithLocationAndPolls(@PathParam("subscriptionId") String subscriptionId, @PathParam("resourceGroupName") String resourceGroupName, @PathParam("mockResourceName") String mockResourceName, @PathParam("pollsRemaining") int pollsUntilResource);
     }
 
     @Test
-    public void syncGet() {
-        final MockResource resource = createMockService(MockResourceService.class)
+    public void get() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResource resource = createMockService(MockResourceService.class, httpClient)
                 .get("1", "mine", "a");
         assertNotNull(resource);
         assertEquals("a", resource.name);
+
+        assertEquals(1, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
     }
 
     @Test
-    public void asyncGet() {
-        final MockResource resource = createMockService(MockResourceService.class)
+    public void getAsync() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResource resource = createMockService(MockResourceService.class, httpClient)
                 .getAsync("1", "mine", "b")
                 .toBlocking().value();
         assertNotNull(resource);
         assertEquals("b", resource.name);
+
+        assertEquals(1, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
     }
 
     @Test
-    public void syncCreate() {
-        final MockResource resource = createMockService(MockResourceService.class)
+    public void create() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResource resource = createMockService(MockResourceService.class, httpClient)
                 .create("1", "mine", "c");
         assertNotNull(resource);
         assertEquals("c", resource.name);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
     }
 
     @Test
-    public void syncCreateWithLocation() {
-        final MockResource resource = createMockService(MockResourceService.class)
+    public void createWithLocation() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResource resource = createMockService(MockResourceService.class, httpClient)
                 .createWithLocation("1", "mine", "c");
         assertNotNull(resource);
         assertEquals("c", resource.name);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(1, httpClient.pollRequests());
     }
 
     @Test
-    public void syncCreateWithLocationAndPolls() {
-        final MockResource resource = createMockService(MockResourceService.class)
+    public void createWithLocationAndPolls() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResource resource = createMockService(MockResourceService.class, httpClient)
                 .createWithLocationAndPolls("1", "mine", "c", 2);
         assertNotNull(resource);
         assertEquals("c", resource.name);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(2, httpClient.pollRequests());
     }
 
     @Test
-    public void asyncCreate() {
-        final MockResource resource = createMockService(MockResourceService.class)
+    public void createAsync() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResource resource = createMockService(MockResourceService.class, httpClient)
                 .createAsync("1", "mine", "c")
                 .toBlocking().value();
         assertNotNull(resource);
         assertEquals("c", resource.name);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
     }
 
     @Test
-    public void asyncCreateWithLocation() {
-        final MockResource resource = createMockService(MockResourceService.class)
+    public void createAsyncWithLocation() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResource resource = createMockService(MockResourceService.class, httpClient)
                 .createAsyncWithLocation("1", "mine", "c")
                 .toBlocking().value();
         assertNotNull(resource);
         assertEquals("c", resource.name);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(1, httpClient.pollRequests());
     }
 
     @Test
-    public void asyncCreateWithLocationAndPolls() {
-        final MockResource resource = createMockService(MockResourceService.class)
-                .createAsyncWithLocationAndPolls("1", "mine", "c", 2)
+    public void createAsyncWithLocationAndPolls() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResource resource = createMockService(MockResourceService.class, httpClient)
+                .createAsyncWithLocationAndPolls("1", "mine", "c", 3)
                 .toBlocking().value();
         assertNotNull(resource);
         assertEquals("c", resource.name);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(3, httpClient.pollRequests());
+    }
+
+    @Test
+    public void beginCreateAsyncWithBadReturnType() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final MockResourceService service = createMockService(MockResourceService.class, httpClient);
+        try {
+            service.beginCreateAsyncWithBadReturnType("1", "mine", "c", 2);
+            fail("Expected exception.");
+        }
+        catch (InvalidReturnTypeException e) {
+            assertContains(e.getMessage(), "AzureProxyTests$MockResourceService.beginCreateAsyncWithBadReturnType()");
+            assertContains(e.getMessage(), "rx.Observable<com.microsoft.azure.v2.MockResource>");
+        }
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
     }
 
     @Test
     public void beginCreateAsyncWithLocationAndPolls() {
-        final AtomicInteger pollCounts = new AtomicInteger();
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final AtomicInteger inProgressCount = new AtomicInteger();
         final Value<MockResource> resource = new Value<>();
 
-        createMockService(MockResourceService.class)
-                .beginCreateAsyncWithLocationAndPolls("1", "mine", "c", 2)
+        createMockService(MockResourceService.class, httpClient)
+                .beginCreateAsyncWithLocationAndPolls("1", "mine", "c", 3)
                 .subscribe(new Action1<OperationStatus<MockResource>>() {
                     @Override
-                    public void call(OperationStatus<MockResource> mockResourceOperationStatus) {
-                        if (!mockResourceOperationStatus.isDone()) {
-                            pollCounts.incrementAndGet();
+                    public void call(OperationStatus<MockResource> operationStatus) {
+                        if (!operationStatus.isDone()) {
+                            inProgressCount.incrementAndGet();
                         }
                         else {
-                            resource.set(mockResourceOperationStatus.result());
+                            resource.set(operationStatus.result());
                         }
                     }
                 });
 
-        assertEquals(1, pollCounts.get());
+        assertEquals(2, inProgressCount.get());
         assertNotNull(resource.get());
         assertEquals("c", resource.get().name);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(3, httpClient.pollRequests());
     }
 
-    private <T> T createMockService(Class<T> serviceClass) {
-        final MockAzureHttpClient mockHttpClient = new MockAzureHttpClient();
-        return AzureProxy.create(serviceClass, mockHttpClient, serializer);
+    @Test
+    public void beginCreateAsyncWithLocationAndPollsWhenPollsUntilResourceIs0() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final AtomicInteger inProgressCount = new AtomicInteger();
+        final Value<MockResource> resource = new Value<>();
+
+        createMockService(MockResourceService.class, httpClient)
+                .beginCreateAsyncWithLocationAndPolls("1", "mine", "c", 0)
+                .subscribe(new Action1<OperationStatus<MockResource>>() {
+                    @Override
+                    public void call(OperationStatus<MockResource> operationStatus) {
+                        if (!operationStatus.isDone()) {
+                            inProgressCount.incrementAndGet();
+                        }
+                        else {
+                            resource.set(operationStatus.result());
+                        }
+                    }
+                });
+
+        assertEquals(0, inProgressCount.get());
+        assertNotNull(resource.get());
+        assertEquals("c", resource.get().name);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(1, httpClient.createRequests());
+        assertEquals(0, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
+    }
+
+    @Test
+    public void delete() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        createMockService(MockResourceService.class, httpClient)
+                .delete("1", "mine", "c");
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(1, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
+    }
+
+    @Test
+    public void deleteWithLocation() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        createMockService(MockResourceService.class, httpClient)
+                .deleteWithLocation("1", "mine", "c");
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(1, httpClient.deleteRequests());
+        assertEquals(1, httpClient.pollRequests());
+    }
+
+    @Test
+    public void deleteWithLocationAndPolls() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        createMockService(MockResourceService.class, httpClient)
+                .deleteWithLocationAndPolls("1", "mine", "c", 4);
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(1, httpClient.deleteRequests());
+        assertEquals(4, httpClient.pollRequests());
+    }
+
+    @Test
+    public void deleteAsync() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        createMockService(MockResourceService.class, httpClient)
+                .deleteAsync("1", "mine", "c")
+                .await();
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(1, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
+    }
+
+    @Test
+    public void deleteAsyncWithLocation() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        createMockService(MockResourceService.class, httpClient)
+                .deleteAsyncWithLocation("1", "mine", "c")
+                .await();
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(1, httpClient.deleteRequests());
+        assertEquals(1, httpClient.pollRequests());
+    }
+
+    @Test
+    public void deleteAsyncWithLocationAndPolls() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        createMockService(MockResourceService.class, httpClient)
+                .deleteAsyncWithLocationAndPolls("1", "mine", "c", 10)
+                .await();
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(1, httpClient.deleteRequests());
+        assertEquals(10, httpClient.pollRequests());
+    }
+
+    @Test
+    public void beginDeleteAsyncWithLocationAndPolls() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final AtomicInteger inProgressCount = new AtomicInteger();
+        final Value<Boolean> completed = new Value<>();
+
+        createMockService(MockResourceService.class, httpClient)
+                .beginDeleteAsyncWithLocationAndPolls("1", "mine", "c", 3)
+                .subscribe(new Action1<OperationStatus<Void>>() {
+                    @Override
+                    public void call(OperationStatus<Void> operationStatus) {
+                        if (!operationStatus.isDone()) {
+                            inProgressCount.incrementAndGet();
+                        }
+                        else {
+                            completed.set(true);
+                        }
+                    }
+                });
+
+        assertEquals(2, inProgressCount.get());
+        assertNotNull(completed.get());
+        assertTrue(completed.get());
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(1, httpClient.deleteRequests());
+        assertEquals(3, httpClient.pollRequests());
+    }
+
+    @Test
+    public void beginDeleteAsyncWithLocationAndPollsWhenPollsUntilResourceIs0() {
+        final MockAzureHttpClient httpClient = new MockAzureHttpClient();
+
+        final AtomicInteger inProgressCount = new AtomicInteger();
+        final Value<Boolean> completed = new Value<>();
+
+        createMockService(MockResourceService.class, httpClient)
+                .beginDeleteAsyncWithLocationAndPolls("1", "mine", "c", 0)
+                .subscribe(new Action1<OperationStatus<Void>>() {
+                    @Override
+                    public void call(OperationStatus<Void> operationStatus) {
+                        if (!operationStatus.isDone()) {
+                            inProgressCount.incrementAndGet();
+                        }
+                        else {
+                            completed.set(true);
+                        }
+                    }
+                });
+
+        assertEquals(0, inProgressCount.get());
+        assertNotNull(completed.get());
+        assertTrue(completed.get());
+
+        assertEquals(0, httpClient.getRequests());
+        assertEquals(0, httpClient.createRequests());
+        assertEquals(1, httpClient.deleteRequests());
+        assertEquals(0, httpClient.pollRequests());
+    }
+
+    private static <T> T createMockService(Class<T> serviceClass, MockAzureHttpClient httpClient) {
+        return AzureProxy.create(serviceClass, httpClient, serializer);
     }
 
     @Test
@@ -285,6 +576,9 @@ public class AzureProxyTests {
         assertEquals(123, AzureProxy.getRetryAfterSeconds(response, 5L).longValue());
     }
 
+    private static void assertContains(String value, String expectedSubstring) {
+        assertTrue("Expected \"" + value + "\" to contain \"" + expectedSubstring + "\".", value.contains(expectedSubstring));
+    }
 
     private static final SerializerAdapter<?> serializer = new JacksonAdapter();
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/InvalidReturnTypeException.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/InvalidReturnTypeException.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2;
+
+/**
+ * An exception that will be thrown when a Swagger interface defines a method with an invalid return
+ * type.
+ */
+public class InvalidReturnTypeException extends RuntimeException {
+    /**
+     * Create a new InvalidReturnTypeException with the provided message.
+     * @param message The message for this exception.
+     */
+    public InvalidReturnTypeException(String message) {
+        super(message);
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -15,6 +15,7 @@ import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.http.UrlBuilder;
 import rx.Completable;
+import rx.Observable;
 import rx.Single;
 import rx.functions.Func1;
 
@@ -127,6 +128,9 @@ public final class RestProxy implements InvocationHandler {
                     }
                 });
             }
+            else if (returnTypeToken.isSubtypeOf(Observable.class)) {
+                returnTypeToken.
+            }
             else {
                 result = null;
             }
@@ -172,7 +176,7 @@ public final class RestProxy implements InvocationHandler {
         Object result;
         final Type returnType = methodParser.returnType();
         final TypeToken returnTypeToken = TypeToken.of(returnType);
-        if (returnTypeToken.isSubtypeOf(Completable.class) || returnTypeToken.isSubtypeOf(Single.class)) {
+        if (returnTypeToken.isSubtypeOf(Completable.class) || returnTypeToken.isSubtypeOf(Single.class) || returnTypeToken.isSubtypeOf(Observable.class)) {
             final Single<HttpResponse> asyncResponse = httpClient.sendRequestAsync(request);
             result = responseHandler.handleAsyncResponse(asyncResponse, methodParser, serializer);
         }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -64,7 +64,7 @@ public class SwaggerMethodParser {
 
         final Class<?> swaggerInterface = swaggerMethod.getDeclaringClass();
 
-        fullyQualifiedMethodName = swaggerInterface.getCanonicalName() + "." + swaggerMethod.getName();
+        fullyQualifiedMethodName = swaggerInterface.getName() + "." + swaggerMethod.getName();
 
         if (swaggerMethod.isAnnotationPresent(GET.class)) {
             setHttpMethodAndRelativePath("GET", swaggerMethod.getAnnotation(GET.class).value());

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -22,6 +22,7 @@ import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpHeaders;
 import org.junit.Test;
 import rx.Completable;
+import rx.Observable;
 import rx.Single;
 
 import java.io.IOException;
@@ -593,10 +594,34 @@ public abstract class RestProxyTests {
         assertEquals("MyHeaderValue", headers.value("MyHeader"));
     }
 
+    @Host("https://httpbin.org")
+    private interface Service15 {
+        @GET("anything")
+        @ExpectedResponses({200})
+        Observable<HttpBinJSON> get();
+    }
+
+    @Test
+    public void service15Get() {
+        final Service15 service = createService(Service15.class);
+        try {
+            service.get();
+            fail("Expected exception.");
+        }
+        catch (InvalidReturnTypeException e) {
+            assertContains(e.getMessage(), "rx.Observable<com.microsoft.rest.v2.HttpBinJSON>");
+            assertContains(e.getMessage(), "RestProxyTests$Service15.get()");
+        }
+    }
+
     // Helpers
     private <T> T createService(Class<T> serviceClass) {
         final HttpClient httpClient = createHttpClient();
         return RestProxy.create(serviceClass, httpClient, serializer);
+    }
+
+    private static void assertContains(String value, String expectedSubstring) {
+        assertTrue("Expected \"" + value + "\" to contain \"" + expectedSubstring + "\".", value.contains(expectedSubstring));
     }
 
     private static final SerializerAdapter<?> serializer = new JacksonAdapter();

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerInterfaceParserTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerInterfaceParserTests.java
@@ -43,7 +43,7 @@ public class SwaggerInterfaceParserTests {
 
         final SwaggerMethodParser methodParser = interfaceParser.methodParser(testMethod3);
         assertNotNull(methodParser);
-        assertEquals("com.microsoft.rest.v2.SwaggerInterfaceParserTests.TestInterface3.testMethod3", methodParser.fullyQualifiedMethodName());
+        assertEquals("com.microsoft.rest.v2.SwaggerInterfaceParserTests$TestInterface3.testMethod3", methodParser.fullyQualifiedMethodName());
 
         final SwaggerMethodParser methodDetails2 = interfaceParser.methodParser(testMethod3);
         assertSame(methodParser, methodDetails2);

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerMethodParserTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/SwaggerMethodParserTests.java
@@ -34,7 +34,7 @@ public class SwaggerMethodParserTests {
         assertEquals("testMethod2", testMethod2.getName());
 
         final SwaggerMethodParser methodParser = new SwaggerMethodParser(testMethod2, "https://raw.host.com");
-        assertEquals("com.microsoft.rest.v2.SwaggerMethodParserTests.TestInterface2.testMethod2", methodParser.fullyQualifiedMethodName());
+        assertEquals("com.microsoft.rest.v2.SwaggerMethodParserTests$TestInterface2.testMethod2", methodParser.fullyQualifiedMethodName());
         assertEquals(null, methodParser.httpMethod());
         assertArrayEquals(new int[] { 200 }, methodParser.expectedStatusCodes());
         assertEquals(RestException.class, methodParser.exceptionType());
@@ -56,7 +56,7 @@ public class SwaggerMethodParserTests {
         assertEquals("testMethod3", testMethod3.getName());
 
         final SwaggerMethodParser methodParser = new SwaggerMethodParser(testMethod3, "https://raw.host.com");
-        assertEquals("com.microsoft.rest.v2.SwaggerMethodParserTests.TestInterface3.testMethod3", methodParser.fullyQualifiedMethodName());
+        assertEquals("com.microsoft.rest.v2.SwaggerMethodParserTests$TestInterface3.testMethod3", methodParser.fullyQualifiedMethodName());
         assertEquals(null, methodParser.httpMethod());
         assertArrayEquals(new int[] { 200 }, methodParser.expectedStatusCodes());
         assertEquals(MyRestException.class, methodParser.exceptionType());


### PR DESCRIPTION
This pull request adds support for long running operations with no return type (some delete calls are this way). It also adds support for polling long running operations and returning periodic OperationStatus objects.