### PR TITLE
Azure management support

### DIFF
--- a/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/MSICredentials.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/MSICredentials.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.credentials;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.microsoft.azure.AzureEnvironment;
+import com.microsoft.azure.management.apigeneration.Beta;
+import com.microsoft.azure.serializer.AzureJacksonAdapter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Managed Service Identity token based credentials for use with a REST Service Client.
+ */
+@Beta
+public class MSICredentials extends AzureTokenCredentials {
+    private final String resource;
+    private final int msiPort;
+    private final AzureJacksonAdapter adapter;
+    /**
+     * Initializes a new instance of the MSICredentials.
+     *
+     * @param environment the Azure environment to use
+     */
+    public MSICredentials(AzureEnvironment environment) {
+        this(environment, 50342);
+    }
+
+    /**
+     * Initializes a new instance of the MSICredentials.
+     *
+     * @param environment the Azure environment to use
+     * @param msiPort the local port to retrieve token from
+     */
+    public MSICredentials(AzureEnvironment environment, int msiPort) {
+        super(environment, null /** retrieving MSI token does not require tenant **/);
+        this.resource = environment.resourceManagerEndpoint();
+        this.msiPort = msiPort;
+        this.adapter = new AzureJacksonAdapter();
+    }
+
+    @Override
+    public String getToken(String resource) throws IOException {
+        URL url = new URL(String.format("http://localhost:%d/oauth2/token", this.msiPort));
+        String postData = String.format("resource=%s", this.resource);
+        HttpURLConnection connection = null;
+
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
+            connection.setRequestProperty("Metadata", "true");
+            connection.setRequestProperty("Content-Length", Integer.toString(postData.length()));
+            connection.setDoOutput(true);
+
+            connection.connect();
+
+            OutputStreamWriter wr = new OutputStreamWriter(connection.getOutputStream());
+            wr.write(postData);
+            wr.flush();
+
+            InputStream stream = connection.getInputStream();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"), 100);
+            String result = reader.readLine();
+
+            MSIToken msiToken = adapter.deserialize(result, MSIToken.class);
+            return msiToken.accessToken;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    /**
+     * Type representing response from the local MSI token provider.
+     */
+    private static class MSIToken {
+        /**
+         * Token type "Bearer".
+         */
+        @JsonProperty(value = "token_type")
+        private String tokenType;
+
+        /**
+         * Access token.
+         */
+        @JsonProperty(value = "access_token")
+        private String accessToken;
+    }
+}

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/credentials/AzureTokenCredentials.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/credentials/AzureTokenCredentials.java
@@ -71,6 +71,11 @@ public abstract class AzureTokenCredentials extends TokenCredentials {
      */
     public abstract String getToken(String resource) throws IOException;
 
+    @Override
+    public String authorizationHeaderValue(String uri) throws IOException {
+        return "Bearer " + getTokenFromUri(uri);
+    }
+
     /**
      * Override this method to provide the domain or tenant ID the token is valid in.
      *

--- a/client-runtime/src/main/java/com/microsoft/rest/RestClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/RestClient.java
@@ -63,6 +63,10 @@ public final class RestClient {
         httpClientBuilder.withRequestPolicies(customPolicyFactories)
             .withRequestPolicy(new LoggingPolicy.Factory(logLevel));
 
+        if (proxy != null) {
+            httpClientBuilder.withProxy(proxy);
+        }
+
         this.httpClient = httpClientBuilder.build();
     }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/ServiceFuture.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/ServiceFuture.java
@@ -8,7 +8,9 @@ package com.microsoft.rest;
 
 import com.google.common.util.concurrent.AbstractFuture;
 import rx.Single;
+import rx.Completable;
 import rx.Subscription;
+import rx.functions.Action0;
 import rx.functions.Action1;
 
 /**
@@ -58,6 +60,36 @@ public class ServiceFuture<T> extends AbstractFuture<T> {
         return serviceFuture;
     }
 
+    /**
+     * Creates a ServiceFuture from an Completable object and a callback.
+     *
+     * @param completable the completable to create from
+     * @param callback the callback to call when event happen
+     * @return the created ServiceFuture
+     */
+    public static ServiceFuture<Void> fromBody(final Completable completable, final ServiceCallback<Void> callback) {
+        final ServiceFuture<Void> serviceFuture = new ServiceFuture<>();
+        completable.subscribe(new Action0() {
+            Void value = null;
+            @Override
+            public void call() {
+                if (callback != null) {
+                    callback.success(value);
+                }
+                serviceFuture.set(value);
+            }
+        }, new Action1<Throwable>() {
+            @Override
+            public void call(Throwable throwable) {
+                if (callback != null) {
+                    callback.failure(throwable);
+                }
+                serviceFuture.setException(throwable);
+            }
+        });
+        return serviceFuture;
+    };
+    
     /**
      * @return the current Rx subscription associated with the ServiceCall.
      */

--- a/client-runtime/src/main/java/com/microsoft/rest/credentials/BasicAuthenticationCredentials.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/credentials/BasicAuthenticationCredentials.java
@@ -35,7 +35,7 @@ public class BasicAuthenticationCredentials implements ServiceClientCredentials 
     }
 
     @Override
-    public String headerValue(String uri) {
+    public String authorizationHeaderValue(String uri) {
         String credential = userName + ":" + password;
         String encodedCredential;
         try {

--- a/client-runtime/src/main/java/com/microsoft/rest/credentials/ServiceClientCredentials.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/credentials/ServiceClientCredentials.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.rest.credentials;
 
+import java.io.IOException;
+
 /**
  * Provides credentials to be put in the HTTP Authorization header.
  */
@@ -13,6 +15,7 @@ public interface ServiceClientCredentials {
     /**
      * @param uri The URI to which the request is being made.
      * @return The value containing currently valid credentials to put in the HTTP header.
+     * @throws IOException if unable to get the authorization header value
      */
-    String headerValue(String uri);
+    String authorizationHeaderValue(String uri) throws IOException;
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/credentials/TokenCredentials.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/credentials/TokenCredentials.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.rest.credentials;
 
+import java.io.IOException;
+
 /**
  * Token based credentials for use with a REST Service Client.
  */
@@ -31,7 +33,7 @@ public class TokenCredentials implements ServiceClientCredentials {
     }
 
     @Override
-    public String headerValue(String uri) {
+    public String authorizationHeaderValue(String uri) throws IOException {
         return scheme + " " + token;
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/policy/CredentialsPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/policy/CredentialsPolicy.java
@@ -11,6 +11,8 @@ import com.microsoft.rest.http.HttpRequest;
 import com.microsoft.rest.http.HttpResponse;
 import rx.Single;
 
+import java.io.IOException;
+
 /**
  * Adds credentials from ServiceClientCredentials to a request.
  */
@@ -50,8 +52,12 @@ public final class CredentialsPolicy implements RequestPolicy {
      */
     @Override
     public Single<HttpResponse> sendAsync(HttpRequest request) {
-        String token = credentials.headerValue(request.url());
-        request.headers().add("Authorization", token);
-        return next.sendAsync(request);
+        try {
+            String token = credentials.authorizationHeaderValue(request.url());
+            request.headers().add("Authorization", token);
+            return next.sendAsync(request);
+        } catch (IOException e) {
+            return Single.error(e);
+        }
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/FlatteningSerializerTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/FlatteningSerializerTests.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.microsoft.rest.serializer.JacksonAdapter;
+import com.microsoft.rest.serializer.JsonFlatten;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FlatteningSerializerTests {
+    @Test
+    public void canFlatten() throws Exception {
+        Foo foo = new Foo();
+        foo.bar = "hello.world";
+        foo.baz = new ArrayList<>();
+        foo.baz.add("hello");
+        foo.baz.add("hello.world");
+        foo.qux = new HashMap<>();
+        foo.qux.put("hello", "world");
+        foo.qux.put("a.b", "c.d");
+
+        String serialized = new JacksonAdapter().serialize(foo);
+        Assert.assertEquals("{\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"a.b\":\"c.d\",\"hello\":\"world\"}}}}}", serialized);
+    }
+
+    @JsonFlatten
+    private class Foo {
+        @JsonProperty(value = "properties.bar")
+        private String bar;
+        @JsonProperty(value = "properties.props.baz")
+        private List<String> baz;
+        @JsonProperty(value = "properties.props.q.qux")
+        private Map<String, String> qux;
+    }
+}


### PR DESCRIPTION
This features a few preliminary changes to the runtime in order to support the management SDK in practice. With these changes, I have our storage accounts and usages tests working :tada:, which is basically all the tests I saw for storage management.

- Put LoggingPolicy at the end of the chain because it lets you see everything that's been done to the HttpRequest.
- Added a Proxy field because AzureConfigurableImpl wanted to be able to set one and our concrete HTTP client can now use one.
- Refactored credentials to reflect that `authorizationHeaderValue` may throw.  Tweaked things so that AzureTokenCredentials will actually try to get a token. Not sure how this stuff can be tested except to run tests in management SDK.

I also merged master in, so some changes e.g. MSICredentials and FlatteningSerializer are just along for the ride.