### PR TITLE
Add default RestClient instances and required parameters in builder constructors

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureRestClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureRestClient.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.v2;
+
+import com.microsoft.azure.v2.serializer.AzureJacksonAdapter;
+import com.microsoft.rest.v2.RestClient;
+
+/**
+ * Helpers for producing {@link RestClient} with Azure-specific configuration.
+ */
+public final class AzureRestClient {
+    private AzureRestClient() { }
+
+    /**
+     * A RestClient which provides default values for Azure clients.
+     * Users can modify the default values by calling {@link RestClient#newBuilder()}.
+     */
+    public static final RestClient DEFAULT = new RestClient.Builder(new AzureJacksonAdapter()).build();
+
+    /**
+     * @return A new {@link RestClient.Builder} instance with default values for Azure clients.
+     */
+    public static RestClient.Builder newDefaultBuilder() {
+        return DEFAULT.newBuilder();
+    }
+}

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureRestClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureRestClient.java
@@ -17,7 +17,7 @@ public final class AzureRestClient {
 
     /**
      * A RestClient which provides default values for Azure clients.
-     * Users can modify the default values by calling {@link RestClient#newBuilder()}.
+     * Users can modify the default values by calling {@link RestClient#newDefaultBuilder()}.
      */
     public static final RestClient DEFAULT = new RestClient.Builder(new AzureJacksonAdapter()).build();
 

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureServiceClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureServiceClient.java
@@ -7,7 +7,6 @@
 package com.microsoft.azure.v2;
 
 import com.google.common.hash.Hashing;
-import com.microsoft.azure.v2.serializer.AzureJacksonAdapter;
 import com.microsoft.rest.v2.RestClient;
 import com.microsoft.rest.v2.ServiceClient;
 import com.microsoft.rest.v2.credentials.ServiceClientCredentials;
@@ -27,10 +26,9 @@ public abstract class AzureServiceClient extends ServiceClient {
      * @param credentials the credentials
      */
     protected AzureServiceClient(String baseUrl, ServiceClientCredentials credentials) {
-        this(RestClient.newDefaultBuilder()
+        this(AzureRestClient.newDefaultBuilder()
                 .withBaseUrl(baseUrl)
                 .withCredentialsPolicy(new CredentialsPolicy.Factory(credentials))
-                .withSerializerAdapter(new AzureJacksonAdapter())
                 .build());
     }
 

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureServiceClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureServiceClient.java
@@ -27,7 +27,7 @@ public abstract class AzureServiceClient extends ServiceClient {
      * @param credentials the credentials
      */
     protected AzureServiceClient(String baseUrl, ServiceClientCredentials credentials) {
-        this(new RestClient.Builder()
+        this(RestClient.newDefaultBuilder()
                 .withBaseUrl(baseUrl)
                 .withCredentialsPolicy(new CredentialsPolicy.Factory(credentials))
                 .withSerializerAdapter(new AzureJacksonAdapter())

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureTests.java
@@ -22,9 +22,8 @@ public class AzureTests {
 // @AzureHost not yet supported.
 //    @Test
 //    public void getBytes() throws Exception {
-//        RestClient client = new RestClient.Builder()
+//        RestClient client = RestClient.newDefaultBuilder()
 //                .withBaseUrl("http://localhost")
-//                .withSerializerAdapter(new JacksonAdapter())
 //                .withResponseBuilderFactory(new ServiceResponseBuilder.Factory())
 //                .build();
 //        HttpBinService service = RestProxy.create(HttpBinService.class, client);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestClient.java
@@ -193,6 +193,15 @@ public final class RestClient {
         }
 
         /**
+         * Creates an instance of the builder.
+         * @deprecated Use {@link RestClient#newDefaultBuilder} or AzureRestClient.newDefaultBuilder if using the Azure runtime.
+         */
+        @Deprecated
+        public Builder() {
+            this(RestClient.DEFAULT);
+        }
+
+        /**
          * Creates an instance of the builder with required parameters.
          * @param serializerAdapter The serializer adapter to use.
          */

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestClient.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 public final class RestClient {
     /**
      * A RestClient which provides default values for vanilla clients.
-     * Users can modify the default values by calling {@link #newBuilder()}.
+     * Users can modify the default values by calling {@link RestClient#newDefaultBuilder()}.
      */
     public static final RestClient DEFAULT = new RestClient.Builder(new JacksonAdapter()).build();
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/ServiceClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/ServiceClient.java
@@ -7,7 +7,6 @@
 package com.microsoft.rest.v2;
 
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
-import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import com.microsoft.rest.v2.http.HttpClient;
 
 /**
@@ -25,10 +24,9 @@ public abstract class ServiceClient {
      * @param baseUrl the service base uri
      */
     protected ServiceClient(String baseUrl) {
-        this(new RestClient.Builder()
+        this(RestClient.newDefaultBuilder()
                 .withBaseUrl(baseUrl)
                 .withLogLevel(LogLevel.BODY_AND_HEADERS)
-                .withSerializerAdapter(new JacksonAdapter())
                 .build());
     }
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestClientTests.java
@@ -30,7 +30,6 @@ public class RestClientTests {
     public void defaultConfigs() {
         RestClient restClient = RestClient.newDefaultBuilder()
                 .withBaseUrl("https://management.azure.com/")
-                .withSerializerAdapter(new JacksonAdapter())
                 .build();
         Assert.assertEquals("https://management.azure.com/", restClient.baseURL());
         Assert.assertEquals(LogLevel.NONE, restClient.logLevel());
@@ -42,7 +41,6 @@ public class RestClientTests {
     public void newBuilderKeepsConfigs() {
         RestClient restClient = RestClient.newDefaultBuilder()
             .withBaseUrl("http://localhost")
-            .withSerializerAdapter(new JacksonAdapter())
             .withCredentialsPolicy(new CredentialsPolicy.Factory(new TokenCredentials("Bearer", "token")))
             .withLogLevel(LogLevel.BASIC)
             .addRequestPolicy(new RequestPolicy.Factory() {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestClientTests.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 public class RestClientTests {
     @Test
     public void defaultConfigs() {
-        RestClient restClient = new RestClient.Builder()
+        RestClient restClient = RestClient.newDefaultBuilder()
                 .withBaseUrl("https://management.azure.com/")
                 .withSerializerAdapter(new JacksonAdapter())
                 .build();
@@ -40,7 +40,7 @@ public class RestClientTests {
 
     @Test
     public void newBuilderKeepsConfigs() {
-        RestClient restClient = new RestClient.Builder()
+        RestClient restClient = RestClient.newDefaultBuilder()
             .withBaseUrl("http://localhost")
             .withSerializerAdapter(new JacksonAdapter())
             .withCredentialsPolicy(new CredentialsPolicy.Factory(new TokenCredentials("Bearer", "token")))
@@ -72,9 +72,8 @@ public class RestClientTests {
 
     @Test
     public void newBuilderClonesProperties() {
-        RestClient restClient = new RestClient.Builder()
+        RestClient restClient = RestClient.newDefaultBuilder()
             .withBaseUrl("http://localhost")
-            .withSerializerAdapter(new JacksonAdapter())
             .withCredentialsPolicy(new CredentialsPolicy.Factory(new TokenCredentials("Bearer", "token")))
             .withLogLevel(LogLevel.BASIC.withPrettyJson(true))
             .addRequestPolicy(new RequestPolicy.Factory() {


### PR DESCRIPTION
This PR adds `DEFAULT` and `newDefaultBuilder()` static members to create RestClient, as well as an AzureRestClient class with similar members. The RestClient.Builder constructor itself now takes all its required parameters as constructor arguments. The RestClient.Builder constructor with no arguments has been deprecated.