### PR TITLE
Remove HttpHeaders.add()

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/SwaggerMethodParser.java
@@ -124,7 +124,7 @@ public class SwaggerMethodParser {
                     if (!headerName.isEmpty()) {
                         final String headerValue = header.substring(colonIndex + 1).trim();
                         if (!headerValue.isEmpty()) {
-                            this.headers.add(headerName, headerValue);
+                            this.headers.set(headerName, headerValue);
                         }
                     }
                 }
@@ -259,7 +259,7 @@ public class SwaggerMethodParser {
 
         final Iterable<EncodedParameter> substitutedHeaders = getEncodedParameters(headerSubstitutions, swaggerMethodArguments, null);
         for (final EncodedParameter substitutedHeader : substitutedHeaders) {
-            result.add(substitutedHeader.name(), substitutedHeader.encodedValue());
+            result.set(substitutedHeader.name(), substitutedHeader.encodedValue());
         }
 
         return result;

--- a/client-runtime/src/main/java/com/microsoft/rest/http/HttpHeaders.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/HttpHeaders.java
@@ -59,7 +59,7 @@ public class HttpHeaders implements Iterable<HttpHeader>, JsonSerializable {
      */
     public HttpHeaders set(String headerName, String headerValue) {
         final String headerKey = headerName.toLowerCase();
-        if (headerValue == null || headerValue.isEmpty()) {
+        if (headerValue == null) {
             headers.remove(headerKey);
         }
         else {

--- a/client-runtime/src/main/java/com/microsoft/rest/http/HttpHeaders.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/HttpHeaders.java
@@ -34,7 +34,7 @@ public class HttpHeaders implements Iterable<HttpHeader>, JsonSerializable {
      */
     public HttpHeaders(Map<String, String> headers) {
         for (final Map.Entry<String, String> header : headers.entrySet()) {
-            this.add(header.getKey(), header.getValue());
+            this.set(header.getKey(), header.getValue());
         }
     }
 
@@ -46,26 +46,8 @@ public class HttpHeaders implements Iterable<HttpHeader>, JsonSerializable {
         this();
 
         for (final HttpHeader header : headers) {
-            this.add(header.name(), header.value());
+            this.set(header.name(), header.value());
         }
-    }
-
-    /**
-     * Add the provided headerName and headerValue to the list of headers for this request.
-     * @param headerName The name of the header.
-     * @param headerValue The value of the header.
-     * @return This HttpHeaders so that multiple operations can be chained together.
-     */
-    public HttpHeaders add(String headerName, String headerValue) {
-        if (headerValue != null && !headerValue.isEmpty()) {
-            final String headerKey = headerName.toLowerCase();
-            if (!headers.containsKey(headerKey)) {
-                headers.put(headerKey, new HttpHeader(headerName, headerValue));
-            } else {
-                headers.get(headerKey).addValue(headerValue);
-            }
-        }
-        return this;
     }
 
     /**

--- a/client-runtime/src/main/java/com/microsoft/rest/http/HttpRequest.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/HttpRequest.java
@@ -60,7 +60,7 @@ public class HttpRequest {
      * @return This HttpRequest so that multiple operations can be chained together.
      */
     public HttpRequest withHeader(String headerName, String headerValue) {
-        headers.add(headerName, headerValue);
+        headers.set(headerName, headerValue);
         return this;
     }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/http/NettyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/http/NettyResponse.java
@@ -57,7 +57,7 @@ class NettyResponse extends HttpResponse {
     public HttpHeaders headers() {
         HttpHeaders headers = new HttpHeaders();
         for (Entry<String, String> header : rxnRes.headers()) {
-            headers.add(header.getKey(), header.getValue());
+            headers.set(header.getKey(), header.getValue());
         }
         return headers;
     }

--- a/client-runtime/src/main/java/com/microsoft/rest/policy/AddCookiesPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/policy/AddCookiesPolicy.java
@@ -49,7 +49,7 @@ public final class AddCookiesPolicy implements RequestPolicy {
             Map<String, List<String>> requestCookies = cookies.get(uri, cookieHeaders);
             for (Map.Entry<String, List<String>> entry : requestCookies.entrySet()) {
                 for (String headerValue : entry.getValue()) {
-                    request.headers().add(entry.getKey(), headerValue);
+                    request.headers().set(entry.getKey(), headerValue);
                 }
             }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/policy/CredentialsPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/policy/CredentialsPolicy.java
@@ -54,7 +54,7 @@ public final class CredentialsPolicy implements RequestPolicy {
     public Single<HttpResponse> sendAsync(HttpRequest request) {
         try {
             String token = credentials.authorizationHeaderValue(request.url());
-            request.headers().add("Authorization", token);
+            request.headers().set("Authorization", token);
             return next.sendAsync(request);
         } catch (IOException e) {
             return Single.error(e);

--- a/client-runtime/src/main/java/com/microsoft/rest/policy/RequestIdPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/policy/RequestIdPolicy.java
@@ -38,7 +38,7 @@ public final class RequestIdPolicy implements RequestPolicy {
     public Single<HttpResponse> sendAsync(HttpRequest request) {
         String requestId = request.headers().value(REQUEST_ID_HEADER);
         if (requestId == null) {
-            request.headers().add(REQUEST_ID_HEADER, UUID.randomUUID().toString());
+            request.headers().set(REQUEST_ID_HEADER, UUID.randomUUID().toString());
         }
 
         return next.sendAsync(request);

--- a/client-runtime/src/test/java/com/microsoft/rest/http/HttpHeadersTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/http/HttpHeadersTests.java
@@ -6,23 +6,23 @@ import static org.junit.Assert.*;
 
 public class HttpHeadersTests {
     @Test
-    public void add()
+    public void testSet()
     {
         final HttpHeaders headers = new HttpHeaders();
 
-        headers.add("a", "b");
+        headers.set("a", "b");
         assertEquals("b", headers.value("a"));
 
-        headers.add("a", "c");
-        assertEquals("b,c", headers.value("a"));
+        headers.set("a", "c");
+        assertEquals("c", headers.value("a"));
 
-        headers.add("a", null);
-        assertEquals("b,c", headers.value("a"));
+        headers.set("a", null);
+        assertNull(headers.value("a"));
 
         headers.set("A", "");
         assertNull(headers.value("a"));
 
-        headers.add("A", "b");
+        headers.set("A", "b");
         assertEquals("b", headers.value("A"));
 
         headers.set("a", null);

--- a/client-runtime/src/test/java/com/microsoft/rest/http/HttpHeadersTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/http/HttpHeadersTests.java
@@ -20,7 +20,7 @@ public class HttpHeadersTests {
         assertNull(headers.value("a"));
 
         headers.set("A", "");
-        assertNull(headers.value("a"));
+        assertEquals("", headers.value("a"));
 
         headers.set("A", "b");
         assertEquals("b", headers.value("A"));

--- a/client-runtime/src/test/java/com/microsoft/rest/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/http/MockHttpClient.java
@@ -28,11 +28,11 @@ import java.util.Map;
  */
 public class MockHttpClient extends HttpClient {
     private static final HttpHeaders responseHeaders = new HttpHeaders()
-            .add("Date", "Fri, 13 Oct 2017 20:33:09 GMT")
-            .add("Via", "1.1 vegur")
-            .add("Connection", "keep-alive")
-            .add("X-Processed-Time", "1.0")
-            .add("Access-Control-Allow-Credentials", "true");
+            .set("Date", "Fri, 13 Oct 2017 20:33:09 GMT")
+            .set("Via", "1.1 vegur")
+            .set("Connection", "keep-alive")
+            .set("X-Processed-Time", "1.0")
+            .set("Access-Control-Allow-Credentials", "true");
 
     public MockHttpClient() {}
 


### PR DESCRIPTION
This PR removes the add() method in favor of the set() method because add() has proven to be a behavior that people generally pick by accident and don't really intend. Other minor changes were made in order to fix the autorest.java headers tests.

We should consider making HttpHeaders immutable, as well as HttpRequest itself, as opposed to providing methods for deep copying.