### PR TITLE
LRO tweaks

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
@@ -22,11 +22,13 @@ import java.io.IOException;
  */
 public class ProvisioningStatePollStrategy extends PollStrategy {
     private final HttpRequest originalRequest;
+    private final SwaggerMethodParser methodParser;
 
     ProvisioningStatePollStrategy(RestProxy restProxy, SwaggerMethodParser methodParser, HttpRequest originalRequest, String provisioningState, long delayInMilliseconds) {
         super(restProxy, methodParser, delayInMilliseconds);
 
         this.originalRequest = originalRequest;
+        this.methodParser = methodParser;
         setStatus(provisioningState);
     }
 
@@ -53,7 +55,11 @@ public class ProvisioningStatePollStrategy extends PollStrategy {
                                             }
 
                                             if (resource == null || resource.properties() == null || resource.properties().provisioningState() == null) {
-                                                throw new CloudException("The polling response does not contain a valid body", bufferedHttpPollResponse, null);
+                                                if (methodParser.isExpectedResponseStatusCode(bufferedHttpPollResponse.statusCode())) {
+                                                   setStatus(OperationState.SUCCEEDED);
+                                                } else {
+                                                    setStatus(OperationState.FAILED);
+                                                }
                                             }
                                             else if (OperationState.isFailedOrCanceled(resource.properties().provisioningState())) {
                                                 throw new CloudException("Async operation failed with provisioning state: " + resource.properties().provisioningState(), bufferedHttpPollResponse);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -416,10 +416,10 @@ public class RestProxy implements InvocationHandler {
         final int responseStatusCode = response.statusCode();
         final Single<HttpResponse> asyncResult;
         if (!methodParser.isExpectedResponseStatusCode(responseStatusCode, additionalAllowedStatusCodes)) {
-            asyncResult = response.bodyAsStringAsync().map(new Function<String, HttpResponse>() {
+            asyncResult = response.bodyAsStringAsync().flatMap(new Function<String, Single<HttpResponse>>() {
                 @Override
-                public HttpResponse apply(String responseBody) throws Exception {
-                    throw instantiateUnexpectedException(methodParser, response, responseBody);
+                public Single<HttpResponse> apply(String responseBody) throws Exception {
+                    return Single.error(instantiateUnexpectedException(methodParser, response, responseBody));
                 }
             });
         } else {
@@ -475,7 +475,7 @@ public class RestProxy implements InvocationHandler {
         return false;
     }
 
-    private Maybe<?> handleBodyReturnTypeAsync(final HttpResponse response, final SwaggerMethodParser methodParser, final Type entityType) {
+    protected final Maybe<?> handleBodyReturnTypeAsync(final HttpResponse response, final SwaggerMethodParser methodParser, final Type entityType) {
         final TypeToken entityTypeToken = TypeToken.of(entityType);
         final int responseStatusCode = response.statusCode();
         final HttpMethod httpMethod = methodParser.httpMethod();

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -420,12 +420,12 @@ public final class NettyClient extends HttpClient {
 
         @Override
         protected void subscribeActual(Subscriber<? super ByteBuf> s) {
-            if (subscriber != null) {
-                throw new IllegalStateException("Multiple subscription not allowed for response content.");
+            if (subscriber == null) {
+                subscriber = s;
+                subscriber.onSubscribe(this);
+            } else {
+                s.onError(new IllegalStateException("Multiple subscription not allowed for response content."));
             }
-
-            subscriber = s;
-            s.onSubscribe(this);
         }
 
         @Override


### PR DESCRIPTION
- LROs emit the first HttpResponse when polling as well as emitting subsequent polling responses.
- Empty bodies are now tolerated when a ProvisioningStatePollStrategy completes in order to accept the real-world behaviors of `ResourceGroups.delete`.
- Fix in NettyClient where we violated Reactive Streams spec by throwing in onSubscribe(Subscriber) instead of calling `Subscriber.onError`
- Experimental/trivial tweak to `RestProxy.instantiateUnexpectedException` while working with RxJava tracing tools.