### PR TITLE
Add 'innererror' property bag to CloudError contract

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/CloudError.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/CloudError.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.azure;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +34,11 @@ public final class CloudError {
      * Details for the error.
      */
     private List<CloudError> details;
+
+    /**
+     * The inner error.
+     */
+    private ObjectNode innererror;
 
     /**
      * Initializes a new instance of CloudError.
@@ -99,5 +106,12 @@ public final class CloudError {
      */
     public List<CloudError> details() {
         return details;
+    }
+
+    /**
+     * @return the inner error
+     */
+    public ObjectNode innererror() {
+        return innererror;
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
@@ -59,7 +59,8 @@ final class CloudErrorDeserializer extends JsonDeserializer<CloudError> {
         nodeContent = nodeContent.replaceFirst("(?i)\"code\"", "\"code\"")
                 .replaceFirst("(?i)\"message\"", "\"message\"")
                 .replaceFirst("(?i)\"target\"", "\"target\"")
-                .replaceFirst("(?i)\"details\"", "\"details\"");
+                .replaceFirst("(?i)\"details\"", "\"details\"")
+                .replaceFirst("(?i)\"innererror\"", "\"innererror\"");
         JsonParser parser = new JsonFactory().createParser(nodeContent);
         parser.setCodec(mapper);
         return parser.readValueAs(CloudError.class);

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/CloudErrorDeserializerTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/CloudErrorDeserializerTests.java
@@ -6,23 +6,13 @@
 
 package com.microsoft.azure;
 
-import com.microsoft.azure.CloudError;
 import com.microsoft.azure.serializer.AzureJacksonAdapter;
 import com.microsoft.rest.interceptors.RequestIdHeaderInterceptor;
 import com.microsoft.rest.RestClient;
-import com.microsoft.rest.retry.RetryHandler;
-import okhttp3.Interceptor;
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.Response;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
-
 public class CloudErrorDeserializerTests {
-    private static final String REQUEST_ID_HEADER = "x-ms-client-request-id";
-
     @Test
     public void errorDeserializedFully() throws Exception {
         RestClient restClient = new RestClient.Builder()

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/CloudErrorDeserializerTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/CloudErrorDeserializerTests.java
@@ -6,21 +6,16 @@
 
 package com.microsoft.azure;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.serializer.AzureJacksonAdapter;
-import com.microsoft.rest.interceptors.RequestIdHeaderInterceptor;
-import com.microsoft.rest.RestClient;
+import com.microsoft.rest.protocol.SerializerAdapter;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class CloudErrorDeserializerTests {
     @Test
     public void errorDeserializedFully() throws Exception {
-        RestClient restClient = new RestClient.Builder()
-                .withBaseUrl("http://localhost")
-                .withSerializerAdapter(new AzureJacksonAdapter())
-                .withResponseBuilderFactory(new AzureResponseBuilder.Factory())
-                .withInterceptor(new RequestIdHeaderInterceptor())
-                .build();
+        SerializerAdapter<ObjectMapper> serializerAdapter = new AzureJacksonAdapter();
         String bodyString =
             "{" +
             "    \"error\": {" +
@@ -39,7 +34,7 @@ public class CloudErrorDeserializerTests {
             "        }" +
             "    }" +
             "}";
-        CloudError cloudError = restClient.serializerAdapter().deserialize(bodyString, CloudError.class);
+        CloudError cloudError = serializerAdapter.deserialize(bodyString, CloudError.class);
 
         Assert.assertEquals("BadArgument", cloudError.code());
         Assert.assertEquals("The provided database ‘foo’ has an invalid username.", cloudError.message());

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/CloudErrorDeserializerTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/CloudErrorDeserializerTests.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure;
+
+import com.microsoft.azure.CloudError;
+import com.microsoft.azure.serializer.AzureJacksonAdapter;
+import com.microsoft.rest.interceptors.RequestIdHeaderInterceptor;
+import com.microsoft.rest.RestClient;
+import com.microsoft.rest.retry.RetryHandler;
+import okhttp3.Interceptor;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class CloudErrorDeserializerTests {
+    private static final String REQUEST_ID_HEADER = "x-ms-client-request-id";
+
+    @Test
+    public void errorDeserializedFully() throws Exception {
+        RestClient restClient = new RestClient.Builder()
+                .withBaseUrl("http://localhost")
+                .withSerializerAdapter(new AzureJacksonAdapter())
+                .withResponseBuilderFactory(new AzureResponseBuilder.Factory())
+                .withInterceptor(new RequestIdHeaderInterceptor())
+                .build();
+        String bodyString =
+            "{" +
+            "    \"error\": {" +
+            "        \"code\": \"BadArgument\"," +
+            "        \"message\": \"The provided database ‘foo’ has an invalid username.\"," +
+            "        \"target\": \"query\"," +
+            "        \"details\": [" +
+            "            {" +
+            "                \"code\": \"301\"," +
+            "                \"target\": \"$search\"," +
+            "                \"message\": \"$search query option not supported\"" +
+            "            }" +
+            "        ]," +
+            "        \"innererror\": {" +
+            "            \"customKey\": \"customValue\"" +
+            "        }" +
+            "    }" +
+            "}";
+        CloudError cloudError = restClient.serializerAdapter().deserialize(bodyString, CloudError.class);
+
+        Assert.assertEquals("BadArgument", cloudError.code());
+        Assert.assertEquals("The provided database ‘foo’ has an invalid username.", cloudError.message());
+        Assert.assertEquals("query", cloudError.target());
+        Assert.assertEquals("301", cloudError.details().get(0).code());
+        Assert.assertEquals("customValue", cloudError.innererror().get("customKey").asText());
+    }
+}


### PR DESCRIPTION
The data contract for ARM errors includes `innererror` field which is a property bag with unspecified contents as per [OData 4.0 spec](http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091). This field wasn't used by ARM up until now, but recently there was a change related to Azure Policy that makes heavy use of this property bag. It is already deployed in all regions and consumed by Azure Portal, so now would be a good time to support it in SDKs as well.

The new errors are generated by the ARM Frontdoor itself, so CloudError seems like the most appropriate contract to include it.