### PR TITLE
Add HTTP client factory

### DIFF
--- a/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/RefreshTokenClient.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/RefreshTokenClient.java
@@ -18,12 +18,15 @@ import com.microsoft.rest.annotations.ExpectedResponses;
 import com.microsoft.rest.annotations.POST;
 import com.microsoft.rest.annotations.PathParam;
 import com.microsoft.rest.http.HttpClient;
+import com.microsoft.rest.http.HttpClient.Configuration;
 import com.microsoft.rest.http.RxNettyAdapter;
+import com.microsoft.rest.policy.RequestPolicy;
 import com.microsoft.rest.protocol.SerializerAdapter;
 import rx.Single;
 import rx.functions.Func1;
 
 import java.net.Proxy;
+import java.util.Collections;
 import java.util.Date;
 
 /**
@@ -43,9 +46,8 @@ final class RefreshTokenClient {
     }
 
     private static HttpClient createHttpClient(Proxy proxy) {
-        return new RxNettyAdapter.Builder()
-                .withProxy(proxy)
-                .build();
+        return new RxNettyAdapter.Factory()
+                .create(new Configuration(Collections.<RequestPolicy.Factory>emptyList(), proxy));
     }
 
     AuthenticationResult refreshToken(String tenant, String clientId, String resource, String refreshToken, boolean isMultipleResoureRefreshToken) {

--- a/client-runtime/src/main/java/com/microsoft/rest/http/BufferedHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/BufferedHttpResponse.java
@@ -61,4 +61,16 @@ public final class BufferedHttpResponse extends HttpResponse {
     public Single<String> bodyAsStringAsync() {
         return Single.just(body);
     }
+
+    @Override
+    public Single<BufferedHttpResponse> buffer() {
+        return Single.just(this);
+    }
+
+    /**
+     * @return The buffered HTTP response body. Will not cause blocking.
+     */
+    public String body() {
+        return body;
+    }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/http/HttpClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/HttpClient.java
@@ -9,6 +9,7 @@ package com.microsoft.rest.http;
 import com.microsoft.rest.policy.RequestPolicy;
 import rx.Single;
 
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,4 +58,48 @@ public abstract class HttpClient {
      * @return A {@link Single} representing the HTTP response that will arrive asynchronously.
      */
     protected abstract Single<HttpResponse> sendRequestInternalAsync(HttpRequest request);
+
+    /**
+     * The set of parameters used to create an HTTP client.
+     */
+    public static final class Configuration {
+        private final List<RequestPolicy.Factory> policyFactories;
+        private final Proxy proxy;
+
+        /**
+         * @return The policy factories to use when creating RequestPolicies to intercept requests.
+         */
+        public List<RequestPolicy.Factory> policyFactories() {
+            return policyFactories;
+        }
+
+        /**
+         * @return The optional proxy to use.
+         */
+        public Proxy proxy() {
+            return proxy;
+        }
+
+        /**
+         * Creates a Configuration.
+         * @param policyFactories The policy factories to use when creating RequestPolicies to intercept requests.
+         * @param proxy The optional proxy to use.
+         */
+        public Configuration(List<RequestPolicy.Factory> policyFactories, Proxy proxy) {
+            this.policyFactories = policyFactories;
+            this.proxy = proxy;
+        }
+    }
+
+    /**
+     * Creates an HttpClient from a Configuration.
+     */
+    public interface Factory {
+        /**
+         * Creates an HttpClient with the given Configuration.
+         * @param configuration the configuration.
+         * @return the HttpClient.
+         */
+        HttpClient create(Configuration configuration);
+    }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/http/HttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/HttpResponse.java
@@ -7,6 +7,7 @@
 package com.microsoft.rest.http;
 
 import rx.Single;
+import rx.functions.Func1;
 
 import java.io.InputStream;
 
@@ -58,4 +59,17 @@ public abstract class HttpResponse {
      * then null will be returned.
      */
     public abstract Single<String> bodyAsStringAsync();
+
+    /**
+     * Buffers the HTTP response body into memory, allowing the content to be inspected and replayed.
+     * @return This HTTP response, with body content buffered into memory.
+     */
+    public Single<BufferedHttpResponse> buffer() {
+        return bodyAsStringAsync().map(new Func1<String, BufferedHttpResponse>() {
+            @Override
+            public BufferedHttpResponse call(String body) {
+                return new BufferedHttpResponse(statusCode(), headers(), body);
+            }
+        });
+    }
 }


### PR DESCRIPTION
When working on tests for management SDK, which depend heavily on recording and playing back HTTP traffic, I found a need to specify a mock HTTP client in RestClient. RestClient had a hard reference on RxNettyAdapter so I needed to rework things a bit.

After some experimentation, I settled on this as a pretty good way to create an HTTP client from some commonly-known configuration set. It concerns me a bit that it's, well, factories and builders all the way down, but it seems to be the cost of immutability in Java 7. One alternative would be to take some of these named Factory interfaces and simply use `Func1<Configuration, Result>`. See what you think.

I also think RestClient.Builder deserves a little thought on which parameters are required-- I'd tend to advocate making those required parameters (the ones that throw if you build without setting them) be arguments to the builder's constructor as well as having `.with` methods, but it would break a lot of usage sites. In the long run, it would provide the advantage of pushing runtime errors back to compile time, which should make RestClient's users happier.

I'm also finding a lot of places where RequestPolicies need to read response body content. So far I think it is working more smoothly to have this BufferedHttpResponse instead of asking the concrete HTTP clients to cache their response body content. The caveat is that any RequestPolicy that reads response body content needs to `.buffer()` and return the BufferedHttpResponse. I'm not married to it working this way though, so feel free to play with it.