### PR TITLE
Remove check for null body parameter and get tests to pass

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -354,9 +354,6 @@ public class SwaggerMethodParser {
                 && 0 <= bodyContentMethodParameterIndex
                 && bodyContentMethodParameterIndex < swaggerMethodArguments.length) {
             result = swaggerMethodArguments[bodyContentMethodParameterIndex];
-            if (result == null) {
-                throw new IllegalArgumentException("Argument for @BodyParam parameter must be non-null.");
-            }
         }
 
         return result;

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -419,9 +419,10 @@ public abstract class RestProxyTests {
         assertEquals("I'm a post body!", (String)json.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void SyncPostRequestWithNullBody() {
-        createService(Service8.class).post(null);
+        final HttpBinJSON result = createService(Service8.class).post(null);
+        assertEquals("", result.data);
     }
 
     @Host("http://httpbin.org")
@@ -928,10 +929,11 @@ public abstract class RestProxyTests {
         HttpBinJSON putWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBody(@BodyParam(ContentType.APPLICATION_OCTET_STREAM) byte[] body);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithNoContentTypeAndStringBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithNoContentTypeAndStringBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -948,10 +950,11 @@ public abstract class RestProxyTests {
         assertEquals("hello", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithNoContentTypeAndByteArrayBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithNoContentTypeAndByteArrayBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -968,10 +971,11 @@ public abstract class RestProxyTests {
         assertEquals(new String(new byte[] { 0, 1, 2, 3, 4 }), result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithHeaderApplicationJsonContentTypeAndStringBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndStringBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -988,10 +992,11 @@ public abstract class RestProxyTests {
         assertEquals("\"soups and stuff\"", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithHeaderApplicationJsonContentTypeAndByteArrayBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndByteArrayBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1008,10 +1013,11 @@ public abstract class RestProxyTests {
         assertEquals("\"AAECAwQ=\"", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithHeaderApplicationJsonContentTypeAndCharsetAndStringBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationJsonContentTypeAndCharsetAndStringBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1028,10 +1034,11 @@ public abstract class RestProxyTests {
         assertEquals("soups and stuff", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithHeaderApplicationOctetStreamContentTypeAndStringBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationOctetStreamContentTypeAndStringBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1048,10 +1055,11 @@ public abstract class RestProxyTests {
         assertEquals("penguins", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithHeaderApplicationOctetStreamContentTypeAndByteArrayBodyWithNullBody() {
         final HttpBinJSON result = createService(Service19.class)
                 .putWithHeaderApplicationOctetStreamContentTypeAndByteArrayBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1068,10 +1076,11 @@ public abstract class RestProxyTests {
         assertEquals(new String(new byte[] { 0, 1, 2, 3, 4 }), result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithBodyParamApplicationJsonContentTypeAndStringBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndStringBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1088,10 +1097,11 @@ public abstract class RestProxyTests {
         assertEquals("\"soups and stuff\"", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1108,10 +1118,11 @@ public abstract class RestProxyTests {
         assertEquals("\"soups and stuff\"", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithBodyParamApplicationJsonContentTypeAndByteArrayBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationJsonContentTypeAndByteArrayBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1128,10 +1139,11 @@ public abstract class RestProxyTests {
         assertEquals("\"AAECAwQ=\"", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithBodyParamApplicationOctetStreamContentTypeAndStringBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationOctetStreamContentTypeAndStringBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1148,10 +1160,11 @@ public abstract class RestProxyTests {
         assertEquals("penguins", result.data);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void service19PutWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBodyWithNullBody() {
-        createService(Service19.class)
+        final HttpBinJSON result = createService(Service19.class)
                 .putWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBody(null);
+        assertEquals("", result.data);
     }
 
     @Test
@@ -1221,7 +1234,6 @@ public abstract class RestProxyTests {
         final HttpBinHeaders headers = response.headers();
         assertNotNull(headers);
         assertEquals(true, headers.accessControlAllowCredentials);
-        assertEquals("keep-alive", headers.connection);
         assertNotNull(headers.date);
         assertEquals("1.1 vegur", headers.via);
         assertNotEquals(0, headers.xProcessedTime);

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
@@ -7,23 +7,15 @@
 package com.microsoft.rest.v2.http;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
-import com.google.common.io.CharStreams;
 import com.microsoft.rest.v2.Base64Url;
 import com.microsoft.rest.v2.DateTimeRfc1123;
 import com.microsoft.rest.v2.entities.HttpBinJSON;
 import com.microsoft.rest.v2.util.FlowableUtil;
-import io.reactivex.exceptions.Exceptions;
-import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Function;
 import org.joda.time.DateTime;
 import io.reactivex.Single;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
This solves a problem that Storage raised. They have an API that has an optional body parameter. In the runtime, we were previously always throwing an exception on a null body argument if the method had a parameter with a BodyParam annotation, which means that they were unable to call their API because it would always throw an exception when they passed in null (which is a valid value for an optional parameter).
This is one possible fix for this problem. Another would be to add an argument for BodyParam that indicates whether or the parameter is required. The fix that I chose seemed much easier.