### PR TITLE
Paging support

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/RestProxy.java
@@ -117,10 +117,16 @@ public class RestProxy implements InvocationHandler {
      * @throws IOException Thrown if the body contents cannot be serialized.
      */
     private HttpRequest createHttpRequest(SwaggerMethodParser methodParser, Object[] args) throws IOException {
+        final String path = methodParser.path(args);
+        final boolean isAbsolute = path.startsWith("http://") || path.startsWith("https://");
+
         final UrlBuilder urlBuilder = new UrlBuilder()
-                .withScheme(methodParser.scheme(args))
-                .withHost(methodParser.host(args))
-                .withPath(methodParser.path(args));
+                .withPath(path);
+
+        if (!isAbsolute) {
+            urlBuilder.withScheme(methodParser.scheme(args))
+                    .withHost(methodParser.host(args));
+        }
 
         for (final EncodedParameter queryParameter : methodParser.encodedQueryParameters(args)) {
             urlBuilder.withQueryParameter(queryParameter.name(), queryParameter.encodedValue());

--- a/client-runtime/src/main/java/com/microsoft/rest/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/RestProxy.java
@@ -117,16 +117,10 @@ public class RestProxy implements InvocationHandler {
      * @throws IOException Thrown if the body contents cannot be serialized.
      */
     private HttpRequest createHttpRequest(SwaggerMethodParser methodParser, Object[] args) throws IOException {
-        final String path = methodParser.path(args);
-        final boolean isAbsolute = path.startsWith("http://") || path.startsWith("https://");
-
         final UrlBuilder urlBuilder = new UrlBuilder()
-                .withPath(path);
-
-        if (!isAbsolute) {
-            urlBuilder.withScheme(methodParser.scheme(args))
-                    .withHost(methodParser.host(args));
-        }
+                .withScheme(methodParser.scheme(args))
+                .withHost(methodParser.host(args))
+                .withPath(methodParser.path(args));
 
         for (final EncodedParameter queryParameter : methodParser.encodedQueryParameters(args)) {
             urlBuilder.withQueryParameter(queryParameter.name(), queryParameter.encodedValue());

--- a/client-runtime/src/main/java/com/microsoft/rest/http/UrlBuilder.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/UrlBuilder.java
@@ -87,16 +87,19 @@ public class UrlBuilder {
     public String toString() {
         final StringBuilder result = new StringBuilder();
 
-        if (scheme != null) {
-            result.append(scheme);
+        final boolean isAbsolutePath = path != null && (path.startsWith("http://") || path.startsWith("https://"));
+        if (!isAbsolutePath) {
+            if (scheme != null) {
+                result.append(scheme);
 
-            if (!scheme.endsWith("://")) {
-                result.append("://");
+                if (!scheme.endsWith("://")) {
+                    result.append("://");
+                }
             }
-        }
 
-        if (host != null) {
-            result.append(host);
+            if (host != null) {
+                result.append(host);
+            }
         }
 
         if (path != null) {

--- a/client-runtime/src/main/java/com/microsoft/rest/http/UrlBuilder.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/UrlBuilder.java
@@ -44,7 +44,21 @@ public class UrlBuilder {
      * @return This UrlBuilder so that multiple setters can be chained together.
      */
     public UrlBuilder withPath(String path) {
-        this.path = path;
+        if (path != null) {
+            String[] parts = path.split("\\?");
+            this.path = parts[0];
+            if (parts.length > 1) {
+                String[] queryPairs = parts[1].split("&");
+                for (String queryPair : queryPairs) {
+                    String[] nameAndValue = queryPair.split("=");
+                    if (nameAndValue.length != 2) {
+                        throw new IllegalArgumentException("Path contained malformed query: " + path);
+                    }
+
+                    withQueryParameter(nameAndValue[0], nameAndValue[1]);
+                }
+            }
+        }
         return this;
     }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/http/UrlBuilder.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/UrlBuilder.java
@@ -44,9 +44,6 @@ public class UrlBuilder {
      * @return This UrlBuilder so that multiple setters can be chained together.
      */
     public UrlBuilder withPath(String path) {
-        if (path != null && !path.startsWith("/")) {
-            path = "/" + path;
-        }
         this.path = path;
         return this;
     }
@@ -89,6 +86,9 @@ public class UrlBuilder {
         }
 
         if (path != null) {
+            if (result.length() != 0 && !path.startsWith("/")) {
+                result.append('/');
+            }
             result.append(path);
         }
 

--- a/client-runtime/src/test/java/com/microsoft/rest/http/UrlBuilderTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/http/UrlBuilderTests.java
@@ -163,4 +163,33 @@ public class UrlBuilderTests {
                 .withPath("index.html");
         assertEquals("http://www.example.com/index.html?A=B&C=D", builder.toString());
     }
+
+    @Test
+    public void withAbsolutePath() {
+        final UrlBuilder builder = new UrlBuilder()
+                .withScheme("http")
+                .withHost("www.example.com")
+                .withPath("http://www.othersite.com");
+        assertEquals("http://www.othersite.com", builder.toString());
+    }
+
+    @Test
+    public void withQueryInPath() {
+        final UrlBuilder builder = new UrlBuilder()
+                .withScheme("http")
+                .withHost("www.example.com")
+                .withPath("mypath?thing=stuff")
+                .withQueryParameter("otherthing", "otherstuff");
+        assertEquals("http://www.example.com/mypath?thing=stuff&otherthing=otherstuff", builder.toString());
+    }
+
+    @Test
+    public void withAbsolutePathAndQuery() {
+        final UrlBuilder builder = new UrlBuilder()
+                .withScheme("http")
+                .withHost("www.example.com")
+                .withPath("http://www.othersite.com/mypath?thing=stuff")
+                .withQueryParameter("otherthing", "otherstuff");
+        assertEquals("http://www.othersite.com/mypath?thing=stuff&otherthing=otherstuff", builder.toString());
+    }
 }


### PR DESCRIPTION
This PR adds support for paging. Cookies are used in the AutoRest tests to track "where" we are in a scenario that takes place over multiple requests, so I added cookie support in RxNettyAdapter.

I also added handling for some of the complex partial URLs that can be returned by services to indicate where the next page is located.