### PR TITLE
Rename RestClient methods

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureServiceClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureServiceClient.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.v2.serializer.AzureJacksonAdapter;
 import com.microsoft.rest.v2.RestClient;
 import com.microsoft.rest.v2.ServiceClient;
 import com.microsoft.rest.v2.credentials.ServiceClientCredentials;
+import com.microsoft.rest.v2.policy.CredentialsPolicy;
 
 import java.net.NetworkInterface;
 import java.util.Enumeration;
@@ -28,7 +29,7 @@ public abstract class AzureServiceClient extends ServiceClient {
     protected AzureServiceClient(String baseUrl, ServiceClientCredentials credentials) {
         this(new RestClient.Builder()
                 .withBaseUrl(baseUrl)
-                .withCredentials(credentials)
+                .withCredentialsPolicy(new CredentialsPolicy.Factory(credentials))
                 .withSerializerAdapter(new AzureJacksonAdapter())
                 .build());
     }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestClient.java
@@ -6,11 +6,9 @@
 
 package com.microsoft.rest.v2;
 
-import com.microsoft.rest.v2.credentials.ServiceClientCredentials;
 import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.NettyClient;
 import com.microsoft.rest.v2.policy.AddCookiesPolicy;
-import com.microsoft.rest.v2.policy.CredentialsPolicy;
 import com.microsoft.rest.v2.policy.LoggingPolicy;
 import com.microsoft.rest.v2.policy.RequestPolicy;
 import com.microsoft.rest.v2.policy.RetryPolicy;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/CredentialsPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/CredentialsPolicy.java
@@ -14,7 +14,7 @@ import rx.Single;
 import java.io.IOException;
 
 /**
- * Adds credentialsPolicyFactory from ServiceClientCredentials to a request.
+ * Adds credentials from ServiceClientCredentials to a request.
  */
 public final class CredentialsPolicy implements RequestPolicy {
     /**
@@ -25,7 +25,7 @@ public final class CredentialsPolicy implements RequestPolicy {
 
         /**
          * Creates a Factory which produces CredentialsPolicy.
-         * @param credentials The credentialsPolicyFactory to use for authentication.
+         * @param credentials The credentials to use for authentication.
          */
         public Factory(ServiceClientCredentials credentials) {
             this.credentials = credentials;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/CredentialsPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/CredentialsPolicy.java
@@ -14,7 +14,7 @@ import rx.Single;
 import java.io.IOException;
 
 /**
- * Adds credentials from ServiceClientCredentials to a request.
+ * Adds credentialsPolicyFactory from ServiceClientCredentials to a request.
  */
 public final class CredentialsPolicy implements RequestPolicy {
     /**
@@ -25,7 +25,7 @@ public final class CredentialsPolicy implements RequestPolicy {
 
         /**
          * Creates a Factory which produces CredentialsPolicy.
-         * @param credentials The credentials to use for authentication.
+         * @param credentials The credentialsPolicyFactory to use for authentication.
          */
         public Factory(ServiceClientCredentials credentials) {
             this.credentials = credentials;

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestClientTests.java
@@ -35,7 +35,7 @@ public class RestClientTests {
         Assert.assertEquals("https://management.azure.com/", restClient.baseURL());
         Assert.assertEquals(LogLevel.NONE, restClient.logLevel());
         Assert.assertTrue(restClient.serializerAdapter() instanceof JacksonAdapter);
-        Assert.assertNull(restClient.credentials());
+        Assert.assertNull(restClient.credentialsPolicyFactory());
     }
 
     @Test
@@ -64,7 +64,7 @@ public class RestClientTests {
         Assert.assertEquals(restClient.logLevel(), newClient.logLevel());
         Assert.assertEquals(restClient.logLevel().isPrettyJson(), newClient.logLevel().isPrettyJson());
         Assert.assertEquals(restClient.serializerAdapter(), newClient.serializerAdapter());
-        Assert.assertEquals(restClient.credentials(), newClient.credentials());
+        Assert.assertEquals(restClient.credentialsPolicyFactory(), newClient.credentialsPolicyFactory());
         Assert.assertEquals(restClient.userAgent(), newClient.userAgent());
         Assert.assertEquals(restClient.customRequestPolicyFactories().size(), newClient.customRequestPolicyFactories().size());
         Assert.assertEquals(TimeUnit.MINUTES.toMillis(100), newClient.connectionTimeoutMillis());
@@ -142,7 +142,7 @@ public class RestClientTests {
         Assert.assertNotEquals(restClient.logLevel(), newClient.logLevel());
         Assert.assertNotEquals(restClient.logLevel().isPrettyJson(), newClient.logLevel().isPrettyJson());
         Assert.assertNotEquals(restClient.serializerAdapter(), newClient.serializerAdapter());
-        Assert.assertNotEquals(restClient.credentials(), newClient.credentials());
+        Assert.assertNotEquals(restClient.credentialsPolicyFactory(), newClient.credentialsPolicyFactory());
         Assert.assertEquals("user", restClient.userAgent());
         Assert.assertEquals("anotheruser", newClient.userAgent());
         Assert.assertNotEquals(restClient.connectionTimeoutMillis(), newClient.connectionTimeoutMillis());

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestClientTests.java
@@ -9,6 +9,7 @@ package com.microsoft.rest.v2;
 
 import com.microsoft.rest.v2.credentials.BasicAuthenticationCredentials;
 import com.microsoft.rest.v2.credentials.TokenCredentials;
+import com.microsoft.rest.v2.policy.CredentialsPolicy;
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
 import com.microsoft.rest.v2.protocol.TypeFactory;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
@@ -42,9 +43,9 @@ public class RestClientTests {
         RestClient restClient = new RestClient.Builder()
             .withBaseUrl("http://localhost")
             .withSerializerAdapter(new JacksonAdapter())
-            .withCredentials(new TokenCredentials("Bearer", "token"))
+            .withCredentialsPolicy(new CredentialsPolicy.Factory(new TokenCredentials("Bearer", "token")))
             .withLogLevel(LogLevel.BASIC)
-            .addCustomPolicy(new RequestPolicy.Factory() {
+            .addRequestPolicy(new RequestPolicy.Factory() {
                 @Override
                 public RequestPolicy create(final RequestPolicy next) {
                     return new RequestPolicy() {
@@ -65,7 +66,7 @@ public class RestClientTests {
         Assert.assertEquals(restClient.serializerAdapter(), newClient.serializerAdapter());
         Assert.assertEquals(restClient.credentials(), newClient.credentials());
         Assert.assertEquals(restClient.userAgent(), newClient.userAgent());
-        Assert.assertEquals(restClient.customPolicyFactories().size(), newClient.customPolicyFactories().size());
+        Assert.assertEquals(restClient.customRequestPolicyFactories().size(), newClient.customRequestPolicyFactories().size());
         Assert.assertEquals(TimeUnit.MINUTES.toMillis(100), newClient.connectionTimeoutMillis());
     }
 
@@ -74,9 +75,9 @@ public class RestClientTests {
         RestClient restClient = new RestClient.Builder()
             .withBaseUrl("http://localhost")
             .withSerializerAdapter(new JacksonAdapter())
-            .withCredentials(new TokenCredentials("Bearer", "token"))
+            .withCredentialsPolicy(new CredentialsPolicy.Factory(new TokenCredentials("Bearer", "token")))
             .withLogLevel(LogLevel.BASIC.withPrettyJson(true))
-            .addCustomPolicy(new RequestPolicy.Factory() {
+            .addRequestPolicy(new RequestPolicy.Factory() {
                 @Override
                 public RequestPolicy create(final RequestPolicy next) {
                     return new RequestPolicy() {
@@ -92,7 +93,7 @@ public class RestClientTests {
             .build();
         RestClient newClient = restClient.newBuilder()
             .withBaseUrl("https://contoso.com")
-            .withCredentials(new BasicAuthenticationCredentials("user", "pass"))
+            .withCredentialsPolicy(new CredentialsPolicy.Factory(new BasicAuthenticationCredentials("user", "pass")))
             .withLogLevel(LogLevel.BODY_AND_HEADERS)
             .withUserAgent("anotheruser")
             .withConnectionTimeout(200, TimeUnit.SECONDS)


### PR DESCRIPTION
- Renames `addCustomPolicy` to `addRequestPolicy`
- Adds `setRequestPolicies(List<RequestPolicy.Factory)`
- Renames `withCredentials(ServiceClientCredentials)` to `withCredentialsPolicy(RequestPolicy.Factory)`
- Removes `withMaxIdleConnections(int)`

The point of "add" instead of "with" is to convey that repeatedly calling it doesn't cause the previous value to get overwritten. Not sure whether it's more consistent to use the name `withRequestPolicies` instead of `setRequestPolicies`.