### PR TITLE
AsyncInputStream and null body length

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -490,6 +490,12 @@ public class RestProxy implements InvocationHandler {
                 });
             }
             asyncResult = responseBodyBytesAsync;
+        } else if (entityTypeToken.isSubtypeOf(AsyncInputStream.class)) {
+            AsyncInputStream stream = new AsyncInputStream(
+                    response.streamBodyAsync(),
+                    Integer.parseInt(response.headerValue("Content-Length")),
+                    false);
+            asyncResult = Maybe.just(stream);
         } else if (isFlowableByteArray(entityTypeToken)) {
             asyncResult = Maybe.just(response.streamBodyAsync());
         } else {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -283,7 +283,9 @@ public class RestProxy implements InvocationHandler {
         }
 
         final Object bodyContentObject = methodParser.body(args);
-        if (bodyContentObject != null) {
+        if (bodyContentObject == null) {
+            request.headers().set("Content-Length", "0");
+        } else {
             String contentType = methodParser.bodyContentType();
             if (contentType == null || contentType.isEmpty()) {
                 contentType = request.headers().value("Content-Type");

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -1321,6 +1321,9 @@ public abstract class RestProxyTests {
     interface DownloadService {
         @GET("/bytes/30720")
         RestResponse<Void, Flowable<byte[]>> getBytes();
+
+        @GET("/bytes/30720")
+        RestResponse<Void, AsyncInputStream> getBytesAsyncInputStream();
     }
 
     @Test
@@ -1328,6 +1331,16 @@ public abstract class RestProxyTests {
         RestResponse<Void, Flowable<byte[]>> response = createService(DownloadService.class).getBytes();
         final AtomicInteger count = new AtomicInteger();
         for (byte[] bytes : response.body().blockingIterable()) {
+            count.addAndGet(bytes.length);
+        }
+        assertEquals(30720, count.intValue());
+    }
+
+    @Test
+    public void SimpleDownloadAsyncInputStreamTest() {
+        RestResponse<Void, AsyncInputStream> response = createService(DownloadService.class).getBytesAsyncInputStream();
+        final AtomicInteger count = new AtomicInteger();
+        for (byte[] bytes : response.body().content().blockingIterable()) {
             count.addAndGet(bytes.length);
         }
         assertEquals(30720, count.intValue());


### PR DESCRIPTION
Small fixes to support AsyncInputStream return type and to add a Content-Length: 0 header when the request has no body.

I'm thinking it'll be simplest to have AsyncInputStream instead of Flowable<byte[]> for both download and upload for consistency. Also, AsyncInputStream may acquire a `close()` method down the line which would dispose of an unwanted connection a bit more elegantly than `stream.content().subscribe().dispose()`.