### PR TITLE
Add flag to pretty print JSON HTTP bodies

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/HttpLogDetailLevel.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/HttpLogDetailLevel.java
@@ -27,7 +27,7 @@ public enum HttpLogDetailLevel {
 
     /**
      * Logs everything in BASIC, plus all the request and response body.
-     * Note that only payloads in plain text or plan text encoded in GZIP
+     * Note that only payloads in plain text or plain text encoded in GZIP
      * will be logged.
      */
     BODY,
@@ -36,28 +36,6 @@ public enum HttpLogDetailLevel {
      * Logs everything in HEADERS and BODY.
      */
     BODY_AND_HEADERS;
-
-    // FIXME: this flag is not currently honored
-    private boolean prettyJson = false;
-
-    /**
-     * @return if the JSON payloads will be prettified when log level is set
-     * to BODY or BODY_AND_HEADERS. Default is false.
-     */
-    public boolean isPrettyJson() {
-        return prettyJson;
-    }
-
-    /**
-     * Specifies whether to log prettified JSON.
-     *
-     * @param prettyJson true if JSON paylods are prettified.
-     * @return the enum object
-     */
-    public HttpLogDetailLevel withPrettyJson(boolean prettyJson) {
-        this.prettyJson = prettyJson;
-        return this;
-    }
 
     /**
      * @return a value indicating whether a request's URL should be logged.

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -1374,7 +1374,7 @@ public abstract class RestProxyTests {
 
         final HttpClient httpClient = createHttpClient();
         // Log the body so that body buffering/replay behavior is exercised.
-        final HttpPipeline httpPipeline = HttpPipeline.build(httpClient, new HttpLoggingPolicyFactory(HttpLogDetailLevel.BODY));
+        final HttpPipeline httpPipeline = HttpPipeline.build(httpClient, new HttpLoggingPolicyFactory(HttpLogDetailLevel.BODY, true));
         RestResponse<Void, HttpBinJSON> response = RestProxy.create(FlowableUploadService.class, httpPipeline, serializer).put(stream);
 
         assertEquals("The quick brown fox jumps over the lazy dog", response.body().data);


### PR DESCRIPTION
I removed the prettyJSON field from LogLevel (now called HttpLogDetailLevel) because it seemed wrong to share mutable state between all users of an enum value. It's now an optional argument to HttpLoggingPolicyFactory and I'm actually accounting for it when I log the body. This is helpful when debugging azure-libraries-for-java tests.