### PR TITLE
Make RestProxy sync scenarios go through async scenarios (one code path)

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureAsyncOperationPollStrategy.java
@@ -68,11 +68,6 @@ public final class AzureAsyncOperationPollStrategy extends PollStrategy {
     }
 
     @Override
-    public void updateFrom(HttpResponse httpPollResponse) throws IOException {
-        updateFromAsync(httpPollResponse).toBlocking().value();
-    }
-
-    @Override
     public Single<HttpResponse> updateFromAsync(final HttpResponse httpPollResponse) {
         updateDelayInMillisecondsFrom(httpPollResponse);
 

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/LocationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/LocationPollStrategy.java
@@ -10,8 +10,6 @@ import com.microsoft.rest.http.HttpRequest;
 import com.microsoft.rest.http.HttpResponse;
 import rx.Single;
 
-import java.io.IOException;
-
 /**
  * A PollStrategy type that uses the Location header value to check the status of a long running
  * operation.
@@ -40,7 +38,7 @@ public final class LocationPollStrategy extends PollStrategy {
     }
 
     @Override
-    public void updateFrom(HttpResponse httpPollResponse) throws IOException {
+    public Single<HttpResponse> updateFromAsync(HttpResponse httpPollResponse) {
         final int httpStatusCode = httpPollResponse.statusCode();
         if (httpStatusCode == 202) {
             locationUrl = httpPollResponse.headerValue(HEADER_NAME);
@@ -49,18 +47,7 @@ public final class LocationPollStrategy extends PollStrategy {
         else {
             done = true;
         }
-    }
-
-    @Override
-    public Single<HttpResponse> updateFromAsync(HttpResponse httpPollResponse) {
-        Single<HttpResponse> result;
-        try {
-            updateFrom(httpPollResponse);
-            result = Single.just(httpPollResponse);
-        } catch (IOException e) {
-            result = Single.error(e);
-        }
-        return result;
+        return Single.just(httpPollResponse);
     }
 
     @Override

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PollStrategy.java
@@ -10,7 +10,6 @@ import com.microsoft.rest.http.HttpRequest;
 import com.microsoft.rest.http.HttpResponse;
 import rx.Single;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -23,14 +22,6 @@ abstract class PollStrategy {
 
     PollStrategy(long delayInMilliseconds) {
         this.delayInMilliseconds = delayInMilliseconds;
-    }
-
-    /**
-     * Get the number of milliseconds to delay before sending the next poll request.
-     * @return The number of milliseconds to delay.
-     */
-    final long delayInMilliseconds() {
-        return delayInMilliseconds;
     }
 
     /**
@@ -52,17 +43,6 @@ abstract class PollStrategy {
             }
             catch (NumberFormatException ignored) {
             }
-        }
-    }
-
-    /**
-     * If this PollStrategy has a retryAfterSeconds value, delay (and block) the current thread for
-     * the number of seconds that are in the retryAfterSeconds value. If this PollStrategy doesn't
-     * have a retryAfterSeconds value, then just return.
-     */
-    void delay() throws InterruptedException {
-        if (delayInMilliseconds > 0) {
-            Thread.sleep(delayInMilliseconds);
         }
     }
 
@@ -102,12 +82,6 @@ abstract class PollStrategy {
      * @return A new HTTP poll request.
      */
     abstract HttpRequest createPollRequest();
-
-    /**
-     * Update the status of this PollStrategy from the provided HTTP poll response.
-     * @param httpPollResponse The response of the most recent poll request.
-     */
-    abstract void updateFrom(HttpResponse httpPollResponse) throws IOException;
 
     /**
      * Update the status of this PollStrategy from the provided HTTP poll response.

--- a/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
@@ -336,15 +336,6 @@ public class SwaggerMethodParser {
     }
 
     /**
-     * Get whether or not this parser's swagger method is asynchronous.
-     * @return Whether or not this parser's swagger method is asynchronous.
-     */
-    public boolean isAsync() {
-        final TypeToken returnTypeToken = TypeToken.of(returnType);
-        return returnTypeToken.isSubtypeOf(Completable.class) || returnTypeToken.isSubtypeOf(Single.class) || returnTypeToken.isSubtypeOf(Observable.class);
-    }
-
-    /**
      * Set both the HTTP method and the path that will be used to complete the Swagger method's
      * request.
      * @param httpMethod The HTTP method that will be used to complete the Swagger method's request.

--- a/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
@@ -8,7 +8,6 @@ package com.microsoft.rest;
 
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
-import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.annotations.BodyParam;
 import com.microsoft.rest.annotations.DELETE;
 import com.microsoft.rest.annotations.ExpectedResponses;
@@ -25,9 +24,6 @@ import com.microsoft.rest.annotations.PathParam;
 import com.microsoft.rest.annotations.QueryParam;
 import com.microsoft.rest.http.HttpHeader;
 import com.microsoft.rest.http.HttpHeaders;
-import rx.Completable;
-import rx.Observable;
-import rx.Single;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;

--- a/client-runtime/src/main/java/com/microsoft/rest/http/HttpClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/HttpClient.java
@@ -9,7 +9,6 @@ package com.microsoft.rest.http;
 import com.microsoft.rest.policy.RequestPolicy;
 import rx.Single;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -50,17 +49,6 @@ public abstract class HttpClient {
             next = factory.create(next);
         }
         return next.sendAsync(request);
-    }
-
-    /**
-     * Send the provided request and block until the response is received.
-     * @param request The HTTP request to send.
-     * @return The HTTP response received.
-     * @throws IOException On network issues.
-     */
-    public final HttpResponse sendRequest(HttpRequest request) throws IOException {
-        final Single<? extends HttpResponse> asyncResult = sendRequestAsync(request);
-        return asyncResult.toBlocking().value();
     }
 
     /**

--- a/client-runtime/src/main/java/com/microsoft/rest/http/HttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/HttpResponse.java
@@ -8,7 +8,6 @@ package com.microsoft.rest.http;
 
 import rx.Single;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -42,28 +41,7 @@ public abstract class HttpResponse {
      * @return This response object's body as an InputStream. If this response object doesn't have a
      * body, then null will be returned.
      */
-    public InputStream bodyAsInputStream() {
-        return bodyAsInputStreamAsync().toBlocking().value();
-    }
-
-    /**
-     * Get this response object's body as an InputStream. If this response object doesn't have a
-     * body, then null will be returned.
-     * @return This response object's body as an InputStream. If this response object doesn't have a
-     * body, then null will be returned.
-     */
     public abstract Single<? extends InputStream> bodyAsInputStreamAsync();
-
-    /**
-     * Get this response object's body as a byte[]. If this response object doesn't have a body,
-     * then null will be returned.
-     * @return This response object's body as a byte[]. If this response object doesn't have a body,
-     * then null will be returned.
-     * @throws IOException On network error.
-     */
-    public byte[] bodyAsByteArray() throws IOException {
-        return bodyAsByteArrayAsync().toBlocking().value();
-    }
 
     /**
      * Get this response object's body as a byte[]. If this response object doesn't have a body,
@@ -72,17 +50,6 @@ public abstract class HttpResponse {
      * then null will be returned.
      */
     public abstract Single<byte[]> bodyAsByteArrayAsync();
-
-    /**
-     * Get this response object's body as a string. If this response object doesn't have a body,
-     * then null will be returned.
-     * @return This response object's body as a string. If this response object doesn't have a body,
-     * then null will be returned.
-     * @throws IOException On network or serialization error.
-     */
-    public String bodyAsString() throws IOException {
-        return bodyAsStringAsync().toBlocking().value();
-    }
 
     /**
      * Get this response object's body as a string. If this response object doesn't have a body,

--- a/client-runtime/src/main/java/com/microsoft/rest/policy/LoggingPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/policy/LoggingPolicy.java
@@ -140,8 +140,8 @@ public final class LoggingPolicy implements RequestPolicy {
             String contentTypeHeader = response.headerValue("Content-Type");
             if ("application/json".equals(contentTypeHeader)) {
                 try {
-                    log(logger, response.bodyAsString());
-                } catch (IOException e) {
+                    log(logger, response.bodyAsStringAsync().toBlocking().value());
+                } catch (Throwable e) {
                     log(logger, "Error occurred when logging body: " + e.getMessage());
                 }
             } else {

--- a/client-runtime/src/test/java/com/microsoft/rest/CredentialsTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/CredentialsTests.java
@@ -41,7 +41,7 @@ public class CredentialsTests {
         HttpClient client = new MockHttpClient(Arrays.asList(new CredentialsPolicy.Factory(credentials), auditorFactory));
 
         HttpRequest request = new HttpRequest("basicCredentialsTest", "GET", "http://localhost");
-        client.sendRequest(request);
+        client.sendRequestAsync(request).toBlocking().value();
     }
 
     @Test
@@ -65,6 +65,6 @@ public class CredentialsTests {
         HttpClient client = new MockHttpClient(Arrays.asList(new CredentialsPolicy.Factory(credentials), auditorFactory));
 
         HttpRequest request = new HttpRequest("basicCredentialsTest", "GET", "http://localhost");
-        client.sendRequest(request);
+        client.sendRequestAsync(request).toBlocking().value();
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/RequestIdPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RequestIdPolicyTests.java
@@ -85,8 +85,8 @@ public class RequestIdPolicyTests {
             }
         };
 
-        client.sendRequest(new HttpRequest("newRequestIdForEachCall", "GET", "http://localhost/"));
-        client.sendRequest(new HttpRequest("newRequestIdForEachCall", "GET", "http://localhost/"));
+        client.sendRequestAsync(new HttpRequest("newRequestIdForEachCall", "GET", "http://localhost/")).toBlocking().value();
+        client.sendRequestAsync(new HttpRequest("newRequestIdForEachCall", "GET", "http://localhost/")).toBlocking().value();
     }
 
     @Test
@@ -111,6 +111,6 @@ public class RequestIdPolicyTests {
                     }
                 };
 
-        client.sendRequest(new HttpRequest("sameRequestIdForRetry", "GET", "http://localhost/"));
+        client.sendRequestAsync(new HttpRequest("sameRequestIdForRetry", "GET", "http://localhost/")).toBlocking().value();
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/RetryPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RetryPolicyTests.java
@@ -31,11 +31,11 @@ public class RetryPolicyTests {
             }
         };
 
-        HttpResponse response = client.sendRequest(
+        HttpResponse response = client.sendRequestAsync(
                 new HttpRequest(
                         "exponentialRetryEndOn501",
                         "GET",
-                        "http://localhost/"));
+                        "http://localhost/")).toBlocking().value();
 
         Assert.assertEquals(501, response.statusCode());
     }
@@ -53,11 +53,11 @@ public class RetryPolicyTests {
             }
         };
 
-        HttpResponse response = client.sendRequest(
+        HttpResponse response = client.sendRequestAsync(
                 new HttpRequest(
                         "exponentialRetryMax",
                         "GET",
-                        "http://localhost/"));
+                        "http://localhost/")).toBlocking().value();
 
         Assert.assertEquals(500, response.statusCode());
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/UserAgentTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/UserAgentTests.java
@@ -33,9 +33,9 @@ public class UserAgentTests {
             }
         };
 
-        HttpResponse response = client.sendRequest(new HttpRequest(
+        HttpResponse response = client.sendRequestAsync(new HttpRequest(
                 "defaultUserAgentTests",
-                "GET", "http://localhost"));
+                "GET", "http://localhost")).toBlocking().value();
 
         Assert.assertEquals(200, response.statusCode());
     }
@@ -51,7 +51,7 @@ public class UserAgentTests {
             }
         };
 
-        HttpResponse response = client.sendRequest(new HttpRequest("customUserAgentTests", "GET", "http://localhost"));
+        HttpResponse response = client.sendRequestAsync(new HttpRequest("customUserAgentTests", "GET", "http://localhost")).toBlocking().value();
         Assert.assertEquals(200, response.statusCode());
     }
 }


### PR DESCRIPTION
This pull request truly makes RestProxy and AzureRestProxy only have a single path that requests go through. There's no longer a distinction between handling async versus sync methods. All methods go through the async handler, and then the sync versions block on the result.