### PR TITLE
Use Single.error instead of throw Exceptions.propagate

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -41,7 +41,6 @@ import io.reactivex.Scheduler;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
-import io.reactivex.exceptions.Exceptions;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
@@ -388,7 +387,7 @@ public final class NettyClient extends HttpClient {
                         LoggerFactory.getLogger(getClass()).warn("Got EncoderException: " + throwable.getMessage());
                         return sendRequestInternalAsync(request, proxy);
                     } else {
-                        throw Exceptions.propagate(throwable);
+                        return Single.error(throwable);
                     }
                 }
             });

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -133,7 +133,7 @@ public class RestProxyStressTests {
                             return sendAsync(request);
                         }
                         LoggerFactory.getLogger(getClass()).warn("Unrecoverable exception occurred: " + throwable.getMessage());
-                        throw Exceptions.propagate(throwable);
+                        return Single.error(throwable);
                     }
                 });
             }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
@@ -173,8 +173,8 @@ public class MockHttpClient extends HttpClient {
                 }
             }
         }
-        catch (Exception ignored) {
-            throw Exceptions.propagate(ignored);
+        catch (Exception ex) {
+            return Single.error(ex);
         }
 
         if (response == null) {


### PR DESCRIPTION
This causes a simpler error type to be received by `onErrorResumeNext`. Before, you'd get a CompositeException containing an IOException and a RuntimeException containing the same IOException, and now you get just the IOException.