### PR TITLE
Cancellation for file uploads

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -152,6 +152,7 @@ public final class NettyClient extends HttpClient {
 
                             if (responseEmitter.isDisposed()) {
                                 channel.close();
+                                channelPool.release(channel);
                                 return;
                             }
 
@@ -164,6 +165,7 @@ public final class NettyClient extends HttpClient {
                                     isDisposed = true;
                                     if (!inboundHandler.didEmitHttpResponse) {
                                         channel.close();
+                                        channelPool.release(channel);
                                     }
                                 }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -33,6 +33,7 @@ import io.reactivex.FlowableSubscriber;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
+import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -189,8 +190,18 @@ public final class NettyClient extends HttpClient {
                                                 }
                                             }
                                         });
-                            } else if (request.body() instanceof FileRequestBody) {
-                                final Flowable<ByteBuf> bodyContent = ((FileRequestBody) request.body()).pooledContent();
+                            } else {
+                                Flowable<ByteBuf> bodyContent;
+                                if (request.body() instanceof FileRequestBody) {
+                                    bodyContent = ((FileRequestBody) request.body()).pooledContent();
+                                } else {
+                                    bodyContent = request.body().content().map(new Function<byte[], ByteBuf>() {
+                                        @Override
+                                        public ByteBuf apply(byte[] bytes) throws Exception {
+                                            return Unpooled.wrappedBuffer(bytes);
+                                        }
+                                    });
+                                }
                                 bodyContent.subscribeOn(Schedulers.io()).subscribe(new FlowableSubscriber<ByteBuf>() {
                                     Subscription subscription;
                                     @Override
@@ -214,59 +225,6 @@ public final class NettyClient extends HttpClient {
                                     @Override
                                     public void onNext(ByteBuf buf) {
                                         channel.writeAndFlush(new DefaultHttpContent(buf))
-                                                .addListener(onChannelWriteComplete);
-
-                                        if (channel.isWritable()) {
-                                            subscription.request(1);
-                                        }
-                                    }
-
-                                    @Override
-                                    public void onError(Throwable t) {
-                                        responseEmitter.onError(t);
-                                    }
-
-                                    @Override
-                                    public void onComplete() {
-                                        channel.writeAndFlush(DefaultLastHttpContent.EMPTY_LAST_CONTENT)
-                                                .addListener(new GenericFutureListener<Future<? super Void>>() {
-                                                    @Override
-                                                    public void operationComplete(Future<? super Void> future) throws Exception {
-                                                        if (!future.isSuccess()) {
-                                                            subscription.cancel();
-                                                            responseEmitter.onError(future.cause());
-                                                        } else {
-                                                            channel.read();
-                                                        }
-                                                    }
-                                                });
-                                    }
-                                });
-                            } else {
-                                final Flowable<byte[]> bodyContent = request.body().content();
-                                bodyContent.subscribeOn(Schedulers.io()).subscribe(new FlowableSubscriber<byte[]>() {
-                                    Subscription subscription;
-                                    @Override
-                                    public void onSubscribe(Subscription s) {
-                                        subscription = s;
-                                        inboundHandler.requestContentSubscription = subscription;
-                                        subscription.request(1);
-                                    }
-
-                                    GenericFutureListener<Future<? super Void>> onChannelWriteComplete =
-                                            new GenericFutureListener<Future<? super Void>>() {
-                                                @Override
-                                                public void operationComplete(Future<? super Void> future) throws Exception {
-                                                    if (!future.isSuccess()) {
-                                                        subscription.cancel();
-                                                        responseEmitter.onError(future.cause());
-                                                    }
-                                                }
-                                            };
-
-                                    @Override
-                                    public void onNext(byte[] bytes) {
-                                        channel.writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(bytes)))
                                                 .addListener(onChannelWriteComplete);
 
                                         if (channel.isWritable()) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -205,6 +205,16 @@ public class SharedChannelPool implements ChannelPool {
         throw new UnsupportedOperationException("Please pass host & port to shared channel pool.");
     }
 
+    /**
+     * Closes the channel and releases it back to the pool.
+     * @param channel the channel to close and release.
+     * @return a Future representing the operation.
+     */
+    public Future<Void> closeAndRelease(final Channel channel) {
+        channel.close();
+        return release(channel);
+    }
+
     @Override
     public Future<Void> release(final Channel channel) {
         return this.release(channel, this.bootstrap.config().group().next().<Void>newPromise());


### PR DESCRIPTION
This makes it so when a Single<HttpResponse> coming from NettyClient is disposed before completion, the channel will be closed, causing the ongoing upload to be canceled.

Also adds several checks to responseEmitter.isDisposed before emitting errors. This is because RxJava will dump big stack traces into your logs if you try to emit an error from a stream that's already been disposed. These are errors people probably won't care about considering they canceled the request that caused the error anyway.