### PR TITLE
Add tests for multiple @HostParam attributes

### DIFF
--- a/azure-client-runtime/src/test/java/com/microsoft/azure/AzureTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/AzureTests.java
@@ -16,7 +16,7 @@ public class AzureTests {
     @AzureHost("{vaultBaseUrl}")
     public interface HttpBinService {
         @GET("secrets/{secretName}")
-        String getSecret(@HostParam String vaultBaseUrl, @PathParam("secretName") String secretName);
+        String getSecret(@HostParam("vaultBaseUrl") String vaultBaseUrl, @PathParam("secretName") String secretName);
     }
 
 // @AzureHost not yet supported.

--- a/client-runtime/src/main/java/com/microsoft/rest/annotations/HostParam.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/annotations/HostParam.java
@@ -46,7 +46,7 @@ public @interface HostParam {
      * @return The name of the variable in the endpoint uri template which will be replaced with the
      * value of the parameter annotated with this annotation.
      */
-    String value() default "";
+    String value();
     /**
      * A value true for this argument indicates that value of {@link HostParam#value()} is already
      * encoded hence engine should not encode it, by default value will be encoded.

--- a/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
@@ -652,6 +652,33 @@ public abstract class RestProxyTests {
         assertArrayEquals(expectedBytes, actualBytes);
     }
 
+    @Host("http://{hostPart1}{hostPart2}.org")
+    private interface Service17 {
+        @GET("get")
+        @ExpectedResponses({200})
+        HttpBinJSON get(@HostParam("hostPart1") String hostPart1, @HostParam("hostPart2") String hostPart2);
+
+        @GET("get")
+        @ExpectedResponses({200})
+        Single<HttpBinJSON> getAsync(@HostParam("hostPart1") String hostPart1, @HostParam("hostPart2") String hostPart2);
+    }
+
+    @Test
+    public void SyncRequestWithMultipleHostParams() {
+        final Service17 service17 = createService(Service17.class);
+        final HttpBinJSON result = service17.get("http", "bin");
+        assertNotNull(result);
+        assertEquals("http://httpbin.org/get", result.url);
+    }
+
+    @Test
+    public void AsyncRequestWithMultipleHostParams() {
+        final Service17 service17 = createService(Service17.class);
+        final HttpBinJSON result = service17.getAsync("http", "bin").toBlocking().value();
+        assertNotNull(result);
+        assertEquals("http://httpbin.org/get", result.url);
+    }
+
     // Helpers
     private <T> T createService(Class<T> serviceClass) {
         final HttpClient httpClient = createHttpClient();


### PR DESCRIPTION
Adds a few simple tests for a service with multiple host parameters. This change is mainly in support of code generator work. I removed the default argument from `@HostParam` because it seems necessary to specify which variable in the raw host is being referenced.