### PR TITLE
Miscellaneous LRO support changes

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperationPollStrategy.java
@@ -103,10 +103,13 @@ public final class AzureAsyncOperationPollStrategy extends PollStrategy {
                                         pollingSucceeded = SUCCEEDED.equalsIgnoreCase(provisioningState);
                                         clearDelayInMilliseconds();
                                     }
-                                } else if (httpPollResponse.statusCode() == 200) {
-                                    throw new CloudException("Response does not contain a valid body", httpPollResponse, null);
                                 }
-                                result = Single.just(httpPollResponse);
+
+                                if (httpPollResponse.statusCode() == 200 && operationResource == null) {
+                                    result = Single.error(new CloudException("Response does not contain a valid body", httpPollResponse, null));
+                                } else {
+                                    result = Single.just(httpPollResponse);
+                                }
                             } catch (IOException e) {
                                 result = Single.error(e);
                             }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperationPollStrategy.java
@@ -100,6 +100,8 @@ public final class AzureAsyncOperationPollStrategy extends PollStrategy {
                                         pollingSucceeded = SUCCEEDED.equalsIgnoreCase(provisioningState);
                                         clearDelayInMilliseconds();
                                     }
+                                } else if (httpPollResponse.statusCode() == 200) {
+                                    throw new CloudException("Response does not contain a valid body", httpPollResponse, null);
                                 }
                                 result = Single.just(httpPollResponse);
                             } catch (IOException e) {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperationPollStrategy.java
@@ -65,13 +65,16 @@ public final class AzureAsyncOperationPollStrategy extends PollStrategy {
 
     @Override
     public HttpRequest createPollRequest() {
-        String pollUrl = null;
+        String pollUrl;
         if (!pollingCompleted) {
             pollUrl = operationResourceUrl;
         }
         else if (pollingSucceeded) {
             pollUrl = originalResourceUrl;
+        } else {
+            throw new IllegalStateException("Polling is completed and did not succeed. Cannot create a polling request.");
         }
+
         return new HttpRequest(fullyQualifiedMethodName, "GET", pollUrl);
     }
 

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/LocationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/LocationPollStrategy.java
@@ -43,7 +43,11 @@ public final class LocationPollStrategy extends PollStrategy {
     public void updateFrom(HttpResponse httpPollResponse) throws IOException {
         final int httpStatusCode = httpPollResponse.statusCode();
         if (httpStatusCode == 202) {
-            locationUrl = httpPollResponse.headerValue(HEADER_NAME);
+            String newLocationUrl = httpPollResponse.headerValue(HEADER_NAME);
+            if (newLocationUrl != null) {
+                locationUrl = newLocationUrl;
+            }
+            
             updateDelayInMillisecondsFrom(httpPollResponse);
         }
         else {

--- a/client-runtime/src/main/java/com/microsoft/rest/RestClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/RestClient.java
@@ -7,16 +7,17 @@
 package com.microsoft.rest;
 
 import com.microsoft.rest.credentials.ServiceClientCredentials;
-import com.microsoft.rest.protocol.Environment;
-import com.microsoft.rest.protocol.SerializerAdapter;
-import com.microsoft.rest.http.ChannelHandlerConfig;
-import com.microsoft.rest.http.HttpClient;
-import com.microsoft.rest.http.RxNettyAdapter;
+import com.microsoft.rest.policy.AddCookiesPolicy;
 import com.microsoft.rest.policy.CredentialsPolicy;
 import com.microsoft.rest.policy.LoggingPolicy;
 import com.microsoft.rest.policy.RequestPolicy;
 import com.microsoft.rest.policy.RetryPolicy;
 import com.microsoft.rest.policy.UserAgentPolicy;
+import com.microsoft.rest.protocol.Environment;
+import com.microsoft.rest.protocol.SerializerAdapter;
+import com.microsoft.rest.http.ChannelHandlerConfig;
+import com.microsoft.rest.http.HttpClient;
+import com.microsoft.rest.http.RxNettyAdapter;
 import com.microsoft.rest.serializer.JacksonAdapter;
 
 import java.util.ArrayList;
@@ -52,6 +53,7 @@ public final class RestClient {
         final RxNettyAdapter.Builder httpClientBuilder = new RxNettyAdapter.Builder()
             .withRequestPolicy(new UserAgentPolicy.Factory(userAgent))
             .withRequestPolicy(new RetryPolicy.Factory())
+            .withRequestPolicy(new AddCookiesPolicy.Factory())
             .withRequestPolicy(new LoggingPolicy.Factory(logLevel));
         if (credentials != null) {
             httpClientBuilder.withRequestPolicy(new CredentialsPolicy.Factory(credentials));

--- a/client-runtime/src/main/java/com/microsoft/rest/http/BufferedHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/BufferedHttpResponse.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.http;
+
+import com.google.common.base.Charsets;
+import rx.Single;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * HTTP response which contains already-buffered body content.
+ */
+public final class BufferedHttpResponse extends HttpResponse {
+    private final int statusCode;
+    private final HttpHeaders headers;
+    private final String body;
+
+    /**
+     * Creates a buffered HTTP response.
+     * @param statusCode The HTTP response status code.
+     * @param headers The HTTP response headers.
+     * @param body The HTTP response body as a string.
+     */
+    public BufferedHttpResponse(int statusCode, HttpHeaders headers, String body) {
+        this.statusCode = statusCode;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    @Override
+    public int statusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String headerValue(String headerName) {
+        return headers.value(headerName);
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return headers;
+    }
+
+    @Override
+    public Single<? extends InputStream> bodyAsInputStreamAsync() {
+        return Single.just(new ByteArrayInputStream(body.getBytes(Charsets.UTF_8)));
+    }
+
+    @Override
+    public Single<byte[]> bodyAsByteArrayAsync() {
+        return Single.just(body.getBytes(Charsets.UTF_8));
+    }
+
+    @Override
+    public Single<String> bodyAsStringAsync() {
+        return Single.just(body);
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/http/RxNettyAdapter.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/RxNettyAdapter.java
@@ -18,7 +18,6 @@ import io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import rx.Observable;
 import rx.Observer;
 import rx.Single;
-import rx.exceptions.Exceptions;
 import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.observables.SyncOnSubscribe;
@@ -27,8 +26,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.CookieHandler;
-import java.net.CookieManager;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -47,7 +44,6 @@ import java.util.Set;
  */
 public class RxNettyAdapter extends HttpClient {
     private final List<ChannelHandlerConfig> handlerConfigs;
-    private final CookieHandler cookies = new CookieManager();
 
     /**
      * Creates RxNettyClient.
@@ -78,11 +74,8 @@ public class RxNettyAdapter extends HttpClient {
         try {
             final URI uri = new URI(request.url());
 
-            // Unfortunately necessary due to conflicting APIs
-            Map<String, List<String>> cookieHeaders = new HashMap<>();
             Map<String, Set<Object>> rxnHeaders = new HashMap<>();
             for (HttpHeader header : request.headers()) {
-                cookieHeaders.put(header.name(), Arrays.asList(request.headers().values(header.name())));
                 rxnHeaders.put(header.name(), Collections.<Object>singleton(header.value()));
             }
 
@@ -111,20 +104,9 @@ public class RxNettyAdapter extends HttpClient {
                 rxnClient = rxnClient.secure(getSSLEngine(uri.getHost()));
             }
 
-            Map<String, List<String>> requestCookies = cookies.get(uri, cookieHeaders);
-            Map<String, Iterable<Object>> rxnCookies = new HashMap<>();
-            for (Map.Entry<String, List<String>> entry : requestCookies.entrySet()) {
-                if (entry.getValue().size() != 0) {
-                    List<Object> cookieValues = new ArrayList<>();
-                    cookieValues.addAll(entry.getValue());
-                    rxnCookies.put(entry.getKey(), cookieValues);
-                }
-            }
-
             final HttpClientRequest<ByteBuf, ByteBuf> rxnReq = rxnClient
                     .createRequest(HttpMethod.valueOf(request.httpMethod()), uri.toASCIIString())
-                    .addHeaders(rxnHeaders)
-                    .addHeaders(rxnCookies);
+                    .addHeaders(rxnHeaders);
 
             Observable<HttpClientResponse<ByteBuf>> obsResponse = rxnReq;
 
@@ -140,16 +122,6 @@ public class RxNettyAdapter extends HttpClient {
                     .map(new Func1<HttpClientResponse<ByteBuf>, HttpResponse>() {
                         @Override
                         public HttpResponse call(HttpClientResponse<ByteBuf> rxnRes) {
-                            Map<String, List<String>> responseHeaders = new HashMap<>();
-                            for (String headerName : rxnRes.getHeaderNames()) {
-                                responseHeaders.put(headerName, rxnRes.getAllHeaderValues(headerName));
-                            }
-                            try {
-                                cookies.put(uri, responseHeaders);
-                            } catch (IOException e) {
-                                throw Exceptions.propagate(e);
-                            }
-
                             return new RxNettyResponse(rxnRes);
                         }
                     })

--- a/client-runtime/src/main/java/com/microsoft/rest/policy/AddCookiesPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/policy/AddCookiesPolicy.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.policy;
+
+import com.microsoft.rest.http.HttpHeader;
+import com.microsoft.rest.http.HttpRequest;
+import com.microsoft.rest.http.HttpResponse;
+import rx.Single;
+import rx.exceptions.Exceptions;
+import rx.functions.Func1;
+
+import java.io.IOException;
+import java.net.CookieHandler;
+import java.net.CookieManager;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A RequestPolicy which stores cookies based on the response Set-Cookie header and adds cookies to requests.
+ */
+public final class AddCookiesPolicy implements RequestPolicy {
+    private final CookieHandler cookies;
+    private final RequestPolicy next;
+
+    private AddCookiesPolicy(CookieHandler cookies, RequestPolicy next) {
+        this.cookies = cookies;
+        this.next = next;
+    }
+
+    @Override
+    public Single<HttpResponse> sendAsync(HttpRequest request) {
+        try {
+            final URI uri = new URI(request.url());
+
+            Map<String, List<String>> cookieHeaders = new HashMap<>();
+            for (HttpHeader header : request.headers()) {
+                cookieHeaders.put(header.name(), Arrays.asList(request.headers().values(header.name())));
+            }
+
+            Map<String, List<String>> requestCookies = cookies.get(uri, cookieHeaders);
+            for (Map.Entry<String, List<String>> entry : requestCookies.entrySet()) {
+                for (String headerValue : entry.getValue()) {
+                    request.headers().add(entry.getKey(), headerValue);
+                }
+            }
+
+            return next.sendAsync(request).map(new Func1<HttpResponse, HttpResponse>() {
+                @Override
+                public HttpResponse call(HttpResponse httpResponse) {
+                    Map<String, List<String>> responseHeaders = new HashMap<>();
+                    for (HttpHeader header : httpResponse.headers()) {
+                        responseHeaders.put(header.name(), Arrays.asList(header.values()));
+                    }
+
+                    try {
+                        cookies.put(uri, responseHeaders);
+                    } catch (IOException e) {
+                        throw Exceptions.propagate(e);
+                    }
+
+                    return httpResponse;
+                }
+            });
+        } catch (URISyntaxException | IOException e) {
+            return Single.error(e);
+        }
+    }
+
+    /**
+     * Factory for creating AddCookiesPolicy.
+     */
+    public static final class Factory implements RequestPolicy.Factory {
+        private final CookieHandler cookies = new CookieManager();
+
+        @Override
+        public RequestPolicy create(RequestPolicy next) {
+            return new AddCookiesPolicy(cookies, next);
+        }
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/policy/AddCookiesPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/policy/AddCookiesPolicy.java
@@ -19,6 +19,7 @@ import java.net.CookieManager;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public final class AddCookiesPolicy implements RequestPolicy {
                 public HttpResponse call(HttpResponse httpResponse) {
                     Map<String, List<String>> responseHeaders = new HashMap<>();
                     for (HttpHeader header : httpResponse.headers()) {
-                        responseHeaders.put(header.name(), Arrays.asList(header.values()));
+                        responseHeaders.put(header.name(), Collections.singletonList(header.value()));
                     }
 
                     try {

--- a/client-runtime/src/main/java/com/microsoft/rest/policy/LoggingPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/policy/LoggingPolicy.java
@@ -8,6 +8,7 @@ package com.microsoft.rest.policy;
 
 import com.google.common.io.CharStreams;
 import com.microsoft.rest.LogLevel;
+import com.microsoft.rest.http.BufferedHttpResponse;
 import com.microsoft.rest.http.HttpHeader;
 import com.microsoft.rest.http.HttpRequest;
 import com.microsoft.rest.http.HttpResponse;
@@ -16,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Single;
 import rx.functions.Action1;
+import rx.functions.Func1;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -101,21 +103,21 @@ public final class LoggingPolicy implements RequestPolicy {
         }
 
         final long startNs = System.nanoTime();
-        return next.sendAsync(request).doOnError(new Action1<Throwable>() {
+        return next.sendAsync(request).flatMap(new Func1<HttpResponse, Single<HttpResponse>>() {
+            @Override
+            public Single<HttpResponse> call(HttpResponse httpResponse) {
+                long tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
+                return logResponse(logger, httpResponse, request.url(), tookMs);
+            }
+        }).doOnError(new Action1<Throwable>() {
             @Override
             public void call(Throwable throwable) {
                 log(logger, "<-- HTTP FAILED: " + throwable);
             }
-        }).doOnSuccess(new Action1<HttpResponse>() {
-            @Override
-            public void call(HttpResponse httpResponse) {
-                long tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
-                logResponse(logger, httpResponse, request.url(), tookMs);
-            }
         });
     }
 
-    private void logResponse(Logger logger, HttpResponse response, String url, long tookMs) {
+    private Single<HttpResponse> logResponse(final Logger logger, final HttpResponse response, String url, long tookMs) {
         String bodySize;
         try {
             long contentLength = Long.parseLong(response.headerValue("Content-Length"));
@@ -136,63 +138,24 @@ public final class LoggingPolicy implements RequestPolicy {
         }
 
         if (logLevel.shouldLogBody()) {
-            logger.warn("Logging HTTP response bodies not fully implemented.");
             String contentTypeHeader = response.headerValue("Content-Type");
-            if ("application/json".equals(contentTypeHeader)) {
-                try {
-                    log(logger, response.bodyAsString());
-                } catch (IOException e) {
-                    log(logger, "Error occurred when logging body: " + e.getMessage());
-                }
+            if ((contentTypeHeader == null || "application/json".equals(contentTypeHeader))) {
+                return response.bodyAsStringAsync().map(new Func1<String, HttpResponse>() {
+                    @Override
+                    public HttpResponse call(String s) {
+                        log(logger, s);
+                        log(logger, "<-- END HTTP");
+                        return new BufferedHttpResponse(response.statusCode(), response.headers(), s);
+                    }
+                });
             } else {
                 log(logger, "Not logging response body because the Content-Type is " + contentTypeHeader);
+                log(logger, "<-- END HTTP");
             }
+        } else {
             log(logger, "<-- END HTTP");
         }
 
-//        if (logLevel == LogLevel.BODY || logLevel == LogLevel.BODY_AND_HEADERS) {
-//            if (response.body() != null) {
-//                BufferedSource source = responseBody.source();
-//                source.request(Long.MAX_VALUE); // Buffer the entire body.
-//                Buffer buffer = source.buffer();
-//
-//                Charset charset = Charset.forName("UTF8");
-//                MediaType contentType = responseBody.contentType();
-//                if (contentType != null) {
-//                    try {
-//                        charset = contentType.charset(charset);
-//                    } catch (UnsupportedCharsetException e) {
-//                        log(logger, "Couldn't decode the response body; charset is likely malformed.");
-//                        log(logger, "<-- END HTTP");
-//                        return response;
-//                    }
-//                }
-//
-//                boolean gzipped = response.header("content-encoding") != null && StringUtils.containsIgnoreCase(response.header("content-encoding"), "gzip");
-//                if (!isPlaintext(buffer) && !gzipped) {
-//                    log(logger, "<-- END HTTP (binary " + buffer.size() + "-byte body omitted)");
-//                    return response;
-//                }
-//
-//                if (contentLength != 0) {
-//                    String content;
-//                    if (gzipped) {
-//                        content = CharStreams.toString(new InputStreamReader(new GZIPInputStream(buffer.clone().inputStream())));
-//                    } else {
-//                        content = buffer.clone().readString(charset);
-//                    }
-//                    if (logLevel.isPrettyJson()) {
-//                        try {
-//                            content = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(MAPPER.readValue(content, JsonNode.class));
-//                        } catch (Exception e) {
-//                            // swallow, keep original content
-//                        }
-//                    }
-//                    log(logger, String.format("%s-byte body:\n%s", buffer.size(), content));
-//                }
-//                log(logger, "<-- END HTTP");
-//            }
-//        }
-//        return response;
+        return Single.just(response);
     }
 }


### PR DESCRIPTION
1. Migrates cookie management to a CookiePolicy
2. Adds a few extra throw statements to LRO handlers
3. Adds BufferedHttpResponse which is created when a LoggingPolicy needs to read an HttpResponse body into memory.
  - I played around with a few alternatives to this and this wound up making sense to me due to the complexity of thread-safe caching of the RxNetty HTTP response that occurs whenever someone first reads it.
  - I'm still concerned actually that this will enable some case where a program will only work if HTTP response bodies are being logged, because BufferedHttpResponse has "replayable" response bodies. May need to revisit and decide to actually cache the HTTP response in RxNettyResponse. Maybe the answer is to read the body eagerly in RxNettyResponse.