### PR TITLE
Remove ResponseHandler, make AzureProxy subclass RestProxy

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
@@ -7,10 +7,10 @@
 package com.microsoft.azure.v2;
 
 import com.google.common.reflect.TypeToken;
-import com.microsoft.rest.RestException;
 import com.microsoft.rest.protocol.SerializerAdapter;
 import com.microsoft.rest.v2.InvalidReturnTypeException;
 import com.microsoft.rest.v2.RestProxy;
+import com.microsoft.rest.v2.SwaggerInterfaceParser;
 import com.microsoft.rest.v2.SwaggerMethodParser;
 import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpRequest;
@@ -23,6 +23,7 @@ import rx.functions.Func1;
 
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.concurrent.TimeUnit;
 
@@ -30,12 +31,16 @@ import java.util.concurrent.TimeUnit;
  * This class can be used to create an Azure specific proxy implementation for a provided Swagger
  * generated interface.
  */
-public class AzureProxy {
-
+public class AzureProxy extends RestProxy {
     /**
-     * Empty constructor.
+     * Create a new instance of RestProxy.
+     * @param httpClient The HttpClient that will be used by this RestProxy to send HttpRequests.
+     * @param serializer The serializer that will be used to convert response bodies to POJOs.
+     * @param interfaceParser The parser that contains information about the swagger interface that
+     *                        this RestProxy "implements".
      */
-    AzureProxy() {
+    AzureProxy(HttpClient httpClient, SerializerAdapter<?> serializer, SwaggerInterfaceParser interfaceParser) {
+        super(httpClient, serializer, interfaceParser);
     }
 
     /**
@@ -49,130 +54,144 @@ public class AzureProxy {
      */
     @SuppressWarnings("unchecked")
     public static <A> A create(Class<A> swaggerInterface, final HttpClient httpClient, SerializerAdapter<?> serializer) {
-        return RestProxy.create(swaggerInterface, null /* FIXME: get URL from @AzureHost */, httpClient, serializer, new RestProxy.ResponseHandler() {
-            @Override
-            public Object handleSyncResponse(HttpResponse response, SwaggerMethodParser methodParser, Type returnType, SerializerAdapter<?> serializer) throws IOException, RestException {
-                while (!isDonePolling(response)) {
-                    final String location = response.headerValue("Location");
-                    final HttpRequest pollRequest = createPollRequest(methodParser.fullyQualifiedMethodName(), location);
-                    response = httpClient.sendRequest(pollRequest);
-                }
-                return RestProxy.DEFAULT_RESPONSE_HANDLER.handleSyncResponse(response, methodParser, returnType, serializer);
-            }
+        /* FIXME: get URL from @AzureHost */
+        final String baseUrl = null;
 
-            @Override
-            public Object handleAsyncResponse(Single<HttpResponse> asyncResponse, final SwaggerMethodParser methodParser, final SerializerAdapter<?> serializer) {
-                Object result = null;
-
-                final Type returnType = methodParser.returnType();
-                final TypeToken returnTypeToken = TypeToken.of(returnType);
-
-                if (returnTypeToken.isSubtypeOf(Completable.class) || returnTypeToken.isSubtypeOf(Single.class)) {
-                    asyncResponse = asyncResponse
-                            .flatMap(new Func1<HttpResponse, Single<? extends HttpResponse>>() {
-                                @Override
-                                public Single<? extends HttpResponse> call(HttpResponse response) {
-                                    Single<HttpResponse> result;
-                                    if (isDonePolling(response)) {
-                                        result = Single.just(response);
-                                    }
-                                    else {
-                                        final Value<String> pollUrl = new Value<>(getPollUrl(response, null));
-                                        final Value<Long> retryAfterSeconds = new Value<>(getRetryAfterSeconds(response, null));
-
-                                        result = sendPollRequestWithDelay(methodParser, httpClient, pollUrl, retryAfterSeconds)
-                                                    .repeat()
-                                                    .takeUntil(new Func1<HttpResponse, Boolean>() {
-                                                        @Override
-                                                        public Boolean call(HttpResponse response) {
-                                                            pollUrl.set(getPollUrl(response, pollUrl.get()));
-                                                            retryAfterSeconds.set(getRetryAfterSeconds(response, retryAfterSeconds.get()));
-                                                            return isDonePolling(response);
-                                                        }
-                                                    })
-                                                    .last()
-                                                    .toSingle();
-                                    }
-                                    return result;
-                                }
-                            });
-                    result = RestProxy.DEFAULT_RESPONSE_HANDLER.handleAsyncResponse(asyncResponse, methodParser, serializer);
-                }
-                else if (returnTypeToken.isSubtypeOf(Observable.class)) {
-                    final Type operationStatusType = ((ParameterizedType) returnType).getActualTypeArguments()[0];
-                    final TypeToken operationStatusTypeToken = TypeToken.of(operationStatusType);
-                    if (!operationStatusTypeToken.isSubtypeOf(OperationStatus.class)) {
-                        throw new InvalidReturnTypeException("AzureProxy only supports swagger interface methods that return Observable (such as " + methodParser.fullyQualifiedMethodName() + "()) if the Observable's inner type that is OperationStatus (not " + returnType.toString() + ").");
-                    }
-                    else {
-                        final Type operationStatusResultType = ((ParameterizedType) operationStatusType).getActualTypeArguments()[0];
-                        result = asyncResponse
-                                .toObservable()
-                                .flatMap(new Func1<HttpResponse, Observable<OperationStatus<Object>>>() {
-                                    @Override
-                                    public Observable<OperationStatus<Object>> call(HttpResponse response) {
-                                        Observable<OperationStatus<Object>> result;
-                                        if (isDonePolling(response)) {
-                                            return toOperationStatusObservable(response, methodParser, operationStatusResultType, serializer);
-                                        } else {
-                                            final Value<String> pollUrl = new Value<>(getPollUrl(response, null));
-                                            final Value<Long> retryAfterSeconds = new Value<>(getRetryAfterSeconds(response, null));
-                                            final Value<OperationStatus<Object>> lastOperationStatus = new Value<>();
-
-                                            result = sendPollRequestWithDelay(methodParser, httpClient, pollUrl, retryAfterSeconds)
-                                                        .flatMap(new Func1<HttpResponse, Observable<OperationStatus<Object>>>() {
-                                                            @Override
-                                                            public Observable<OperationStatus<Object>> call(HttpResponse httpResponse) {
-                                                                pollUrl.set(getPollUrl(httpResponse, pollUrl.get()));
-                                                                retryAfterSeconds.set(getRetryAfterSeconds(httpResponse, retryAfterSeconds.get()));
-
-                                                                Observable<OperationStatus<Object>> result;
-                                                                if (isDonePolling(httpResponse)) {
-                                                                    result = toOperationStatusObservable(httpResponse, methodParser, operationStatusResultType, serializer);
-                                                                }
-                                                                else {
-                                                                    result = Observable.just(OperationStatus.inProgress());
-                                                                }
-                                                                return result;
-                                                            }
-                                                        })
-                                                        .repeat()
-                                                        .takeUntil(new Func1<OperationStatus<Object>, Boolean>() {
-                                                            @Override
-                                                            public Boolean call(OperationStatus<Object> operationStatus) {
-                                                                final boolean stop = operationStatus.isDone();
-                                                                if (stop) {
-                                                                    // Take until will not return the operationStatus that is
-                                                                    // marked as done, so we set it here and then concatWith() it
-                                                                    // later to force the Observable to return the operationStatus
-                                                                    // that is done.
-                                                                    lastOperationStatus.set(operationStatus);
-                                                                }
-                                                                return stop;
-                                                            }
-                                                        })
-                                                        .concatWith(Observable.defer(new Func0<Observable<OperationStatus<Object>>>() {
-                                                            @Override
-                                                            public Observable<OperationStatus<Object>> call() {
-                                                                return Observable.just(lastOperationStatus.get());
-                                                            }
-                                                        }));
-                                        }
-                                        return result;
-                                    }
-                                });
-                    }
-                }
-
-                return result;
-            }
-        });
+        final SwaggerInterfaceParser interfaceParser = new SwaggerInterfaceParser(swaggerInterface, baseUrl);
+        final AzureProxy azureProxy = new AzureProxy(httpClient, serializer, interfaceParser);
+        return (A) Proxy.newProxyInstance(swaggerInterface.getClassLoader(), new Class[]{swaggerInterface}, azureProxy);
     }
 
-    private static Observable<OperationStatus<Object>> toOperationStatusObservable(HttpResponse httpResponse, SwaggerMethodParser methodParser, Type operationStatusResultType, SerializerAdapter<?> serializer) {
+    @Override
+    protected Object handleSyncHttpResponse(HttpResponse httpResponse, SwaggerMethodParser methodParser) throws IOException, InterruptedException {
+        String pollUrl = null;
+        Long retryAfterSeconds = null;
+        while (!isDonePolling(httpResponse)) {
+            pollUrl = getPollUrl(httpResponse, pollUrl);
+
+            retryAfterSeconds = getRetryAfterSeconds(httpResponse, retryAfterSeconds);
+            if (retryAfterSeconds != null && retryAfterSeconds > 0) {
+                Thread.sleep(retryAfterSeconds * 1000);
+            }
+
+            final HttpRequest pollRequest = createPollRequest(methodParser.fullyQualifiedMethodName(), pollUrl);
+            httpResponse = sendHttpRequest(pollRequest);
+        }
+
+        return super.handleSyncHttpResponse(httpResponse, methodParser);
+    }
+
+    @Override
+    protected Object handleAsyncHttpResponse(Single<HttpResponse> asyncHttpResponse, final SwaggerMethodParser methodParser) {
+        Object result = null;
+
+        final Type returnType = methodParser.returnType();
+        final TypeToken returnTypeToken = TypeToken.of(returnType);
+
+        if (returnTypeToken.isSubtypeOf(Completable.class) || returnTypeToken.isSubtypeOf(Single.class)) {
+            asyncHttpResponse = asyncHttpResponse
+                    .flatMap(new Func1<HttpResponse, Single<? extends HttpResponse>>() {
+                        @Override
+                        public Single<? extends HttpResponse> call(HttpResponse response) {
+                            Single<HttpResponse> result;
+                            if (isDonePolling(response)) {
+                                result = Single.just(response);
+                            }
+                            else {
+                                final Value<String> pollUrl = new Value<>(getPollUrl(response, null));
+                                final Value<Long> retryAfterSeconds = new Value<>(getRetryAfterSeconds(response, null));
+
+                                result = sendPollRequestWithDelay(methodParser, pollUrl, retryAfterSeconds)
+                                        .repeat()
+                                        .takeUntil(new Func1<HttpResponse, Boolean>() {
+                                            @Override
+                                            public Boolean call(HttpResponse response) {
+                                                pollUrl.set(getPollUrl(response, pollUrl.get()));
+                                                retryAfterSeconds.set(getRetryAfterSeconds(response, retryAfterSeconds.get()));
+                                                return isDonePolling(response);
+                                            }
+                                        })
+                                        .last()
+                                        .toSingle();
+                            }
+                            return result;
+                        }
+                    });
+            result = super.handleAsyncHttpResponse(asyncHttpResponse, methodParser);
+        }
+        else if (returnTypeToken.isSubtypeOf(Observable.class)) {
+            final Type operationStatusType = ((ParameterizedType) returnType).getActualTypeArguments()[0];
+            final TypeToken operationStatusTypeToken = TypeToken.of(operationStatusType);
+            if (!operationStatusTypeToken.isSubtypeOf(OperationStatus.class)) {
+                throw new InvalidReturnTypeException("AzureProxy only supports swagger interface methods that return Observable (such as " + methodParser.fullyQualifiedMethodName() + "()) if the Observable's inner type that is OperationStatus (not " + returnType.toString() + ").");
+            }
+            else {
+                final Type operationStatusResultType = ((ParameterizedType) operationStatusType).getActualTypeArguments()[0];
+                result = asyncHttpResponse
+                        .toObservable()
+                        .flatMap(new Func1<HttpResponse, Observable<OperationStatus<Object>>>() {
+                            @Override
+                            public Observable<OperationStatus<Object>> call(HttpResponse response) {
+                                Observable<OperationStatus<Object>> result;
+                                if (isDonePolling(response)) {
+                                    return toOperationStatusObservable(response, methodParser, operationStatusResultType);
+                                } else {
+                                    final Value<String> pollUrl = new Value<>(getPollUrl(response, null));
+                                    final Value<Long> retryAfterSeconds = new Value<>(getRetryAfterSeconds(response, null));
+                                    final Value<OperationStatus<Object>> lastOperationStatus = new Value<>();
+
+                                    result = sendPollRequestWithDelay(methodParser, pollUrl, retryAfterSeconds)
+                                            .flatMap(new Func1<HttpResponse, Observable<OperationStatus<Object>>>() {
+                                                @Override
+                                                public Observable<OperationStatus<Object>> call(HttpResponse httpResponse) {
+                                                    pollUrl.set(getPollUrl(httpResponse, pollUrl.get()));
+                                                    retryAfterSeconds.set(getRetryAfterSeconds(httpResponse, retryAfterSeconds.get()));
+
+                                                    Observable<OperationStatus<Object>> result;
+                                                    if (isDonePolling(httpResponse)) {
+                                                        result = toOperationStatusObservable(httpResponse, methodParser, operationStatusResultType);
+                                                    }
+                                                    else {
+                                                        result = Observable.just(OperationStatus.inProgress());
+                                                    }
+                                                    return result;
+                                                }
+                                            })
+                                            .repeat()
+                                            .takeUntil(new Func1<OperationStatus<Object>, Boolean>() {
+                                                @Override
+                                                public Boolean call(OperationStatus<Object> operationStatus) {
+                                                    final boolean stop = operationStatus.isDone();
+                                                    if (stop) {
+                                                        // Take until will not return the operationStatus that is
+                                                        // marked as done, so we set it here and then concatWith() it
+                                                        // later to force the Observable to return the operationStatus
+                                                        // that is done.
+                                                        lastOperationStatus.set(operationStatus);
+                                                    }
+                                                    return stop;
+                                                }
+                                            })
+                                            .concatWith(Observable.defer(new Func0<Observable<OperationStatus<Object>>>() {
+                                                @Override
+                                                public Observable<OperationStatus<Object>> call() {
+                                                    return Observable.just(lastOperationStatus.get());
+                                                }
+                                            }));
+                                }
+                                return result;
+                            }
+                        });
+            }
+        }
+
+        return result;
+    }
+
+    private Observable<OperationStatus<Object>> toOperationStatusObservable(HttpResponse httpResponse, SwaggerMethodParser methodParser, Type operationStatusResultType) {
         Observable<OperationStatus<Object>> result;
         try {
-            final Object resultObject = RestProxy.DEFAULT_RESPONSE_HANDLER.handleSyncResponse(httpResponse, methodParser, operationStatusResultType, serializer);
+            final Object resultObject = super.handleSyncHttpResponse(httpResponse, methodParser, operationStatusResultType);
             final OperationStatus<Object> operationStatus = OperationStatus.completed(resultObject);
             result = Observable.just(operationStatus);
         } catch (IOException e) {
@@ -202,7 +221,7 @@ public class AzureProxy {
         return pollUrl;
     }
 
-    private static Observable<HttpResponse> sendPollRequestWithDelay(SwaggerMethodParser methodParser, final HttpClient httpClient, final Value<String> pollUrl, final Value<Long> retryAfterSeconds) {
+    private Observable<HttpResponse> sendPollRequestWithDelay(SwaggerMethodParser methodParser, final Value<String> pollUrl, final Value<Long> retryAfterSeconds) {
         final String fullyQualifiedMethodName = methodParser.fullyQualifiedMethodName();
 
         return Observable.defer(new Func0<Observable<HttpResponse>>() {
@@ -210,7 +229,7 @@ public class AzureProxy {
             public Observable<HttpResponse> call() {
                 final HttpRequest pollRequest = createPollRequest(fullyQualifiedMethodName, pollUrl.get());
 
-                Single<HttpResponse> pollResponse = httpClient.sendRequestAsync(pollRequest);
+                Single<HttpResponse> pollResponse = sendHttpRequestAsync(pollRequest);
                 if (retryAfterSeconds.get() != null) {
                     pollResponse = pollResponse.delay(retryAfterSeconds.get(), TimeUnit.SECONDS);
                 }

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyTests.java
@@ -23,11 +23,6 @@ import static org.junit.Assert.*;
 
 public class AzureProxyTests {
 
-    @Test
-    public void constructor() {
-        new AzureProxy();
-    }
-
     @Host("https://mock.azure.com")
     private interface MockResourceService {
         @GET("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/mockprovider/mockresources/{mockResourceName}")

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/ValueTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/ValueTests.java
@@ -1,0 +1,21 @@
+package com.microsoft.azure.v2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ValueTests {
+    @Test
+    public void constructorWithNoArguments() {
+        final Value<Integer> v = new Value<>();
+        assertNull(v.get());
+        assertEquals("null", v.toString());
+    }
+
+    @Test
+    public void constructorWithArgument() {
+        final Value<Integer> v = new Value<>(20);
+        assertEquals(20, v.get().intValue());
+        assertEquals("20", v.toString());
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -15,7 +15,6 @@ import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.http.UrlBuilder;
 import rx.Completable;
-import rx.Observable;
 import rx.Single;
 import rx.functions.Func1;
 
@@ -35,119 +34,80 @@ import java.lang.reflect.Type;
  * deserialized Java objects as well as asynchronous Single objects that resolve to a deserialized
  * Java object.
  */
-public final class RestProxy implements InvocationHandler {
+public class RestProxy implements InvocationHandler {
     private final HttpClient httpClient;
     private final SerializerAdapter<?> serializer;
     private final SwaggerInterfaceParser interfaceParser;
-    private final ResponseHandler responseHandler;
 
     /**
-     * The default response handler that will be used to convert HttpResponse objects to the proxy
-     * method's return value.
+     * Create a new instance of RestProxy.
+     * @param httpClient The HttpClient that will be used by this RestProxy to send HttpRequests.
+     * @param serializer The serializer that will be used to convert response bodies to POJOs.
+     * @param interfaceParser The parser that contains information about the swagger interface that
+     *                        this RestProxy "implements".
      */
-    public static final ResponseHandler DEFAULT_RESPONSE_HANDLER = new ResponseHandler() {
-        @Override
-        public Object handleSyncResponse(HttpResponse response, SwaggerMethodParser methodParser, Type returnType, SerializerAdapter<?> serializer) throws IOException {
-            Object result;
-
-            final TypeToken returnTypeToken = TypeToken.of(returnType);
-            final int responseStatusCode = response.statusCode();
-            if (!methodParser.isExpectedResponseStatusCode(responseStatusCode)) {
-                final Class<? extends RestException> exceptionType = methodParser.exceptionType();
-                String responseContent = null;
-                try {
-                    final Class<?> exceptionBodyType = methodParser.exceptionBodyType();
-                    final Constructor<? extends RestException> exceptionConstructor = exceptionType.getConstructor(String.class, HttpResponse.class, exceptionBodyType);
-
-                    try {
-                        responseContent = response.bodyAsString();
-                    } catch (IOException ignored) {
-                    }
-
-                    final Object exceptionBody = responseContent == null || responseContent.isEmpty() ? null : serializer.deserialize(responseContent, exceptionBodyType);
-
-                    throw exceptionConstructor.newInstance("Status code " + responseStatusCode + ", " + responseContent, response, exceptionBody);
-                } catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException e) {
-                    String message = "Status code " + responseStatusCode + ", but an instance of " + exceptionType.getCanonicalName() + " cannot be created.";
-                    if (responseContent != null && responseContent.isEmpty()) {
-                        message += " Response content: \"" + responseContent + "\"";
-                    }
-                    throw new IOException(message, e);
-                }
-            }
-
-            if (returnType.equals(Void.TYPE) || methodParser.httpMethod().equalsIgnoreCase("HEAD")) {
-                result = null;
-            } else if (returnTypeToken.isSubtypeOf(InputStream.class)) {
-                result = response.bodyAsInputStream();
-            } else if (returnTypeToken.isSubtypeOf(byte[].class)) {
-                result = response.bodyAsByteArray();
-            } else {
-                final String responseBodyString = response.bodyAsString();
-                result = serializer.deserialize(responseBodyString, returnType);
-            }
-
-            return result;
-        }
-
-        @Override
-        public Object handleAsyncResponse(Single<HttpResponse> asyncResponse, final SwaggerMethodParser methodParser, final SerializerAdapter<?> serializer) {
-            Object result;
-
-            final Type returnType = methodParser.returnType();
-            final TypeToken returnTypeToken = TypeToken.of(returnType);
-            if (returnTypeToken.isSubtypeOf(Completable.class)) {
-                result = Completable.fromSingle(asyncResponse);
-            }
-            else if (returnTypeToken.isSubtypeOf(Single.class)) {
-                result = asyncResponse.flatMap(new Func1<HttpResponse, Single<?>>() {
-                    @Override
-                    public Single<?> call(HttpResponse response) {
-                        Single<?> asyncResult;
-                        final Type singleReturnType = ((ParameterizedType) returnType).getActualTypeArguments()[0];
-                        final TypeToken singleReturnTypeToken = TypeToken.of(singleReturnType);
-                        if (methodParser.httpMethod().equalsIgnoreCase("HEAD")) {
-                            asyncResult = Single.just(null);
-                        } else if (singleReturnTypeToken.isSubtypeOf(InputStream.class)) {
-                            asyncResult = response.bodyAsInputStreamAsync();
-                        } else if (singleReturnTypeToken.isSubtypeOf(byte[].class)) {
-                            asyncResult = response.bodyAsByteArrayAsync();
-                        } else {
-                            final Single<String> asyncResponseBodyString = response.bodyAsStringAsync();
-                            asyncResult = asyncResponseBodyString.flatMap(new Func1<String, Single<Object>>() {
-                                @Override
-                                public Single<Object> call(String responseBodyString) {
-                                    try {
-                                        return Single.just(serializer.deserialize(responseBodyString, singleReturnType));
-                                    } catch (Throwable e) {
-                                        return Single.error(e);
-                                    }
-                                }
-                            });
-                        }
-                        return asyncResult;
-                    }
-                });
-            }
-            else {
-                throw new InvalidReturnTypeException("RestProxy does not support swagger interface methods (such as " + methodParser.fullyQualifiedMethodName() + "()) with a return type of " + returnType.toString());
-            }
-
-            return result;
-        }
-    };
-
-    RestProxy(HttpClient httpClient, SerializerAdapter<?> serializer, SwaggerInterfaceParser interfaceParser, ResponseHandler responseHandler) {
+    public RestProxy(HttpClient httpClient, SerializerAdapter<?> serializer, SwaggerInterfaceParser interfaceParser) {
         this.httpClient = httpClient;
         this.serializer = serializer;
         this.interfaceParser = interfaceParser;
-        this.responseHandler = responseHandler;
+    }
+
+    /**
+     * Get the SwaggerMethodParser for the provided method. The Method must exist on the Swagger
+     * interface that this RestProxy was created to "implement".
+     * @param method The method to get a SwaggerMethodParser for.
+     * @return The SwaggerMethodParser for the provided method.
+     */
+    private SwaggerMethodParser methodParser(Method method) {
+        return interfaceParser.methodParser(method);
+    }
+
+    /**
+     * Send the provided request and block until the response is received.
+     * @param request The HTTP request to send.
+     * @return The HTTP response received.
+     * @throws IOException On network issues.
+     */
+    public HttpResponse sendHttpRequest(HttpRequest request) throws IOException {
+        return httpClient.sendRequest(request);
+    }
+
+    /**
+     * Send the provided request asynchronously, applying any request policies provided to the HttpClient instance.
+     * @param request The HTTP request to send.
+     * @return A {@link Single} representing the HTTP response that will arrive asynchronously.
+     */
+    public Single<HttpResponse> sendHttpRequestAsync(HttpRequest request) {
+        return httpClient.sendRequestAsync(request);
     }
 
     @Override
-    public Object invoke(Object proxy, final Method method, Object[] args) throws IOException {
-        final SwaggerMethodParser methodParser = interfaceParser.methodParser(method);
+    public Object invoke(Object proxy, final Method method, Object[] args) throws IOException, InterruptedException {
+        final SwaggerMethodParser methodParser = methodParser(method);
 
+        final HttpRequest request = createHttpRequest(methodParser, args);
+
+        Object result;
+        if (methodParser.isAsync()) {
+            final Single<HttpResponse> asyncResponse = sendHttpRequestAsync(request);
+            result = handleAsyncHttpResponse(asyncResponse, methodParser);
+        }
+        else {
+            final HttpResponse response = sendHttpRequest(request);
+            result = handleSyncHttpResponse(response, methodParser);
+        }
+
+        return result;
+    }
+
+    /**
+     * Create a HttpRequest for the provided Swagger method using the provided arguments.
+     * @param methodParser The Swagger method parser to use.
+     * @param args The arguments to use to populate the method's annotation values.
+     * @return A HttpRequest.
+     * @throws IOException Thrown if the body contents cannot be serialized.
+     */
+    private HttpRequest createHttpRequest(SwaggerMethodParser methodParser, Object[] args) throws IOException {
         final UrlBuilder urlBuilder = new UrlBuilder()
                 .withScheme(methodParser.scheme(args))
                 .withHost(methodParser.host(args))
@@ -171,16 +131,97 @@ public final class RestProxy implements InvocationHandler {
             request.withBody(bodyContentString, mimeType);
         }
 
+        return request;
+    }
+
+    protected Object handleSyncHttpResponse(HttpResponse httpResponse, SwaggerMethodParser methodParser) throws IOException, InterruptedException {
+        final Type returnType = methodParser.returnType();
+        return handleSyncHttpResponse(httpResponse, methodParser, returnType);
+    }
+
+    protected Object handleSyncHttpResponse(HttpResponse httpResponse, SwaggerMethodParser methodParser, Type returnType) throws IOException {
         Object result;
+
+        final TypeToken returnTypeToken = TypeToken.of(returnType);
+        final int responseStatusCode = httpResponse.statusCode();
+        if (!methodParser.isExpectedResponseStatusCode(responseStatusCode)) {
+            final Class<? extends RestException> exceptionType = methodParser.exceptionType();
+            String responseContent = null;
+            try {
+                final Class<?> exceptionBodyType = methodParser.exceptionBodyType();
+                final Constructor<? extends RestException> exceptionConstructor = exceptionType.getConstructor(String.class, HttpResponse.class, exceptionBodyType);
+
+                try {
+                    responseContent = httpResponse.bodyAsString();
+                } catch (IOException ignored) {
+                }
+
+                final Object exceptionBody = responseContent == null || responseContent.isEmpty() ? null : serializer.deserialize(responseContent, exceptionBodyType);
+
+                throw exceptionConstructor.newInstance("Status code " + responseStatusCode + ", " + responseContent, httpResponse, exceptionBody);
+            } catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException e) {
+                String message = "Status code " + responseStatusCode + ", but an instance of " + exceptionType.getCanonicalName() + " cannot be created.";
+                if (responseContent != null && responseContent.isEmpty()) {
+                    message += " Response content: \"" + responseContent + "\"";
+                }
+                throw new IOException(message, e);
+            }
+        }
+
+        if (returnType.equals(Void.TYPE) || methodParser.httpMethod().equalsIgnoreCase("HEAD")) {
+            result = null;
+        } else if (returnTypeToken.isSubtypeOf(InputStream.class)) {
+            result = httpResponse.bodyAsInputStream();
+        } else if (returnTypeToken.isSubtypeOf(byte[].class)) {
+            result = httpResponse.bodyAsByteArray();
+        } else {
+            final String responseBodyString = httpResponse.bodyAsString();
+            result = serializer.deserialize(responseBodyString, returnType);
+        }
+
+        return result;
+    }
+
+    protected Object handleAsyncHttpResponse(Single<HttpResponse> asyncHttpResponse, final SwaggerMethodParser methodParser) {
+        Object result;
+
         final Type returnType = methodParser.returnType();
         final TypeToken returnTypeToken = TypeToken.of(returnType);
-        if (returnTypeToken.isSubtypeOf(Completable.class) || returnTypeToken.isSubtypeOf(Single.class) || returnTypeToken.isSubtypeOf(Observable.class)) {
-            final Single<HttpResponse> asyncResponse = httpClient.sendRequestAsync(request);
-            result = responseHandler.handleAsyncResponse(asyncResponse, methodParser, serializer);
+        if (returnTypeToken.isSubtypeOf(Completable.class)) {
+            result = Completable.fromSingle(asyncHttpResponse);
+        }
+        else if (returnTypeToken.isSubtypeOf(Single.class)) {
+            result = asyncHttpResponse.flatMap(new Func1<HttpResponse, Single<?>>() {
+                @Override
+                public Single<?> call(HttpResponse response) {
+                    Single<?> asyncResult;
+                    final Type singleReturnType = ((ParameterizedType) returnType).getActualTypeArguments()[0];
+                    final TypeToken singleReturnTypeToken = TypeToken.of(singleReturnType);
+                    if (methodParser.httpMethod().equalsIgnoreCase("HEAD")) {
+                        asyncResult = Single.just(null);
+                    } else if (singleReturnTypeToken.isSubtypeOf(InputStream.class)) {
+                        asyncResult = response.bodyAsInputStreamAsync();
+                    } else if (singleReturnTypeToken.isSubtypeOf(byte[].class)) {
+                        asyncResult = response.bodyAsByteArrayAsync();
+                    } else {
+                        final Single<String> asyncResponseBodyString = response.bodyAsStringAsync();
+                        asyncResult = asyncResponseBodyString.flatMap(new Func1<String, Single<Object>>() {
+                            @Override
+                            public Single<Object> call(String responseBodyString) {
+                                try {
+                                    return Single.just(serializer.deserialize(responseBodyString, singleReturnType));
+                                } catch (Throwable e) {
+                                    return Single.error(e);
+                                }
+                            }
+                        });
+                    }
+                    return asyncResult;
+                }
+            });
         }
         else {
-            final HttpResponse response = httpClient.sendRequest(request);
-            result = responseHandler.handleSyncResponse(response, methodParser, methodParser.returnType(), serializer);
+            throw new InvalidReturnTypeException("RestProxy does not support swagger interface methods (such as " + methodParser.fullyQualifiedMethodName() + "()) with a return type of " + returnType.toString());
         }
 
         return result;
@@ -190,7 +231,6 @@ public final class RestProxy implements InvocationHandler {
      * Create a proxy implementation of the provided Swagger interface.
      * @param swaggerInterface The Swagger interface to provide a proxy implementation for.
      * @param baseURL The base URL for the service.
-     *                Passing null causes the value of the @Host annotation to be used.
      * @param httpClient The internal HTTP client that will be used to make REST calls.
      * @param serializer The serializer that will be used to convert POJOs to and from request and
      *                   response bodies.
@@ -199,57 +239,8 @@ public final class RestProxy implements InvocationHandler {
      */
     @SuppressWarnings("unchecked")
     public static <A> A create(Class<A> swaggerInterface, String baseURL, HttpClient httpClient, SerializerAdapter<?> serializer) {
-        return create(swaggerInterface, baseURL, httpClient, serializer, DEFAULT_RESPONSE_HANDLER);
-    }
-
-    /**
-     * Create a proxy implementation of the provided Swagger interface.
-     * @param swaggerInterface The Swagger interface to provide a proxy implementation for.
-     * @param baseURL The base URL for the service.
-     * @param httpClient The internal HTTP client that will be used to make REST calls.
-     * @param serializer The serializer that will be used to convert POJOs to and from request and
-     *                   response bodies.
-     * @param responseHandler The object that will be used to handle responses to HTTP requests.
-     * @param <A> The type of the Swagger interface.
-     * @return A proxy implementation of the provided Swagger interface.
-     */
-    @SuppressWarnings("unchecked")
-    public static <A> A create(Class<A> swaggerInterface, String baseURL, HttpClient httpClient, SerializerAdapter<?> serializer, ResponseHandler responseHandler) {
         final SwaggerInterfaceParser interfaceParser = new SwaggerInterfaceParser(swaggerInterface, baseURL);
-        final RestProxy restProxy = new RestProxy(httpClient, serializer, interfaceParser, responseHandler);
+        final RestProxy restProxy = new RestProxy(httpClient, serializer, interfaceParser);
         return (A) Proxy.newProxyInstance(swaggerInterface.getClassLoader(), new Class[]{swaggerInterface}, restProxy);
-    }
-
-    /**
-     * The handler that determines how to deal with an incoming HTTP response from this RestProxy.
-     */
-    public interface ResponseHandler {
-        /**
-         * Convert the provided synchronous HttpResponse object into the appropriate return value.
-         * @param response The HttpResponse to handle.
-         * @param methodParser The SwaggerMethodParser that was used to send the HttpRequest that
-         *                     created the HttpResponse passed to this method.
-         * @param returnType The type of the return value.
-         * @param serializer The serializer that can be used to convert a String to the Swagger
-         *                   method's return type.
-         * @throws IOException If the response's return status code is not recognized and the
-         * response body cannot be converted to the expected error type.
-         * @throws RestException If the response's return status code is not recognized and the
-         * response body can be converted to the expected error type.
-         * @return The return value.
-         */
-        Object handleSyncResponse(HttpResponse response, SwaggerMethodParser methodParser, Type returnType, SerializerAdapter<?> serializer) throws IOException, RestException;
-
-        /**
-         * Convert the provided asynchronous HttpResponse object into the appropriate asynchronous
-         * return value.
-         * @param response The asynchronous HttpResponse to handle.
-         * @param methodParser The SwaggerMethodParser that was used to send the HttpRequest that
-         *                     created the HttpResponse passed to this method.
-         * @param serializer The serializer that can be used to convert a String to the Swagger
-         *                   method's return type.
-         * @return The asynchronous return value.
-         */
-        Object handleAsyncResponse(Single<HttpResponse> response, SwaggerMethodParser methodParser, SerializerAdapter<?> serializer);
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerInterfaceParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerInterfaceParser.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * This class is responsible for creating individual Swagger interface method parsers from a Swagger
  * interface.
  */
-class SwaggerInterfaceParser {
+public class SwaggerInterfaceParser {
     private final Class<?> swaggerInterface;
     private final String host;
     private final Map<Method, SwaggerMethodParser> methodParsers = new HashMap<>();
@@ -25,8 +25,9 @@ class SwaggerInterfaceParser {
      * Create a new SwaggerInterfaceParser object with the provided fully qualified interface
      * name.
      * @param swaggerInterface The interface that will be parsed.
+     * @param host The host of URLs that this Swagger interface targets.
      */
-    SwaggerInterfaceParser(Class<?> swaggerInterface, String host) {
+    public SwaggerInterfaceParser(Class<?> swaggerInterface, String host) {
         this.swaggerInterface = swaggerInterface;
 
         final Host hostAnnotation = swaggerInterface.getAnnotation(Host.class);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -8,6 +8,7 @@ package com.microsoft.rest.v2;
 
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
+import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.RestException;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
@@ -25,6 +26,9 @@ import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.http.HttpHeader;
 import com.microsoft.rest.v2.http.HttpHeaders;
+import rx.Completable;
+import rx.Observable;
+import rx.Single;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -312,6 +316,15 @@ public class SwaggerMethodParser {
      */
     public Type returnType() {
         return returnType;
+    }
+
+    /**
+     * Get whether or not this parser's swagger method is asynchronous.
+     * @return Whether or not this parser's swagger method is asynchronous.
+     */
+    public boolean isAsync() {
+        final TypeToken returnTypeToken = TypeToken.of(returnType);
+        return returnTypeToken.isSubtypeOf(Completable.class) || returnTypeToken.isSubtypeOf(Single.class) || returnTypeToken.isSubtypeOf(Observable.class);
     }
 
     /**


### PR DESCRIPTION
Originally I liked the idea of having the ResponseHandler interface that RestProxy and AzureProxy would use, but the more I saw it, the less I liked it. This pull request removes that idea in favor of just having AzureProxy inherit from RestProxy. This simplifies many of the helper functions in RestProxy and AzureProxy (no need to pass arguments when they are members of a parent type).