### PR TITLE
Fix handling of checked exceptions from serialization

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/PollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/PollStrategy.java
@@ -38,6 +38,7 @@ abstract class PollStrategy {
         this.delayInMilliseconds = delayInMilliseconds;
     }
 
+    @SuppressWarnings("unchecked")
     protected <T> T deserialize(String value, Type returnType) throws IOException {
         return (T) restProxy.deserialize(value, returnType, null, Encoding.JSON);
     }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
@@ -11,7 +11,6 @@ import com.microsoft.rest.v2.SwaggerMethodParser;
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import rx.Single;
-import rx.exceptions.Exceptions;
 import rx.functions.Func1;
 
 import java.io.IOException;
@@ -46,8 +45,12 @@ public class ProvisioningStatePollStrategy extends PollStrategy {
                                 .map(new Func1<String, HttpResponse>() {
                                     @Override
                                     public HttpResponse call(String responseBody) {
-                                        try {
-                                            final ResourceWithProvisioningState resource = deserialize(responseBody, ResourceWithProvisioningState.class);
+                                            ResourceWithProvisioningState resource = null;
+                                            try {
+                                                resource = deserialize(responseBody, ResourceWithProvisioningState.class);
+                                            } catch (IOException ignored) {
+                                            }
+
                                             if (resource == null || resource.properties() == null || resource.properties().provisioningState() == null) {
                                                 throw new CloudException("The polling response does not contain a valid body", bufferedHttpPollResponse, null);
                                             }
@@ -57,9 +60,6 @@ public class ProvisioningStatePollStrategy extends PollStrategy {
                                             else {
                                                 setStatus(resource.properties().provisioningState());
                                             }
-                                        } catch (IOException e) {
-                                            throw Exceptions.propagate(e);
-                                        }
                                         return bufferedHttpPollResponse;
                                     }
                                 });


### PR DESCRIPTION
There were some cases where IOExceptions produced by Jackson were wrapped into RuntimeExceptions and we failed to catch them as IOExceptions. This is part of why autorest.java LRO tests fail in the cases where invalid JSON is provided.

The deserialize convenience methods that `throw Exceptions.propagate(Exception)` were probably just there because it's cumbersome to wrap things in try/catch inside your map in Rx. The functional interfaces in RxJava 2 allow throwing checked exceptions, so this will pretty much be a non-issue after we migrate.