### PR TITLE
Add UrlBuilder.parse()

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/PortPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/PortPolicy.java
@@ -30,7 +30,7 @@ public class PortPolicy implements RequestPolicy {
     public Single<HttpResponse> sendAsync(HttpRequest request) {
         final UrlBuilder urlBuilder = UrlBuilder.parse(request.url());
         if (overwrite || urlBuilder.port() == null) {
-            request.withUrl(urlBuilder.withPort(3000).toString());
+            request.withUrl(urlBuilder.withPort(port).toString());
         }
         return nextPolicy.sendAsync(request);
     }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/PortPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/PortPolicy.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2.policy;
+
+
+import com.microsoft.rest.v2.http.HttpRequest;
+import com.microsoft.rest.v2.http.HttpResponse;
+import com.microsoft.rest.v2.http.UrlBuilder;
+import rx.Single;
+
+/**
+ * A RequestPolicy that adds the provided port to each HttpRequest.
+ */
+public class PortPolicy implements RequestPolicy {
+    private final RequestPolicy nextPolicy;
+    private final int port;
+    private final boolean overwrite;
+
+    PortPolicy(RequestPolicy nextPolicy, int port, boolean overwrite) {
+        this.nextPolicy = nextPolicy;
+        this.port = port;
+        this.overwrite = overwrite;
+    }
+
+    @Override
+    public Single<HttpResponse> sendAsync(HttpRequest request) {
+        final UrlBuilder urlBuilder = UrlBuilder.parse(request.url());
+        if (overwrite || urlBuilder.port() == null) {
+            request.withUrl(urlBuilder.withPort(3000).toString());
+        }
+        return nextPolicy.sendAsync(request);
+    }
+
+    /**
+     * A RequestPolicy.Factory class that creates PortPolicy objects.
+     */
+    public static class Factory implements RequestPolicy.Factory {
+        private final int port;
+        private final boolean overwrite;
+
+        /**
+         * Create a new PortPolicy.Factory object.
+         * @param port The port to set on every HttpRequest.
+         */
+        public Factory(int port) {
+            this(port, true);
+        }
+
+        /**
+         * Create a new PortPolicy.Factory object.
+         * @param port The port to set.
+         * @param overwrite Whether or not to overwrite a HttpRequest's port if it already has one.
+         */
+        public Factory(int port, boolean overwrite) {
+            this.port = port;
+            this.overwrite = overwrite;
+        }
+
+        @Override
+        public RequestPolicy create(RequestPolicy next, Options options) {
+            return new PortPolicy(next, port, overwrite);
+        }
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/RequestPolicy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/RequestPolicy.java
@@ -61,7 +61,7 @@ public interface RequestPolicy {
          * Get the Logger that has been assigned to the HttpPipeline.
          * @return The Logger that has been assigned to the HttpPipeline.
          */
-        public HttpPipeline.Logger getLogger() {
+        public HttpPipeline.Logger logger() {
             return logger;
         }
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/UrlBuilderTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/UrlBuilderTests.java
@@ -192,4 +192,160 @@ public class UrlBuilderTests {
                 .withQueryParameter("otherthing", "otherstuff");
         assertEquals("http://www.othersite.com/mypath?thing=stuff&otherthing=otherstuff", builder.toString());
     }
+
+    @Test
+    public void parseWithNull() {
+        final UrlBuilder builder = UrlBuilder.parse(null);
+        assertEquals("", builder.toString());
+    }
+
+    @Test
+    public void parseWithEmpty() {
+        final UrlBuilder builder = UrlBuilder.parse("");
+        assertEquals("", builder.toString());
+    }
+
+    @Test
+    public void parseWithHost() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com");
+        assertEquals("www.bing.com", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHost() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com");
+        assertEquals("https://www.bing.com", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPort() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com:8080");
+        assertEquals("www.bing.com:8080", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPort() {
+        final UrlBuilder builder = UrlBuilder.parse("ftp://www.bing.com:8080");
+        assertEquals("ftp://www.bing.com:8080", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPath() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com/my/path");
+        assertEquals("www.bing.com/my/path", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPath() {
+        final UrlBuilder builder = UrlBuilder.parse("ftp://www.bing.com/my/path");
+        assertEquals("ftp://www.bing.com/my/path", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPortAndPath() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com:1234/my/path");
+        assertEquals("www.bing.com:1234/my/path", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPortAndPath() {
+        final UrlBuilder builder = UrlBuilder.parse("ftp://www.bing.com:2345/my/path");
+        assertEquals("ftp://www.bing.com:2345/my/path", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndOneQueryParameter() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com?a=1");
+        assertEquals("www.bing.com?a=1", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndOneQueryParameter() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com?a=1");
+        assertEquals("https://www.bing.com?a=1", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPortAndOneQueryParameter() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com:123?a=1");
+        assertEquals("www.bing.com:123?a=1", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPortAndOneQueryParameter() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com:987?a=1");
+        assertEquals("https://www.bing.com:987?a=1", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPathAndOneQueryParameter() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com/folder/index.html?a=1");
+        assertEquals("www.bing.com/folder/index.html?a=1", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPathAndOneQueryParameter() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com/image.gif?a=1");
+        assertEquals("https://www.bing.com/image.gif?a=1", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPortAndPathAndOneQueryParameter() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com:123/index.html?a=1");
+        assertEquals("www.bing.com:123/index.html?a=1", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPortAndPathAndOneQueryParameter() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com:987/my/path/again?a=1");
+        assertEquals("https://www.bing.com:987/my/path/again?a=1", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndTwoQueryParameters() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com?a=1&b=2");
+        assertEquals("www.bing.com?a=1&b=2", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndTwoQueryParameters() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com?a=1&b=2");
+        assertEquals("https://www.bing.com?a=1&b=2", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPortAndTwoQueryParameters() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com:123?a=1&b=2");
+        assertEquals("www.bing.com:123?a=1&b=2", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPortAndTwoQueryParameters() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com:987?a=1&b=2");
+        assertEquals("https://www.bing.com:987?a=1&b=2", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPathAndTwoQueryParameters() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com/folder/index.html?a=1&b=2");
+        assertEquals("www.bing.com/folder/index.html?a=1&b=2", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPathAndTwoQueryParameters() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com/image.gif?a=1&b=2");
+        assertEquals("https://www.bing.com/image.gif?a=1&b=2", builder.toString());
+    }
+
+    @Test
+    public void parseWithHostAndPortAndPathAndTwoQueryParameters() {
+        final UrlBuilder builder = UrlBuilder.parse("www.bing.com:123/index.html?a=1&b=2");
+        assertEquals("www.bing.com:123/index.html?a=1&b=2", builder.toString());
+    }
+
+    @Test
+    public void parseWithProtocolAndHostAndPortAndPathAndTwoQueryParameters() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com:987/my/path/again?a=1&b=2");
+        assertEquals("https://www.bing.com:987/my/path/again?a=1&b=2", builder.toString());
+    }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/UrlBuilderTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/UrlBuilderTests.java
@@ -195,14 +195,12 @@ public class UrlBuilderTests {
 
     @Test
     public void parseWithNull() {
-        final UrlBuilder builder = UrlBuilder.parse(null);
-        assertEquals("", builder.toString());
+        assertNull(UrlBuilder.parse(null));
     }
 
     @Test
     public void parseWithEmpty() {
-        final UrlBuilder builder = UrlBuilder.parse("");
-        assertEquals("", builder.toString());
+        assertNull(UrlBuilder.parse(""));
     }
 
     @Test
@@ -347,5 +345,11 @@ public class UrlBuilderTests {
     public void parseWithProtocolAndHostAndPortAndPathAndTwoQueryParameters() {
         final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com:987/my/path/again?a=1&b=2");
         assertEquals("https://www.bing.com:987/my/path/again?a=1&b=2", builder.toString());
+    }
+
+    @Test
+    public void parseWithColonInPath() {
+        final UrlBuilder builder = UrlBuilder.parse("https://www.bing.com/my:/path");
+        assertEquals("https://www.bing.com/my:/path", builder.toString());
     }
 }


### PR DESCRIPTION
I added this method because I need to modify a URL in autorest.java and I need to check if a port already exists. If it doesn't, then I need to add it. java.net.URL doesn't allow me to check if the port already exists, otherwise I would've just used that.