### PR TITLE
Support byte[] body params

### DIFF
--- a/azure-client-runtime/src/test/java/com/microsoft/azure/ValueTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/ValueTests.java
@@ -1,6 +1,5 @@
 package com.microsoft.azure;
 
-import com.microsoft.azure.Value;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/client-runtime/src/main/java/com/microsoft/rest/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/RestProxy.java
@@ -131,9 +131,17 @@ public class RestProxy implements InvocationHandler {
             request.withHeader(header.name(), header.value());
         }
 
+        String mimeType = request.headers().value("Content-Type");
         final Object bodyContentObject = methodParser.body(args);
-        if (bodyContentObject != null) {
-            final String mimeType = "application/json";
+        if (bodyContentObject instanceof byte[]) {
+            if (mimeType == null) {
+                mimeType = "application/octet-stream";
+            }
+            request.withBody((byte[]) bodyContentObject, mimeType);
+        } else if (bodyContentObject != null) {
+            if (mimeType == null) {
+                mimeType = "application/json";
+            }
             final String bodyContentString = serializer.serialize(bodyContentObject);
             request.withBody(bodyContentString, mimeType);
         }

--- a/client-runtime/src/main/java/com/microsoft/rest/http/HttpRequest.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/HttpRequest.java
@@ -103,7 +103,8 @@ public class HttpRequest {
     public HttpRequest withBody(HttpRequestBody body, String mimeType) {
         this.body = body;
         this.mimeType = mimeType;
-        return withHeader("Content-Length", String.valueOf(body.contentLength()));
+        headers.set("Content-Length", String.valueOf(body.contentLength()));
+        return this;
     }
 
     /**

--- a/client-runtime/src/main/java/com/microsoft/rest/http/RxNettyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/RxNettyResponse.java
@@ -49,7 +49,7 @@ class RxNettyResponse extends HttpResponse {
 
     private Single<ByteBuf> collectContent(boolean pooled) {
         // Reading entire response into memory-- not sure if this is OK
-        int contentLength = (int) rxnRes.getContentLength();
+        int contentLength = (int) rxnRes.getContentLength(0);
         final ByteBuf collector;
         if (pooled) {
             collector = PooledByteBufAllocator.DEFAULT.heapBuffer(contentLength);

--- a/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
@@ -613,6 +613,45 @@ public abstract class RestProxyTests {
         }
     }
 
+    @Host("https://httpbin.org")
+    private interface Service16 {
+        @PUT("put")
+        @ExpectedResponses({200})
+        HttpBinJSON putByteArray(@BodyParam byte[] bytes);
+
+        @PUT("put")
+        @ExpectedResponses({200})
+        Single<HttpBinJSON> putByteArrayAsync(@BodyParam byte[] bytes);
+    }
+
+    @Test
+    public void service16Put() throws Exception {
+        final Service16 service16 = createService(Service16.class);
+        final byte[] expectedBytes = new byte[] { 1, 2, 3, 4 };
+        final HttpBinJSON httpBinJSON = service16.putByteArray(expectedBytes);
+
+        // httpbin sends the data back as a string like "\u0001\u0002\u0003\u0004"
+        assertTrue(httpBinJSON.data instanceof String);
+
+        final String base64String = (String) httpBinJSON.data;
+        final byte[] actualBytes = base64String.getBytes();
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+
+    @Test
+    public void service16PutAsync() throws Exception {
+        final Service16 service16 = createService(Service16.class);
+        final byte[] expectedBytes = new byte[] { 1, 2, 3, 4 };
+        final HttpBinJSON httpBinJSON = service16.putByteArrayAsync(expectedBytes)
+                .toBlocking()
+                .value();
+        assertTrue(httpBinJSON.data instanceof String);
+
+        final String base64String = (String) httpBinJSON.data;
+        final byte[] actualBytes = base64String.getBytes();
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+
     // Helpers
     private <T> T createService(Class<T> serviceClass) {
         final HttpClient httpClient = createHttpClient();


### PR DESCRIPTION
This simply makes it so when a byte[] is passed as a `@BodyParam`, RestProxy uses it as the request body. There are also some small changes that prevent setting multiple Content-Length header values, respect the Content-Type set in `@Headers`, and provide robustness when a server neglects to pass a Content-Length header on a response.