### PR TITLE
Throw for null body param

### DIFF
--- a/azure-client-runtime/src/test/java/com/microsoft/azure/AzureProxyToRestProxyTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/AzureProxyToRestProxyTests.java
@@ -445,19 +445,19 @@ public abstract class AzureProxyToRestProxyTests {
 
     @Host("http://httpbin.org")
     private interface Service10 {
-        @HEAD("get")
+        @HEAD("anything")
         @ExpectedResponses({200})
         HttpBinJSON head();
 
-        @HEAD("get")
+        @HEAD("anything")
         @ExpectedResponses({200})
         void voidHead();
 
-        @HEAD("get")
+        @HEAD("anything")
         @ExpectedResponses({200})
         Single<HttpBinJSON> headAsync();
 
-        @HEAD("get")
+        @HEAD("anything")
         @ExpectedResponses({200})
         Completable completableHeadAsync();
     }

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/http/MockAzureHttpClient.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/http/MockAzureHttpClient.java
@@ -65,12 +65,16 @@ public class MockAzureHttpClient extends HttpClient {
             final String requestPathLower = requestPath.toLowerCase();
             if (requestHost.equalsIgnoreCase("httpbin.org")) {
                 if (requestPathLower.equals("/anything") || requestPathLower.startsWith("/anything/")) {
-                    final HttpBinJSON json = new HttpBinJSON();
-                    json.url = request.url()
-                            // This is just to mimic the behavior we've seen with httpbin.org.
-                            .replace("%20", " ");
-                    json.headers = toMap(request.headers());
-                    response = new MockAzureHttpResponse(200, json);
+                    if ("HEAD".equals(request.httpMethod())) {
+                        response = new MockAzureHttpResponse(200, "");
+                    } else {
+                        final HttpBinJSON json = new HttpBinJSON();
+                        json.url = request.url()
+                                // This is just to mimic the behavior we've seen with httpbin.org.
+                                .replace("%20", " ");
+                        json.headers = toMap(request.headers());
+                        response = new MockAzureHttpResponse(200, json);
+                    }
                 }
                 else if (requestPathLower.startsWith("/bytes/")) {
                     final String byteCountString = requestPath.substring("/bytes/".length());

--- a/client-runtime/src/main/java/com/microsoft/rest/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/RestProxy.java
@@ -235,8 +235,12 @@ public class RestProxy implements InvocationHandler {
     private Single<?> toProxyReturnValue(HttpResponse response, SwaggerMethodParser methodParser, final Type entityType) {
         final TypeToken entityTypeToken = TypeToken.of(entityType);
         final Single<?> asyncResult;
-        if (entityTypeToken.isSubtypeOf(void.class) || methodParser.httpMethod().equalsIgnoreCase("HEAD")) {
+        if (entityTypeToken.isSubtypeOf(void.class) || entityTypeToken.isSubtypeOf(Void.class)) {
             asyncResult = Single.just(null);
+        } else if (methodParser.httpMethod().equalsIgnoreCase("HEAD")
+                && (entityTypeToken.isSubtypeOf(boolean.class) || entityTypeToken.isSubtypeOf(Boolean.class))) {
+            boolean isSuccess = response.statusCode() / 100 == 2;
+            asyncResult = Single.just(isSuccess);
         } else if (entityTypeToken.isSubtypeOf(InputStream.class)) {
             asyncResult = response.bodyAsInputStreamAsync();
         } else if (entityTypeToken.isSubtypeOf(byte[].class)) {

--- a/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
@@ -386,9 +386,8 @@ public class SwaggerMethodParser {
                 final int parameterIndex = substitution.methodParameterIndex();
                 if (0 <= parameterIndex && parameterIndex < methodArguments.length) {
                     final Object methodArgument = methodArguments[substitution.methodParameterIndex()];
-
-                    String parameterValue = methodArgument == null ? "" : methodArgument.toString();
-                    if (parameterValue != null && !parameterValue.isEmpty()) {
+                    String parameterValue = methodArgument == null ? null : methodArgument.toString();
+                    if (parameterValue != null) {
                         if (substitution.shouldEncode() && escaper != null) {
                             parameterValue = escaper.escape(parameterValue);
                         }

--- a/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
@@ -309,8 +309,12 @@ public class SwaggerMethodParser {
 
         if (bodyContentMethodParameterIndex != null
                 && swaggerMethodArguments != null
-                && 0 <= bodyContentMethodParameterIndex && bodyContentMethodParameterIndex < swaggerMethodArguments.length) {
+                && 0 <= bodyContentMethodParameterIndex
+                && bodyContentMethodParameterIndex < swaggerMethodArguments.length) {
             result = swaggerMethodArguments[bodyContentMethodParameterIndex];
+            if (result == null) {
+                throw new IllegalArgumentException("Argument for @BodyParam parameter must be non-null.");
+            }
         }
 
         return result;

--- a/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
@@ -393,6 +393,12 @@ public abstract class RestProxyTests {
         assertEquals("I'm a post body!", (String)json.data);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void SyncPostRequestWithNullBody() {
+        final HttpBinJSON json = createService(Service8.class)
+                .post(null);
+    }
+
     @Host("http://httpbin.org")
     private interface Service9 {
         @PUT("put")

--- a/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
@@ -509,19 +509,27 @@ public abstract class RestProxyTests {
 
     @Host("http://httpbin.org")
     private interface Service10 {
-        @HEAD("get")
+        @HEAD("anything")
         @ExpectedResponses({200})
         HttpBinJSON head();
 
-        @HEAD("get")
+        @HEAD("anything")
+        @ExpectedResponses({200})
+        boolean headBoolean();
+
+        @HEAD("anything")
         @ExpectedResponses({200})
         void voidHead();
 
-        @HEAD("get")
+        @HEAD("anything")
         @ExpectedResponses({200})
         Single<HttpBinJSON> headAsync();
 
-        @HEAD("get")
+        @HEAD("anything")
+        @ExpectedResponses({200})
+        Single<Boolean> headBooleanAsync();
+
+        @HEAD("anything")
         @ExpectedResponses({200})
         Completable completableHeadAsync();
     }
@@ -531,6 +539,12 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service10.class)
                 .head();
         assertNull(json);
+    }
+
+    @Test
+    public void SyncHeadBooleanRequest() {
+        final boolean result = createService(Service10.class).headBoolean();
+        assertTrue(result);
     }
 
     @Test
@@ -545,6 +559,12 @@ public abstract class RestProxyTests {
                 .headAsync()
                 .toBlocking().value();
         assertNull(json);
+    }
+
+    @Test
+    public void AsyncHeadBooleanRequest() {
+        final boolean result = createService(Service10.class).headBooleanAsync().toBlocking().value();
+        assertTrue(result);
     }
 
     @Test

--- a/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
@@ -885,11 +885,10 @@ public abstract class RestProxyTests {
         HttpBinJSON putWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBody(@BodyParam(ContentType.APPLICATION_OCTET_STREAM) byte[] body);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithNoContentTypeAndStringBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithNoContentTypeAndStringBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -906,11 +905,10 @@ public abstract class RestProxyTests {
         assertEquals("hello", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithNoContentTypeAndByteArrayBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithNoContentTypeAndByteArrayBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -927,11 +925,10 @@ public abstract class RestProxyTests {
         assertEquals(new String(new byte[] { 0, 1, 2, 3, 4 }), result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationJsonContentTypeAndStringBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndStringBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -948,11 +945,10 @@ public abstract class RestProxyTests {
         assertEquals("\"soups and stuff\"", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationJsonContentTypeAndByteArrayBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndByteArrayBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -969,11 +965,10 @@ public abstract class RestProxyTests {
         assertEquals("\"AAECAwQ=\"", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationJsonContentTypeAndCharsetAndStringBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndCharsetAndStringBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -990,11 +985,10 @@ public abstract class RestProxyTests {
         assertEquals("\"soups and stuff\"", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationOctetStreamContentTypeAndStringBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationOctetStreamContentTypeAndStringBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -1011,11 +1005,10 @@ public abstract class RestProxyTests {
         assertEquals("penguins", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationOctetStreamContentTypeAndByteArrayBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationOctetStreamContentTypeAndByteArrayBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -1032,11 +1025,10 @@ public abstract class RestProxyTests {
         assertEquals(new String(new byte[] { 0, 1, 2, 3, 4 }), result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationJsonContentTypeAndStringBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndStringBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -1053,11 +1045,10 @@ public abstract class RestProxyTests {
         assertEquals("\"soups and stuff\"", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -1074,11 +1065,10 @@ public abstract class RestProxyTests {
         assertEquals("\"soups and stuff\"", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationJsonContentTypeAndByteArrayBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndByteArrayBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -1095,11 +1085,10 @@ public abstract class RestProxyTests {
         assertEquals("\"AAECAwQ=\"", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationOctetStreamContentTypeAndStringBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationOctetStreamContentTypeAndStringBody(null);
-        assertEquals("", result.data);
     }
 
     @Test
@@ -1116,11 +1105,10 @@ public abstract class RestProxyTests {
         assertEquals("penguins", result.data);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBody(null);
-        assertEquals("", result.data);
     }
 
     @Test

--- a/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RestProxyTests.java
@@ -396,8 +396,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void SyncPostRequestWithNullBody() {
-        final HttpBinJSON json = createService(Service8.class)
-                .post(null);
+        createService(Service8.class).post(null);
     }
 
     @Host("http://httpbin.org")
@@ -887,7 +886,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithNoContentTypeAndStringBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithNoContentTypeAndStringBody(null);
     }
 
@@ -907,7 +906,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithNoContentTypeAndByteArrayBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithNoContentTypeAndByteArrayBody(null);
     }
 
@@ -927,7 +926,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationJsonContentTypeAndStringBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndStringBody(null);
     }
 
@@ -947,7 +946,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationJsonContentTypeAndByteArrayBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndByteArrayBody(null);
     }
 
@@ -967,7 +966,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationJsonContentTypeAndCharsetAndStringBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndCharsetAndStringBody(null);
     }
 
@@ -987,7 +986,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithHeaderApplicationOctetStreamContentTypeAndStringBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithHeaderApplicationOctetStreamContentTypeAndStringBody(null);
     }
 
@@ -1027,7 +1026,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationJsonContentTypeAndStringBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndStringBody(null);
     }
 
@@ -1047,7 +1046,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBody(null);
     }
 
@@ -1067,7 +1066,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationJsonContentTypeAndByteArrayBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndByteArrayBody(null);
     }
 
@@ -1087,7 +1086,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationOctetStreamContentTypeAndStringBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithBodyParamApplicationOctetStreamContentTypeAndStringBody(null);
     }
 
@@ -1107,7 +1106,7 @@ public abstract class RestProxyTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void service19PutWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBodyWithNullBody() {
-        final HttpBinJSON result = createService(Service19.class)
+        createService(Service19.class)
                 .putWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBody(null);
     }
 

--- a/client-runtime/src/test/java/com/microsoft/rest/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/http/MockHttpClient.java
@@ -40,12 +40,16 @@ public class MockHttpClient extends HttpClient {
                 final String requestPath = requestUrl.getPath();
                 final String requestPathLower = requestPath.toLowerCase();
                 if (requestPathLower.equals("/anything") || requestPathLower.startsWith("/anything/")) {
-                    final HttpBinJSON json = new HttpBinJSON();
-                    json.url = request.url()
-                            // This is just to mimic the behavior we've seen with httpbin.org.
-                            .replace("%20", " ");
-                    json.headers = toMap(request.headers());
-                    response = new MockHttpResponse(200, json);
+                    if ("HEAD".equals(request.httpMethod())) {
+                        response = new MockHttpResponse(200, "");
+                    } else {
+                        final HttpBinJSON json = new HttpBinJSON();
+                        json.url = request.url()
+                                // This is just to mimic the behavior we've seen with httpbin.org.
+                                .replace("%20", " ");
+                        json.headers = toMap(request.headers());
+                        response = new MockHttpResponse(200, json);
+                    }
                 }
                 else if (requestPathLower.startsWith("/bytes/")) {
                     final String byteCountString = requestPath.substring("/bytes/".length());


### PR DESCRIPTION
This ensures that the runtime throws IllegalArgumentException when null is passed as the argument for a `@BodyParam`. It also ensure that when null is provided for a query parameter, the entire name/value pair is omitted, and if the empty string is passed, it's rendered like a non-empty string would be, like `?param=&nextparam=something`.