### PR TITLE
Fix endless loop in AutoRest Azure tests

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/ProvisioningState.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/ProvisioningState.java
@@ -26,11 +26,19 @@ public final class ProvisioningState {
     public static final String FAILED = "Failed";
 
     /**
+     * The provisioning state of the operation resource if the operation is canceled.
+     */
+    public static final String CANCELED = "Canceled";
+
+    /**
      * Get whether or not the provided provisioning state represents a completed state.
      * @param provisioningState The provisioning state to check.
      * @return Whether or not the provided provisioning state represents a completed state.
      */
     public static boolean isCompleted(String provisioningState) {
-        return SUCCEEDED.equalsIgnoreCase(provisioningState) || FAILED.equalsIgnoreCase(provisioningState);
+        return SUCCEEDED.equalsIgnoreCase(provisioningState)
+                || FAILED.equalsIgnoreCase(provisioningState)
+                || CANCELED.equalsIgnoreCase(provisioningState);
     }
+
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/ProvisioningStatePollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/ProvisioningStatePollStrategy.java
@@ -45,7 +45,7 @@ public class ProvisioningStatePollStrategy extends PollStrategy {
                         try {
                             final ResourceWithProvisioningState resource = deserialize(responseBody, ResourceWithProvisioningState.class);
                             if (resource == null || resource.properties() == null || resource.properties().provisioningState() == null) {
-                                setProvisioningState(ProvisioningState.IN_PROGRESS);
+                                setProvisioningState(ProvisioningState.FAILED);
                             }
                             else {
                                 setProvisioningState(resource.properties().provisioningState());


### PR DESCRIPTION
I tried running AutoRest tests against the most recent client runtime and they didn't terminate for the reasons implied by these code changes.

1. Canceled is a known conclusive state. Since there might be other values that services give back to indicate the operation is done, it might be best to implement by comparing to InProgress.

2. If the service doesn't give back a provisioning state, best to consider it a failure.

There are several other tests failing, many of which due to the way errors are handled. AutoRest tests expect a non-success completed state to throw an exception. It might be most productive to work on LROs directly against AutoRest tests because they exercise so many failure conditions.