### PR TITLE
Perform response deserialization in HttpPipeline

### DIFF
--- a/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/AzureCliCredentials.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/AzureCliCredentials.java
@@ -19,8 +19,6 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Token based credentials for use with a REST Service Client.

--- a/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/AzureCliCredentials.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/AzureCliCredentials.java
@@ -32,7 +32,6 @@ public final class AzureCliCredentials extends AzureTokenCredentials {
     private Map<String, AzureCliSubscription> subscriptions;
     private File azureProfile;
     private File accessTokens;
-    private Lock lock = new ReentrantLock();
 
     private AzureCliCredentials() {
         super(null, null);

--- a/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/http/MockHttpResponse.java
+++ b/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/http/MockHttpResponse.java
@@ -13,9 +13,7 @@ import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 public class MockHttpResponse extends HttpResponse {
     private final static SerializerAdapter<?> serializer = new JacksonAdapter();
@@ -49,7 +47,7 @@ public class MockHttpResponse extends HttpResponse {
         this(statusCode);
 
         try {
-            this.string = serializer.serialize(serializable);
+            this.string = serializer.serialize(serializable, SerializerEncoding.JSON);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -68,11 +66,6 @@ public class MockHttpResponse extends HttpResponse {
     @Override
     public HttpHeaders headers() {
         return new HttpHeaders(headers);
-    }
-
-    @Override
-    public Single<? extends InputStream> bodyAsInputStreamAsync() {
-        return Single.just(new ByteArrayInputStream(byteArray));
     }
 
     @Override

--- a/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/http/MockHttpResponse.java
+++ b/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/http/MockHttpResponse.java
@@ -9,6 +9,7 @@ package com.microsoft.azure.v2.credentials.http;
 import com.microsoft.rest.v2.http.HttpHeaders;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
+import com.microsoft.rest.v2.protocol.SerializerEncoding;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import io.reactivex.Flowable;
 import io.reactivex.Single;

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureAsyncOperationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureAsyncOperationPollStrategy.java
@@ -64,11 +64,11 @@ public final class AzureAsyncOperationPollStrategy extends PollStrategy {
             throw new IllegalStateException("Polling is completed and did not succeed. Cannot create a polling request.");
         }
 
-        return new HttpRequest(fullyQualifiedMethodName(), HttpMethod.GET, pollUrl);
+        return new HttpRequest(fullyQualifiedMethodName(), HttpMethod.GET, pollUrl, createResponseDecoder());
     }
 
     @Override
-    public Single<HttpResponse> updateFromAsync(final HttpResponse httpPollResponse) {
+    public Single<HttpResponse> updateFromAsync(HttpResponse httpPollResponse) {
         return ensureExpectedStatus(httpPollResponse)
                 .flatMap(new Function<HttpResponse, Single<HttpResponse>>() {
                     @Override

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
@@ -300,7 +300,7 @@ public final class AzureProxy extends RestProxy {
                     public Single<PollStrategy> apply(final HttpResponse originalHttpResponse) {
                         final int httpStatusCode = originalHttpResponse.statusCode();
                         final int[] longRunningOperationStatusCodes = new int[] {200, 201, 202};
-                        return Single.just(originalHttpResponse)
+                        return ensureExpectedStatus(originalHttpResponse, methodParser, longRunningOperationStatusCodes)
                                 .flatMap(new Function<HttpResponse, Single<? extends PollStrategy>>() {
                                     @Override
                                     public Single<? extends PollStrategy> apply(HttpResponse response) {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
@@ -10,7 +10,6 @@ import com.google.common.hash.Hashing;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.annotations.AzureHost;
 import com.microsoft.azure.v2.serializer.AzureJacksonAdapter;
-import com.microsoft.rest.v2.RestException;
 import com.microsoft.rest.v2.credentials.ServiceClientCredentials;
 import com.microsoft.rest.v2.http.HttpClient;
 import com.microsoft.rest.v2.http.HttpMethod;

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/CompletedPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/CompletedPollStrategy.java
@@ -37,12 +37,12 @@ public class CompletedPollStrategy extends PollStrategy {
 
     @Override
     HttpRequest createPollRequest() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     Single<HttpResponse> updateFromAsync(HttpResponse httpPollResponse) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/CompletedPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/CompletedPollStrategy.java
@@ -8,6 +8,7 @@ package com.microsoft.azure.v2;
 
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.SwaggerMethodParser;
+import com.microsoft.rest.v2.http.BufferedHttpResponse;
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import io.reactivex.Observable;
@@ -20,7 +21,7 @@ import java.lang.reflect.Type;
  * further polling.
  */
 public class CompletedPollStrategy extends PollStrategy {
-    private final HttpResponse firstHttpResponse;
+    private final BufferedHttpResponse firstHttpResponse;
 
     /**
      * Create a new CompletedPollStrategy.
@@ -31,7 +32,7 @@ public class CompletedPollStrategy extends PollStrategy {
      */
     public CompletedPollStrategy(RestProxy restProxy, SwaggerMethodParser methodParser, HttpResponse firstHttpResponse) {
         super(restProxy, methodParser, 0);
-        this.firstHttpResponse = firstHttpResponse;
+        this.firstHttpResponse = firstHttpResponse.buffer();
         setStatus(OperationState.SUCCEEDED);
     }
 
@@ -55,6 +56,6 @@ public class CompletedPollStrategy extends PollStrategy {
     }
 
     Single<HttpResponse> pollUntilDone() {
-        return Single.just(firstHttpResponse);
+        return Single.<HttpResponse>just(firstHttpResponse);
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/CompletedPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/CompletedPollStrategy.java
@@ -20,19 +20,18 @@ import java.lang.reflect.Type;
  * further polling.
  */
 public class CompletedPollStrategy extends PollStrategy {
-    private final HttpResponse bufferedOriginalHttpResponse;
+    private final HttpResponse firstHttpResponse;
 
     /**
      * Create a new CompletedPollStrategy.
      * @param restProxy The RestProxy that created this PollStrategy.
      * @param methodParser The method parser that describes the service interface method that
      *                     initiated the long running operation.
-     * @param originalHttpResponse The HTTP response to the original HTTP request.
+     * @param firstHttpResponse The HTTP response to the original HTTP request.
      */
-    public CompletedPollStrategy(RestProxy restProxy, SwaggerMethodParser methodParser, HttpResponse originalHttpResponse) {
+    public CompletedPollStrategy(RestProxy restProxy, SwaggerMethodParser methodParser, HttpResponse firstHttpResponse) {
         super(restProxy, methodParser, 0);
-
-        this.bufferedOriginalHttpResponse = originalHttpResponse.buffer();
+        this.firstHttpResponse = firstHttpResponse;
         setStatus(OperationState.SUCCEEDED);
     }
 
@@ -52,10 +51,10 @@ public class CompletedPollStrategy extends PollStrategy {
     }
 
     Observable<OperationStatus<Object>> pollUntilDoneWithStatusUpdates(final HttpRequest originalHttpRequest, final SwaggerMethodParser methodParser, final Type operationStatusResultType) {
-        return createOperationStatusObservable(originalHttpRequest, bufferedOriginalHttpResponse, methodParser, operationStatusResultType);
+        return createOperationStatusObservable(originalHttpRequest, firstHttpResponse, methodParser, operationStatusResultType);
     }
 
     Single<HttpResponse> pollUntilDone() {
-        return Single.just(bufferedOriginalHttpResponse);
+        return Single.just(firstHttpResponse);
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/LocationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/LocationPollStrategy.java
@@ -39,7 +39,7 @@ public final class LocationPollStrategy extends PollStrategy {
 
     @Override
     public HttpRequest createPollRequest() {
-        return new HttpRequest(fullyQualifiedMethodName(), HttpMethod.GET, locationUrl);
+        return new HttpRequest(fullyQualifiedMethodName(), HttpMethod.GET, locationUrl, createResponseDecoder());
     }
 
     @Override

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/LocationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/LocationPollStrategy.java
@@ -44,7 +44,7 @@ public final class LocationPollStrategy extends PollStrategy {
 
     @Override
     public Single<HttpResponse> updateFromAsync(HttpResponse httpPollResponse) {
-        return ensureExpectedStatus(httpPollResponse, new int[] {202})
+        return Single.just(httpPollResponse) // FIXME ensureExpectedStatus(httpPollResponse, new int[] {202})
                 .map(new Function<HttpResponse, HttpResponse>() {
                     @Override
                     public HttpResponse apply(HttpResponse response) throws MalformedURLException {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/LocationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/LocationPollStrategy.java
@@ -44,7 +44,7 @@ public final class LocationPollStrategy extends PollStrategy {
 
     @Override
     public Single<HttpResponse> updateFromAsync(HttpResponse httpPollResponse) {
-        return Single.just(httpPollResponse) // FIXME ensureExpectedStatus(httpPollResponse, new int[] {202})
+        return ensureExpectedStatus(httpPollResponse, new int[] {202})
                 .map(new Function<HttpResponse, HttpResponse>() {
                     @Override
                     public HttpResponse apply(HttpResponse response) throws MalformedURLException {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/PollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/PollStrategy.java
@@ -16,7 +16,6 @@ import com.microsoft.rest.v2.protocol.SerializerEncoding;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import io.reactivex.SingleSource;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
 
@@ -156,19 +155,6 @@ abstract class PollStrategy {
                                 return restProxy.sendHttpRequestAsync(pollRequest);
                             }
                         }))
-                        .onErrorResumeNext(new Function<Throwable, SingleSource<? extends HttpResponse>>() {
-                            @Override
-                            public SingleSource<? extends HttpResponse> apply(Throwable throwable) throws Exception {
-                                if (throwable instanceof RestException) {
-                                    HttpResponse response = ((RestException) throwable).response();
-                                    if (response.statusCode() == 202) {
-                                        return Single.just(response);
-                                    }
-                                }
-
-                                return Single.error(throwable);
-                            }
-                        })
                         .flatMap(new Function<HttpResponse, Single<HttpResponse>>() {
                             @Override
                             public Single<HttpResponse> apply(HttpResponse response) {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/PollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/PollStrategy.java
@@ -122,6 +122,10 @@ abstract class PollStrategy {
         this.status = status;
     }
 
+    protected final HttpResponseDecoder createResponseDecoder() {
+        return new HttpResponseDecoder(methodParser, restProxy.serializer());
+    }
+
     /**
      * Create a new HTTP poll request.
      * @return A new HTTP poll request.
@@ -149,8 +153,7 @@ abstract class PollStrategy {
                         .andThen(Single.defer(new Callable<Single<HttpResponse>>() {
                             @Override
                             public Single<HttpResponse> call() throws Exception {
-                                final HttpRequest pollRequest = createPollRequest()
-                                        .withResponseDecoder(new HttpResponseDecoder(methodParser, restProxy.serializer()));
+                                final HttpRequest pollRequest = createPollRequest();
 
                                 return restProxy.sendHttpRequestAsync(pollRequest);
                             }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
@@ -34,7 +34,7 @@ public final class ProvisioningStatePollStrategy extends PollStrategy {
 
     @Override
     HttpRequest createPollRequest() {
-        return new HttpRequest(originalRequest.callerMethod(), HttpMethod.GET, originalRequest.url());
+        return new HttpRequest(originalRequest.callerMethod(), HttpMethod.GET, originalRequest.url(), createResponseDecoder());
     }
 
     @Override

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
@@ -20,7 +20,7 @@ import java.io.IOException;
  * A PollStrategy that will continue to poll a resource's URL until the resource's provisioning
  * state property is in a completed state.
  */
-public class ProvisioningStatePollStrategy extends PollStrategy {
+public final class ProvisioningStatePollStrategy extends PollStrategy {
     private final HttpRequest originalRequest;
     private final SwaggerMethodParser methodParser;
 
@@ -39,27 +39,35 @@ public class ProvisioningStatePollStrategy extends PollStrategy {
 
     @Override
     Single<HttpResponse> updateFromAsync(HttpResponse pollResponse) {
-        ResourceWithProvisioningState resource = null;
-        try {
-            resource = reserialize(pollResponse.deserializedBody(), ResourceWithProvisioningState.class);
-        } catch (IOException ignored) {
-        }
+        return ensureExpectedStatus(pollResponse)
+                .flatMap(new Function<HttpResponse, Single<HttpResponse>>() {
+                    @Override
+                    public Single<HttpResponse> apply(HttpResponse response) {
+                        final HttpResponse bufferedHttpPollResponse = response.buffer();
+                        return bufferedHttpPollResponse.bodyAsStringAsync()
+                                .map(new Function<String, HttpResponse>() {
+                                    @Override
+                                    public HttpResponse apply(String responseBody) {
+                                        ResourceWithProvisioningState resource = null;
+                                        try {
+                                            resource = deserialize(responseBody, ResourceWithProvisioningState.class);
+                                        } catch (IOException ignored) {
+                                        }
 
-        if (resource == null || resource.properties() == null || resource.properties().provisioningState() == null) {
-            if (methodParser.isExpectedResponseStatusCode(pollResponse.statusCode())) {
-                setStatus(OperationState.SUCCEEDED);
-            } else {
-                setStatus(OperationState.FAILED);
-            }
-        }
-        else if (OperationState.isFailedOrCanceled(resource.properties().provisioningState())) {
-            throw new CloudException("Async operation failed with provisioning state: " + resource.properties().provisioningState(), pollResponse);
-        }
-        else {
-            setStatus(resource.properties().provisioningState());
-        }
-
-        return Single.just(pollResponse);
+                                        if (resource == null || resource.properties() == null || resource.properties().provisioningState() == null) {
+                                            throw new CloudException("The polling response does not contain a valid body", bufferedHttpPollResponse, null);
+                                        }
+                                        else if (OperationState.isFailedOrCanceled(resource.properties().provisioningState())) {
+                                            throw new CloudException("Async operation failed with provisioning state: " + resource.properties().provisioningState(), bufferedHttpPollResponse);
+                                        }
+                                        else {
+                                            setStatus(resource.properties().provisioningState());
+                                        }
+                                        return bufferedHttpPollResponse;
+                                    }
+                                });
+                    }
+                });
     }
 
     @Override

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyTests.java
@@ -6,6 +6,7 @@ import com.microsoft.rest.v2.http.HttpPipeline;
 import com.microsoft.rest.v2.RestException;
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
+import com.microsoft.rest.v2.policy.DecodingPolicyFactory;
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import com.microsoft.rest.v2.InvalidReturnTypeException;
@@ -771,7 +772,7 @@ public class AzureProxyTests {
     }
 
     private static <T> T createMockService(Class<T> serviceClass, MockAzureHttpClient httpClient) {
-        return AzureProxy.create(serviceClass, (AzureEnvironment) null, HttpPipeline.build(httpClient), serializer);
+        return AzureProxy.create(serviceClass, null, HttpPipeline.build(httpClient, new DecodingPolicyFactory()), serializer);
     }
 
     private static void assertContains(String value, String expectedSubstring) {

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyToRestProxyTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyToRestProxyTests.java
@@ -5,6 +5,7 @@ import com.microsoft.rest.v2.http.ContentType;
 import com.microsoft.rest.v2.http.HttpPipeline;
 import com.microsoft.rest.v2.RestException;
 import com.microsoft.rest.v2.RestResponse;
+import com.microsoft.rest.v2.policy.DecodingPolicyFactory;
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import com.microsoft.rest.v2.annotations.BodyParam;
@@ -136,36 +137,6 @@ public abstract class AzureProxyToRestProxyTests {
         createService(Service3.class)
                 .getNothingAsync()
                 .blockingAwait();
-    }
-
-    @Host("http://httpbin.org")
-    private interface Service4 {
-        @GET("bytes/2")
-        @ExpectedResponses({200})
-        InputStream getByteStream();
-
-        @GET("bytes/2")
-        @ExpectedResponses({200})
-        Single<InputStream> getByteStreamAsync();
-    }
-
-    @Test
-    public void SyncGetRequestWithInputStreamReturn() throws IOException {
-        final InputStream byteStream = createService(Service4.class)
-                .getByteStream();
-        final byte[] buffer = new byte[10];
-        assertEquals(2, byteStream.read(buffer));
-        assertEquals(-1, byteStream.read(buffer));
-    }
-
-    @Test
-    public void AsyncGetRequestWithInputStreamReturn() throws IOException {
-        final InputStream byteStream = createService(Service4.class)
-                .getByteStreamAsync()
-                .blockingGet();
-        final byte[] buffer = new byte[10];
-        assertEquals(2, byteStream.read(buffer));
-        assertEquals(-1, byteStream.read(buffer));
     }
 
     @Host("http://httpbin.org")
@@ -776,7 +747,7 @@ public abstract class AzureProxyToRestProxyTests {
 
     private <T> T createService(Class<T> serviceClass) {
         final HttpClient httpClient = createHttpClient();
-        return AzureProxy.create(serviceClass, (AzureEnvironment) null, HttpPipeline.build(httpClient), serializer);
+        return AzureProxy.create(serviceClass, null, HttpPipeline.build(httpClient, new DecodingPolicyFactory()), serializer);
     }
 
     private static void assertContains(String value, String expectedSubstring) {

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpClient.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpClient.java
@@ -7,9 +7,6 @@
 package com.microsoft.azure.v2.http;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
-import com.google.common.io.CharStreams;
 import com.microsoft.azure.v2.AsyncOperationResource;
 import com.microsoft.azure.v2.AzureAsyncOperationPollStrategy;
 import com.microsoft.azure.v2.MockResource;
@@ -24,13 +21,9 @@ import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.util.FlowableUtil;
 import io.reactivex.Single;
-import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Function;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpResponse.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpResponse.java
@@ -9,6 +9,7 @@ package com.microsoft.azure.v2.http;
 import com.microsoft.rest.v2.http.HttpHeaders;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
+import com.microsoft.rest.v2.protocol.SerializerEncoding;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
@@ -48,7 +49,7 @@ public class MockAzureHttpResponse extends HttpResponse {
     private static byte[] serialize(Object serializable) {
         byte[] result = null;
         try {
-            final String serializedString = serializer.serialize(serializable);
+            final String serializedString = serializer.serialize(serializable, SerializerEncoding.JSON);
             result = serializedString == null ? null : serializedString.getBytes();
         } catch (IOException e) {
             e.printStackTrace();

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpResponse.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpResponse.java
@@ -72,11 +72,6 @@ public class MockAzureHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Single<? extends InputStream> bodyAsInputStreamAsync() {
-        return Single.just(new ByteArrayInputStream(bodyBytes));
-    }
-
-    @Override
     public Single<byte[]> bodyAsByteArrayAsync() {
         return Single.just(bodyBytes);
     }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -153,7 +153,7 @@ public class RestProxy implements InvocationHandler {
         }
 
         final URL url = urlBuilder.toURL();
-        final HttpRequest request = new HttpRequest(methodParser.fullyQualifiedMethodName(), methodParser.httpMethod(), url).withResponseDecoder(new HttpResponseDecoder(methodParser, serializer));
+        final HttpRequest request = new HttpRequest(methodParser.fullyQualifiedMethodName(), methodParser.httpMethod(), url, new HttpResponseDecoder(methodParser, serializer));
 
         final Object bodyContentObject = methodParser.body(args);
         if (bodyContentObject == null) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -380,7 +380,7 @@ public class RestProxy implements InvocationHandler {
         return handleRestReturnType(httpRequest, asyncHttpResponse, methodParser, returnType);
     }
 
-    private static final Function<Throwable, Single<?>> warnMissingDecoding = new Function<Throwable, Single<?>>() {
+    private static final Function<Throwable, Single<?>> WARN_MISSING_DECODING = new Function<Throwable, Single<?>>() {
         @Override
         public Single<?> apply(Throwable throwable) throws Exception {
             if (throwable instanceof NoSuchElementException) {
@@ -416,7 +416,7 @@ public class RestProxy implements InvocationHandler {
                 public Single<?> apply(HttpResponse response) throws Exception {
                     return handleRestResponseReturnTypeAsync(response, methodParser, singleTypeParam);
                 }
-            }).onErrorResumeNext(warnMissingDecoding);
+            }).onErrorResumeNext(WARN_MISSING_DECODING);
         }
         else if (returnTypeToken.isSubtypeOf(Observable.class)) {
             throw new InvalidReturnTypeException("RestProxy does not support swagger interface methods (such as " + methodParser.fullyQualifiedMethodName() + "()) with a return type of " + returnType.toString());
@@ -441,7 +441,7 @@ public class RestProxy implements InvocationHandler {
                         public Single<?> apply(HttpResponse httpResponse) throws Exception {
                             return handleRestResponseReturnTypeAsync(httpResponse, methodParser, returnType);
                         }
-                    }).onErrorResumeNext(warnMissingDecoding).blockingGet();
+                    }).onErrorResumeNext(WARN_MISSING_DECODING).blockingGet();
         }
 
         return result;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -23,9 +23,9 @@ import com.microsoft.rest.v2.policy.CredentialsPolicyFactory;
 import com.microsoft.rest.v2.policy.RequestPolicyFactory;
 import com.microsoft.rest.v2.policy.RetryPolicyFactory;
 import com.microsoft.rest.v2.policy.UserAgentPolicyFactory;
+import com.microsoft.rest.v2.protocol.HttpResponseDecoder;
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
-import com.microsoft.rest.v2.protocol.SerializerAdapter.Encoding;
-import com.microsoft.rest.v2.protocol.TypeFactory;
+import com.microsoft.rest.v2.protocol.SerializerEncoding;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
@@ -34,11 +34,9 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import org.joda.time.DateTime;
 import org.reactivestreams.Publisher;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -47,9 +45,8 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.net.URL;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.NoSuchElementException;
 
 /**
  * This class can be used to create a proxy implementation for a provided Swagger generated
@@ -90,131 +87,8 @@ public class RestProxy implements InvocationHandler {
      * Get the SerializerAdapter used by this RestProxy.
      * @return The SerializerAdapter used by this RestProxy.
      */
-    protected SerializerAdapter<?> serializer() {
+    public SerializerAdapter<?> serializer() {
         return serializer;
-    }
-
-    /**
-     * Use this RestProxy's serializer to deserialize the provided String into the provided Type.
-     * @param value The String value to deserialize.
-     * @param resultType The Type of the object to return.
-     * @param wireType The serialized type that is sent across the network.
-     * @param encoding The encoding used in the serialized value.
-     * @throws IOException when serialization fails
-     * @return The deserialized version of the provided String value.
-     */
-    public Object deserialize(String value, Type resultType, Type wireType, SerializerAdapter.Encoding encoding) throws IOException {
-        Object result;
-
-        if (wireType == null) {
-            result = serializer.deserialize(value, resultType, encoding);
-        }
-        else {
-            final Type wireResponseType = constructWireResponseType(resultType, wireType);
-            final Object wireResponse = serializer.deserialize(value, wireResponseType, encoding);
-            result = convertToResultType(wireResponse, resultType, wireType);
-        }
-
-        return result;
-    }
-
-    private Type constructWireResponseType(Type resultType, Type wireType) {
-        Type wireResponseType = resultType;
-
-        if (resultType == byte[].class) {
-            if (wireType == Base64Url.class) {
-                wireResponseType = Base64Url.class;
-            }
-        }
-        else if (resultType == DateTime.class) {
-            if (wireType == DateTimeRfc1123.class) {
-                wireResponseType = DateTimeRfc1123.class;
-            }
-            else if (wireType == UnixTime.class) {
-                wireResponseType = UnixTime.class;
-            }
-        }
-        else {
-            final TypeToken resultTypeToken = TypeToken.of(resultType);
-            if (resultTypeToken.isSubtypeOf(List.class)) {
-                final Type resultElementType = getTypeArgument(resultType);
-                final Type wireResponseElementType = constructWireResponseType(resultElementType, wireType);
-
-                final TypeFactory typeFactory = serializer.getTypeFactory();
-                wireResponseType = typeFactory.create((ParameterizedType) resultType, wireResponseElementType);
-            }
-            else if (resultTypeToken.isSubtypeOf(Map.class) || resultTypeToken.isSubtypeOf(RestResponse.class)) {
-                Type[] typeArguments = getTypeArguments(resultType);
-                final Type resultValueType = typeArguments[1];
-                final Type wireResponseValueType = constructWireResponseType(resultValueType, wireType);
-
-                final TypeFactory typeFactory = serializer.getTypeFactory();
-                wireResponseType = typeFactory.create((ParameterizedType) resultType, new Type[] {typeArguments[0], wireResponseValueType});
-            }
-        }
-        return wireResponseType;
-    }
-
-    private Object convertToResultType(Object wireResponse, Type resultType, Type wireType) {
-        Object result = wireResponse;
-
-        if (wireResponse != null) {
-            if (resultType == byte[].class) {
-                if (wireType == Base64Url.class) {
-                    result = ((Base64Url) wireResponse).decodedBytes();
-                }
-            } else if (resultType == DateTime.class) {
-                if (wireType == DateTimeRfc1123.class) {
-                    result = ((DateTimeRfc1123) wireResponse).dateTime();
-                } else if (wireType == UnixTime.class) {
-                    result = ((UnixTime) wireResponse).dateTime();
-                }
-            } else {
-                final TypeToken resultTypeToken = TypeToken.of(resultType);
-                if (resultTypeToken.isSubtypeOf(List.class)) {
-                    final Type resultElementType = getTypeArgument(resultType);
-
-                    final List<Object> wireResponseList = (List<Object>) wireResponse;
-
-                    final int wireResponseListSize = wireResponseList.size();
-                    for (int i = 0; i < wireResponseListSize; ++i) {
-                        final Object wireResponseElement = wireResponseList.get(i);
-                        final Object resultElement = convertToResultType(wireResponseElement, resultElementType, wireType);
-                        if (wireResponseElement != resultElement) {
-                            wireResponseList.set(i, resultElement);
-                        }
-                    }
-
-                    result = wireResponseList;
-                }
-                else if (resultTypeToken.isSubtypeOf(Map.class)) {
-                    final Type resultValueType = getTypeArguments(resultType)[1];
-
-                    final Map<String, Object> wireResponseMap = (Map<String, Object>) wireResponse;
-
-                    final Set<String> wireResponseKeys = wireResponseMap.keySet();
-                    for (String wireResponseKey : wireResponseKeys) {
-                        final Object wireResponseValue = wireResponseMap.get(wireResponseKey);
-                        final Object resultValue = convertToResultType(wireResponseValue, resultValueType, wireType);
-                        if (wireResponseValue != resultValue) {
-                            wireResponseMap.put(wireResponseKey, resultValue);
-                        }
-                    }
-                } else if (resultTypeToken.isSubtypeOf(RestResponse.class)) {
-                    RestResponse<?, ?> restResponse = (RestResponse<?, ?>) wireResponse;
-                    Object wireResponseBody = restResponse.body();
-
-                    Object resultBody = convertToResultType(wireResponseBody, getTypeArguments(resultType)[1], wireType);
-                    if (wireResponseBody != resultBody) {
-                        result = new RestResponse<>(restResponse.statusCode(), restResponse.headers(), restResponse.rawHeaders(), resultBody);
-                    } else {
-                        result = restResponse;
-                    }
-                }
-            }
-        }
-
-        return result;
     }
 
     /**
@@ -281,7 +155,7 @@ public class RestProxy implements InvocationHandler {
         }
 
         final URL url = urlBuilder.toURL();
-        final HttpRequest request = new HttpRequest(methodParser.fullyQualifiedMethodName(), methodParser.httpMethod(), url);
+        final HttpRequest request = new HttpRequest(methodParser.fullyQualifiedMethodName(), methodParser.httpMethod(), url).withResponseDecoder(new HttpResponseDecoder(methodParser, serializer));
 
         final Object bodyContentObject = methodParser.body(args);
         if (bodyContentObject == null) {
@@ -309,7 +183,7 @@ public class RestProxy implements InvocationHandler {
             }
 
             if (isJson) {
-                final String bodyContentString = serializer.serialize(bodyContentObject, SerializerAdapter.Encoding.JSON);
+                final String bodyContentString = serializer.serialize(bodyContentObject, SerializerEncoding.JSON);
                 request.withBody(bodyContentString);
             }
             else if (isFlowableByteArray(TypeToken.of(methodParser.bodyJavaType()))) {
@@ -327,7 +201,7 @@ public class RestProxy implements InvocationHandler {
                 }
             }
             else {
-                final String bodyContentString = serializer.serialize(bodyContentObject, bodyEncoding(request.headers()));
+                final String bodyContentString = serializer.serialize(bodyContentObject, SerializerEncoding.fromHeaders(request.headers()));
                 request.withBody(bodyContentString);
             }
         }
@@ -365,7 +239,7 @@ public class RestProxy implements InvocationHandler {
 
             final Object exceptionBody = responseContent.isEmpty() || !isSerializableContentType
                     ? null
-                    : serializer.deserialize(responseContent, exceptionBodyType, bodyEncoding(response.headers()));
+                    : serializer.deserialize(responseContent, exceptionBodyType, SerializerEncoding.fromHeaders(response.headers()));
 
             result = exceptionConstructor.newInstance("Status code " + responseStatusCode + ", " + bodyRepresentation, response, exceptionBody);
         } catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException | JsonParseException e) {
@@ -430,16 +304,13 @@ public class RestProxy implements InvocationHandler {
         final Single<?> asyncResult;
         if (entityTypeToken.isSubtypeOf(RestResponse.class)) {
             final Type[] deserializedTypes = getTypeArguments(entityType);
-            final Type deserializedHeadersType = deserializedTypes[0];
             final Type bodyType = deserializedTypes[1];
             final HttpHeaders responseHeaders = response.headers();
-            final Object deserializedHeaders = TypeToken.of(deserializedHeadersType).isSubtypeOf(Void.class)
-                    ? null
-                    : deserializeHeaders(responseHeaders, deserializedHeadersType);
+            final Object deserializedHeaders = response.deserializedHeaders();
 
             final TypeToken bodyTypeToken = TypeToken.of(bodyType);
             if (bodyTypeToken.isSubtypeOf(Void.class)) {
-                asyncResult = Single.just(new RestResponse<>(responseStatusCode, deserializedHeaders, responseHeaders.toMap(), (Void) null));
+                asyncResult = Single.just(new RestResponse<>(responseStatusCode, deserializedHeaders, responseHeaders.toMap(), null));
             } else {
                 final Map<String, String> rawHeaders = responseHeaders.toMap();
 
@@ -480,8 +351,6 @@ public class RestProxy implements InvocationHandler {
                 && (entityTypeToken.isSubtypeOf(boolean.class) || entityTypeToken.isSubtypeOf(Boolean.class))) {
             boolean isSuccess = (responseStatusCode / 100) == 2;
             asyncResult = Maybe.just(isSuccess);
-        } else if (entityTypeToken.isSubtypeOf(InputStream.class)) {
-            asyncResult = response.bodyAsInputStreamAsync().toMaybe();
         } else if (entityTypeToken.isSubtypeOf(byte[].class)) {
             Maybe<byte[]> responseBodyBytesAsync = response.bodyAsByteArrayAsync().toMaybe();
             if (returnValueWireType == Base64Url.class) {
@@ -496,44 +365,31 @@ public class RestProxy implements InvocationHandler {
         } else if (isFlowableByteArray(entityTypeToken)) {
             asyncResult = Maybe.just(response.streamBodyAsync());
         } else {
-            asyncResult = response
-                    .bodyAsStringAsync()
-                    .flatMapMaybe(new Function<String, Maybe<Object>>() {
-                        @Override
-                        public Maybe<Object> apply(String responseBodyString) throws IOException {
-                            Object result = deserialize(responseBodyString, entityType, returnValueWireType, bodyEncoding(response.headers()));
-                            if (result == null) {
-                                return Maybe.empty();
-                            } else {
-                                return Maybe.just(result);
-                            }
-                        }
-                    });
+            Object result = response.deserializedBody();
+            if (result == null) {
+                asyncResult = Maybe.empty();
+            } else {
+                asyncResult = Maybe.just(result);
+            }
         }
 
         return asyncResult;
     }
 
-    private SerializerAdapter.Encoding bodyEncoding(HttpHeaders headers) {
-        String mimeContentType = headers.value("Content-Type");
-        if (mimeContentType != null) {
-            String[] parts = mimeContentType.split(";");
-            if (parts[0].equalsIgnoreCase("application/xml") || parts[0].equalsIgnoreCase("text/xml")) {
-                return SerializerAdapter.Encoding.XML;
-            }
-        }
-
-        return SerializerAdapter.Encoding.JSON;
-    }
-
-    private Object deserializeHeaders(HttpHeaders headers, Type deserializedHeadersType) throws IOException {
-        final String headersJsonString = serializer.serialize(headers, Encoding.JSON);
-        return deserialize(headersJsonString, deserializedHeadersType, null, Encoding.JSON);
-    }
-
     protected Object handleAsyncHttpResponse(HttpRequest httpRequest, Single<HttpResponse> asyncHttpResponse, SwaggerMethodParser methodParser, Type returnType) {
         return handleRestReturnType(httpRequest, asyncHttpResponse, methodParser, returnType);
     }
+
+    private static final Function<Throwable, Single<?>> warnMissingDecoding = new Function<Throwable, Single<?>>() {
+        @Override
+        public Single<?> apply(Throwable throwable) throws Exception {
+            if (throwable instanceof NoSuchElementException) {
+                return Single.error(new IllegalStateException("No decoded response body was found. DecodingPolicyFactory may be missing from the pipeline.", throwable));
+            } else {
+                return Single.error(throwable);
+            }
+        }
+    };
 
     /**
      * Handle the provided asynchronous HTTP response and return the deserialized value.
@@ -560,7 +416,7 @@ public class RestProxy implements InvocationHandler {
                 public Single<?> apply(HttpResponse response) throws Exception {
                     return handleRestResponseReturnTypeAsync(response, methodParser, singleTypeParam);
                 }
-            });
+            }).onErrorResumeNext(warnMissingDecoding);
         }
         else if (returnTypeToken.isSubtypeOf(Observable.class)) {
             throw new InvalidReturnTypeException("RestProxy does not support swagger interface methods (such as " + methodParser.fullyQualifiedMethodName() + "()) with a return type of " + returnType.toString());
@@ -585,7 +441,7 @@ public class RestProxy implements InvocationHandler {
                         public Single<?> apply(HttpResponse httpResponse) throws Exception {
                             return handleRestResponseReturnTypeAsync(httpResponse, methodParser, returnType);
                         }
-                    }).blockingGet();
+                    }).onErrorResumeNext(warnMissingDecoding).blockingGet();
         }
 
         return result;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -27,7 +27,6 @@ import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.http.HttpHeader;
 import com.microsoft.rest.v2.http.HttpHeaders;
 import com.microsoft.rest.v2.http.HttpMethod;
-import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -27,6 +27,7 @@ import com.microsoft.rest.v2.annotations.QueryParam;
 import com.microsoft.rest.v2.http.HttpHeader;
 import com.microsoft.rest.v2.http.HttpHeaders;
 import com.microsoft.rest.v2.http.HttpMethod;
+import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
@@ -77,5 +77,25 @@ public final class BufferedHttpResponse extends HttpResponse {
         return this;
     }
 
+    @Override
+    public Object deserializedHeaders() {
+        return innerHttpResponse.deserializedHeaders();
+    }
 
+    @Override
+    public HttpResponse withDeserializedHeaders(Object deserializedHeaders) {
+        innerHttpResponse.withDeserializedHeaders(deserializedHeaders);
+        return this;
+    }
+
+    @Override
+    public Object deserializedBody() {
+        return innerHttpResponse.deserializedBody();
+    }
+
+    @Override
+    public HttpResponse withDeserializedBody(Object deserializedBody) {
+        innerHttpResponse.withDeserializedBody(deserializedBody);
+        return this;
+    }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
@@ -58,7 +58,6 @@ public final class BufferedHttpResponse extends HttpResponse {
 
     @Override
     public Flowable<byte[]> streamBodyAsync() {
-        // FIXME: maybe need to enable streaming/collecting in here
         return bodyAsByteArrayAsync().toFlowable();
     }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
@@ -10,9 +10,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-
 /**
  * HTTP response which will buffer the response's body when/if it is read.
  */

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
@@ -45,17 +45,6 @@ public final class BufferedHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Single<? extends InputStream> bodyAsInputStreamAsync() {
-        return bodyAsByteArrayAsync()
-            .map(new Function<byte[], InputStream>() {
-                @Override
-                public InputStream apply(byte[] bytes) {
-                    return new ByteArrayInputStream(bytes);
-                }
-            });
-    }
-
-    @Override
     public Single<byte[]> bodyAsByteArrayAsync() {
         if (body == null) {
             body = innerHttpResponse.bodyAsByteArrayAsync()
@@ -91,4 +80,6 @@ public final class BufferedHttpResponse extends HttpResponse {
     public BufferedHttpResponse buffer() {
         return this;
     }
+
+
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpRequest.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpRequest.java
@@ -109,7 +109,7 @@ public class HttpRequest {
     }
 
     /**
-     * Get the {@link HttpResponseDecoder} which decodes messages sent in response to this HttpRequest
+     * Get the {@link HttpResponseDecoder} which decodes messages sent in response to this HttpRequest.
      * @return the response decoder
      */
     public HttpResponseDecoder responseDecoder() {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpRequest.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpRequest.java
@@ -6,6 +6,7 @@
 
 package com.microsoft.rest.v2.http;
 
+import com.microsoft.rest.v2.protocol.HttpResponseDecoder;
 import io.reactivex.Flowable;
 
 import java.net.URL;
@@ -18,6 +19,7 @@ public class HttpRequest {
     private String callerMethod;
     private HttpMethod httpMethod;
     private URL url;
+    private HttpResponseDecoder responseDecoder;
     private HttpHeaders headers;
     private Flowable<byte[]> body;
 
@@ -107,6 +109,24 @@ public class HttpRequest {
     }
 
     /**
+     * Get the {@link HttpResponseDecoder} which decodes messages sent in response to this HttpRequest
+     * @return the response decoder
+     */
+    public HttpResponseDecoder responseDecoder() {
+        return responseDecoder;
+    }
+
+    /**
+     * Set the {@link HttpResponseDecoder} which decodes messages sent in response to this HttpRequest.
+     * @param responseDecoder the response decoder
+     * @return this HttpRequest
+     */
+    public HttpRequest withResponseDecoder(HttpResponseDecoder responseDecoder) {
+        this.responseDecoder = responseDecoder;
+        return this;
+    }
+
+    /**
      * Get the headers for this request.
      * @return The headers for this request.
      */
@@ -185,6 +205,6 @@ public class HttpRequest {
      */
     public HttpRequest buffer() {
         final HttpHeaders bufferedHeaders = new HttpHeaders(headers);
-        return new HttpRequest(callerMethod, httpMethod, url, bufferedHeaders, body);
+        return new HttpRequest(callerMethod, httpMethod, url, bufferedHeaders, body).withResponseDecoder(responseDecoder);
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpRequest.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpRequest.java
@@ -19,9 +19,9 @@ public class HttpRequest {
     private String callerMethod;
     private HttpMethod httpMethod;
     private URL url;
-    private HttpResponseDecoder responseDecoder;
     private HttpHeaders headers;
     private Flowable<byte[]> body;
+    private final HttpResponseDecoder responseDecoder;
 
     /**
      * Create a new HttpRequest object with the provided HTTP method (GET, POST, PUT, etc.) and the
@@ -29,13 +29,15 @@ public class HttpRequest {
      * @param callerMethod The fully qualified method that was called to invoke this HTTP request.
      * @param httpMethod The HTTP method to use with this request.
      * @param url The URL where this HTTP request should be sent to.
+     * @param responseDecoder the which decodes messages sent in response to this HttpRequest.
      */
-    public HttpRequest(String callerMethod, HttpMethod httpMethod, URL url) {
+    public HttpRequest(String callerMethod, HttpMethod httpMethod, URL url, HttpResponseDecoder responseDecoder) {
         this.callerMethod = callerMethod;
         this.httpMethod = httpMethod;
         this.url = url;
         this.headers = new HttpHeaders();
         this.body = null;
+        this.responseDecoder = responseDecoder;
     }
 
     /**
@@ -45,13 +47,15 @@ public class HttpRequest {
      * @param url The URL where this HTTP request should be sent to.
      * @param headers The HTTP headers to use with this request.
      * @param body The body of this HTTP request.
+     * @param responseDecoder the which decodes messages sent in response to this HttpRequest.
      */
-    public HttpRequest(String callerMethod, HttpMethod httpMethod, URL url, HttpHeaders headers, Flowable<byte[]> body) {
+    public HttpRequest(String callerMethod, HttpMethod httpMethod, URL url, HttpHeaders headers, Flowable<byte[]> body, HttpResponseDecoder responseDecoder) {
         this.callerMethod = callerMethod;
         this.httpMethod = httpMethod;
         this.url = url;
         this.headers = headers;
         this.body = body;
+        this.responseDecoder = responseDecoder;
     }
 
     /**
@@ -114,16 +118,6 @@ public class HttpRequest {
      */
     public HttpResponseDecoder responseDecoder() {
         return responseDecoder;
-    }
-
-    /**
-     * Set the {@link HttpResponseDecoder} which decodes messages sent in response to this HttpRequest.
-     * @param responseDecoder the response decoder
-     * @return this HttpRequest
-     */
-    public HttpRequest withResponseDecoder(HttpResponseDecoder responseDecoder) {
-        this.responseDecoder = responseDecoder;
-        return this;
     }
 
     /**
@@ -205,6 +199,6 @@ public class HttpRequest {
      */
     public HttpRequest buffer() {
         final HttpHeaders bufferedHeaders = new HttpHeaders(headers);
-        return new HttpRequest(callerMethod, httpMethod, url, bufferedHeaders, body).withResponseDecoder(responseDecoder);
+        return new HttpRequest(callerMethod, httpMethod, url, bufferedHeaders, body, responseDecoder);
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpResponse.java
@@ -9,13 +9,16 @@ package com.microsoft.rest.v2.http;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 
-import java.io.InputStream;
+import java.io.Closeable;
 
 /**
  * This class contains all of the details necessary for reacting to a HTTP response from a
  * HttpResponse.
  */
-public abstract class HttpResponse {
+public abstract class HttpResponse implements Closeable {
+    private Object deserializedHeaders;
+    private Object deserializedBody;
+
     /**
      * Get this response object's HTTP status code.
      * @return This response object's HTTP status code.
@@ -37,12 +40,10 @@ public abstract class HttpResponse {
     public abstract HttpHeaders headers();
 
     /**
-     * Get this response object's body as an InputStream. If this response object doesn't have a
-     * body, then null will be returned.
-     * @return This response object's body as an InputStream. If this response object doesn't have a
-     * body, then null will be returned.
+     * Stream this response's body content.
+     * @return This response's body as an asynchronous sequence of byte[].
      */
-    public abstract Single<? extends InputStream> bodyAsInputStreamAsync();
+    public abstract Flowable<byte[]> streamBodyAsync();
 
     /**
      * Get this response object's body as a byte[]. If this response object doesn't have a body,
@@ -51,12 +52,6 @@ public abstract class HttpResponse {
      * then null will be returned.
      */
     public abstract Single<byte[]> bodyAsByteArrayAsync();
-
-    /**
-     * Stream this response's body content.
-     * @return This response's body as an asynchronous sequence of byte[].
-     */
-    public abstract Flowable<byte[]> streamBodyAsync();
 
     /**
      * Get this response object's body as a string. If this response object doesn't have a body,
@@ -71,6 +66,49 @@ public abstract class HttpResponse {
      * @return This HTTP response, with body content buffered into memory.
      */
     public HttpResponse buffer() {
-        return new BufferedHttpResponse(this);
+        return new BufferedHttpResponse(this)
+                .withDeserializedBody(deserializedBody)
+                .withDeserializedHeaders(deserializedHeaders);
+    }
+
+    /**
+     * Closes the stream providing this HttpResponse's content, if any.
+     */
+    public void close() {
+        // no-op
+    }
+
+    /**
+     * @return the deserialized headers, if present. Otherwise, null.
+     */
+    public Object deserializedHeaders() {
+        return deserializedHeaders;
+    }
+
+    /**
+     * Set the deserialized headers on this HttpResponse.
+     * @param deserializedHeaders the deserialized headers
+     * @return this HTTP repsonse
+     */
+    public HttpResponse withDeserializedHeaders(Object deserializedHeaders) {
+        this.deserializedHeaders = deserializedHeaders;
+        return this;
+    }
+
+    /**
+     * @return the deserialized body, if present. Otherwise, null.
+     */
+    public Object deserializedBody() {
+        return deserializedBody;
+    }
+
+    /**
+     * Sets the deserialized body on this HttpResponse.
+     * @param deserializedBody the deserialized body
+     * @return this HTTP response
+     */
+    public HttpResponse withDeserializedBody(Object deserializedBody) {
+        this.deserializedBody = deserializedBody;
+        return this;
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpResponse.java
@@ -65,10 +65,8 @@ public abstract class HttpResponse implements Closeable {
      * Buffers the HTTP response body into memory, allowing the content to be inspected and replayed.
      * @return This HTTP response, with body content buffered into memory.
      */
-    public HttpResponse buffer() {
-        return new BufferedHttpResponse(this)
-                .withDeserializedBody(deserializedBody)
-                .withDeserializedHeaders(deserializedHeaders);
+    public BufferedHttpResponse buffer() {
+        return new BufferedHttpResponse(this);
     }
 
     /**

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
@@ -13,7 +13,6 @@ import io.reactivex.Flowable;
 import io.reactivex.FlowableSubscriber;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Functions;
 import org.reactivestreams.Subscription;
 
 import java.util.List;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
@@ -9,12 +9,13 @@ package com.microsoft.rest.v2.http;
 import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ReferenceCountUtil;
 import io.reactivex.Flowable;
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import org.reactivestreams.Subscription;
 
-import java.io.InputStream;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -60,16 +61,6 @@ class NettyResponse extends HttpResponse {
     }
 
     @Override
-    public Single<? extends InputStream> bodyAsInputStreamAsync() {
-        return collectContent().map(new Function<ByteBuf, InputStream>() {
-            @Override
-            public InputStream apply(ByteBuf byteBuf) {
-                return new ClosableByteBufInputStream(byteBuf);
-            }
-        });
-    }
-
-    @Override
     public Single<byte[]> bodyAsByteArrayAsync() {
         return collectContent().map(new Function<ByteBuf, byte[]>() {
             @Override
@@ -110,20 +101,28 @@ class NettyResponse extends HttpResponse {
         });
     }
 
-    /**
-     * Extends the ByreBufInputStream so that underlying ByteBuf can be returned to pool.
-     */
-    private class ClosableByteBufInputStream extends io.netty.buffer.ByteBufInputStream {
-        private final ByteBuf buffer;
+    @Override
+    public void close() {
+        contentStream.subscribe(new FlowableSubscriber<ByteBuf>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.cancel();
+            }
 
-        ClosableByteBufInputStream(ByteBuf buffer) {
-            super(buffer);
-            this.buffer = buffer;
-        }
+            @Override
+            public void onNext(ByteBuf byteBuf) {
+                // no-op
+            }
 
-        @Override
-        public void close() {
-            ReferenceCountUtil.release(this.buffer);
-        }
+            @Override
+            public void onError(Throwable ignored) {
+                // May receive a "multiple subscription not allowed" error here, but we don't care
+            }
+
+            @Override
+            public void onComplete() {
+                // no-op
+            }
+        });
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/DecodingPolicyFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/DecodingPolicyFactory.java
@@ -1,0 +1,34 @@
+package com.microsoft.rest.v2.policy;
+
+import com.microsoft.rest.v2.http.HttpRequest;
+import com.microsoft.rest.v2.http.HttpResponse;
+import io.reactivex.Single;
+import io.reactivex.SingleSource;
+import io.reactivex.functions.Function;
+
+/**
+ * Creates a RequestPolicy which decodes the response body and headers.
+ */
+public class DecodingPolicyFactory implements RequestPolicyFactory {
+    @Override
+    public RequestPolicy create(RequestPolicy next, RequestPolicyOptions options) {
+        return new SerializationPolicy(next);
+    }
+
+    private class SerializationPolicy implements RequestPolicy {
+        private final RequestPolicy next;
+        private SerializationPolicy(RequestPolicy next) {
+            this.next = next;
+        }
+
+        @Override
+        public Single<HttpResponse> sendAsync(final HttpRequest request) {
+            return next.sendAsync(request).flatMap(new Function<HttpResponse, SingleSource<? extends HttpResponse>>() {
+                @Override
+                public SingleSource<? extends HttpResponse> apply(final HttpResponse response) throws Exception {
+                    return request.responseDecoder().decode(response);
+                }
+            });
+        }
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/DecodingPolicyFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/DecodingPolicyFactory.java
@@ -8,6 +8,7 @@ package com.microsoft.rest.v2.policy;
 
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
+import com.microsoft.rest.v2.protocol.HttpResponseDecoder;
 import io.reactivex.Single;
 import io.reactivex.SingleSource;
 import io.reactivex.functions.Function;
@@ -32,7 +33,12 @@ public final class DecodingPolicyFactory implements RequestPolicyFactory {
             return next.sendAsync(request).flatMap(new Function<HttpResponse, SingleSource<? extends HttpResponse>>() {
                 @Override
                 public SingleSource<? extends HttpResponse> apply(final HttpResponse response) throws Exception {
-                    return request.responseDecoder().decode(response);
+                    HttpResponseDecoder decoder = request.responseDecoder();
+                    if (decoder != null) {
+                        return request.responseDecoder().decode(response);
+                    } else {
+                        return Single.error(new NullPointerException("HttpRequest.responseDecoder() was null when decoding."));
+                    }
                 }
             });
         }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/DecodingPolicyFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/DecodingPolicyFactory.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
 package com.microsoft.rest.v2.policy;
 
 import com.microsoft.rest.v2.http.HttpRequest;
@@ -9,13 +15,13 @@ import io.reactivex.functions.Function;
 /**
  * Creates a RequestPolicy which decodes the response body and headers.
  */
-public class DecodingPolicyFactory implements RequestPolicyFactory {
+public final class DecodingPolicyFactory implements RequestPolicyFactory {
     @Override
     public RequestPolicy create(RequestPolicy next, RequestPolicyOptions options) {
         return new DecodingPolicy(next);
     }
 
-    private class DecodingPolicy implements RequestPolicy {
+    private final class DecodingPolicy implements RequestPolicy {
         private final RequestPolicy next;
         private DecodingPolicy(RequestPolicy next) {
             this.next = next;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/DecodingPolicyFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/DecodingPolicyFactory.java
@@ -12,12 +12,12 @@ import io.reactivex.functions.Function;
 public class DecodingPolicyFactory implements RequestPolicyFactory {
     @Override
     public RequestPolicy create(RequestPolicy next, RequestPolicyOptions options) {
-        return new SerializationPolicy(next);
+        return new DecodingPolicy(next);
     }
 
-    private class SerializationPolicy implements RequestPolicy {
+    private class DecodingPolicy implements RequestPolicy {
         private final RequestPolicy next;
-        private SerializationPolicy(RequestPolicy next) {
+        private DecodingPolicy(RequestPolicy next) {
             this.next = next;
         }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
@@ -73,9 +73,10 @@ public final class HttpResponseDecoder {
         int[] expectedStatuses = methodParser.expectedStatusCodes();
         boolean isErrorStatus = true;
         if (expectedStatuses != null) {
-            for (int i = 0; i < expectedStatuses.length && isErrorStatus; i++) {
-                if (expectedStatuses[i] == response.statusCode()) {
+            for (int expectedStatus : expectedStatuses) {
+                if (expectedStatus == response.statusCode()) {
                     isErrorStatus = false;
+                    break;
                 }
             }
         } else {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
@@ -1,6 +1,11 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
 package com.microsoft.rest.v2.protocol;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.Base64Url;
 import com.microsoft.rest.v2.DateTimeRfc1123;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
@@ -1,0 +1,322 @@
+package com.microsoft.rest.v2.protocol;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.google.common.reflect.TypeToken;
+import com.microsoft.rest.v2.Base64Url;
+import com.microsoft.rest.v2.DateTimeRfc1123;
+import com.microsoft.rest.v2.RestException;
+import com.microsoft.rest.v2.RestResponse;
+import com.microsoft.rest.v2.SwaggerMethodParser;
+import com.microsoft.rest.v2.UnixTime;
+import com.microsoft.rest.v2.http.HttpHeaders;
+import com.microsoft.rest.v2.http.HttpResponse;
+import com.microsoft.rest.v2.util.FlowableUtil;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import io.reactivex.functions.Function;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Deserializes an {@link HttpResponse}.
+ */
+public final class HttpResponseDecoder {
+    private final SwaggerMethodParser methodParser;
+    private final SerializerAdapter<?> serializer;
+
+    /**
+     * Creates an HttpResponseDecoder.
+     * @param methodParser metadata about the Swagger method used for decoding.
+     * @param serializer the serializer
+     */
+    public HttpResponseDecoder(SwaggerMethodParser methodParser, SerializerAdapter<?> serializer) {
+        this.methodParser = methodParser;
+        this.serializer = serializer;
+    }
+
+    /**
+     * Asynchronously decodes an {@link HttpResponse}, deserializing into a response or error value.
+     * @param response the {@link HttpResponse}
+     * @return A {@link Single} containing either the decoded HttpResponse or an error
+     */
+    public Single<HttpResponse> decode(final HttpResponse response) {
+        final Object deserializedHeaders;
+        try {
+            deserializedHeaders = deserializeHeaders(response.headers());
+        } catch (IOException e) {
+            return Single.error(e);
+        }
+
+        final Type returnValueWireType = methodParser.returnValueWireType();
+
+        final TypeToken entityTypeToken = getEntityType();
+
+        boolean isSerializableBody = !FlowableUtil.isFlowableByteArray(entityTypeToken)
+            && !entityTypeToken.isSubtypeOf(Completable.class)
+            && !entityTypeToken.isSubtypeOf(byte[].class)
+            && !entityTypeToken.isSubtypeOf(boolean.class) && !entityTypeToken.isSubtypeOf(Boolean.class)
+            && !entityTypeToken.isSubtypeOf(Void.TYPE) && !entityTypeToken.isSubtypeOf(Void.class);
+
+        Single<HttpResponse> result = ensureExpectedStatus(response, methodParser);
+
+        if (isSerializableBody) {
+            result = result.toCompletable().andThen(response.bodyAsStringAsync().map(new Function<String, HttpResponse>() {
+                @Override
+                public HttpResponse apply(String bodyString) throws Exception {
+                    Object body = deserialize(bodyString, getEntityType().getType(), returnValueWireType, SerializerEncoding.fromHeaders(response.headers()));
+                    return response
+                            .withDeserializedHeaders(deserializedHeaders)
+                            .withDeserializedBody(body);
+                }
+            }));
+        } else {
+            result = result.toCompletable().andThen(Single.just(response.withDeserializedHeaders(deserializedHeaders)));
+        }
+
+        return result;
+    }
+
+    private Object deserialize(String value, Type resultType, Type wireType, SerializerEncoding encoding) throws IOException {
+        Object result;
+
+        if (wireType == null) {
+            result = serializer.deserialize(value, resultType, encoding);
+        }
+        else {
+            final Type wireResponseType = constructWireResponseType(resultType, wireType);
+            final Object wireResponse = serializer.deserialize(value, wireResponseType, encoding);
+            result = convertToResultType(wireResponse, resultType, wireType);
+        }
+
+        return result;
+    }
+
+    private static Type[] getTypeArguments(Type type) {
+        return ((ParameterizedType) type).getActualTypeArguments();
+    }
+
+    private static Type getTypeArgument(Type type) {
+        return getTypeArguments(type)[0];
+    }
+
+    private Type constructWireResponseType(Type resultType, Type wireType) {
+        Type wireResponseType = resultType;
+
+        if (resultType == byte[].class) {
+            if (wireType == Base64Url.class) {
+                wireResponseType = Base64Url.class;
+            }
+        }
+        else if (resultType == DateTime.class) {
+            if (wireType == DateTimeRfc1123.class) {
+                wireResponseType = DateTimeRfc1123.class;
+            }
+            else if (wireType == UnixTime.class) {
+                wireResponseType = UnixTime.class;
+            }
+        }
+        else {
+            final TypeToken resultTypeToken = TypeToken.of(resultType);
+            if (resultTypeToken.isSubtypeOf(List.class)) {
+                final Type resultElementType = getTypeArgument(resultType);
+                final Type wireResponseElementType = constructWireResponseType(resultElementType, wireType);
+
+                final TypeFactory typeFactory = serializer.getTypeFactory();
+                wireResponseType = typeFactory.create((ParameterizedType) resultType, wireResponseElementType);
+            }
+            else if (resultTypeToken.isSubtypeOf(Map.class) || resultTypeToken.isSubtypeOf(RestResponse.class)) {
+                Type[] typeArguments = getTypeArguments(resultType);
+                final Type resultValueType = typeArguments[1];
+                final Type wireResponseValueType = constructWireResponseType(resultValueType, wireType);
+
+                final TypeFactory typeFactory = serializer.getTypeFactory();
+                wireResponseType = typeFactory.create((ParameterizedType) resultType, new Type[] {typeArguments[0], wireResponseValueType});
+            }
+        }
+        return wireResponseType;
+    }
+
+    private Object convertToResultType(Object wireResponse, Type resultType, Type wireType) {
+        Object result = wireResponse;
+
+        if (wireResponse != null) {
+            if (resultType == byte[].class) {
+                if (wireType == Base64Url.class) {
+                    result = ((Base64Url) wireResponse).decodedBytes();
+                }
+            } else if (resultType == DateTime.class) {
+                if (wireType == DateTimeRfc1123.class) {
+                    result = ((DateTimeRfc1123) wireResponse).dateTime();
+                } else if (wireType == UnixTime.class) {
+                    result = ((UnixTime) wireResponse).dateTime();
+                }
+            } else {
+                final TypeToken resultTypeToken = TypeToken.of(resultType);
+                if (resultTypeToken.isSubtypeOf(List.class)) {
+                    final Type resultElementType = getTypeArgument(resultType);
+
+                    final List<Object> wireResponseList = (List<Object>) wireResponse;
+
+                    final int wireResponseListSize = wireResponseList.size();
+                    for (int i = 0; i < wireResponseListSize; ++i) {
+                        final Object wireResponseElement = wireResponseList.get(i);
+                        final Object resultElement = convertToResultType(wireResponseElement, resultElementType, wireType);
+                        if (wireResponseElement != resultElement) {
+                            wireResponseList.set(i, resultElement);
+                        }
+                    }
+
+                    result = wireResponseList;
+                }
+                else if (resultTypeToken.isSubtypeOf(Map.class)) {
+                    final Type resultValueType = getTypeArguments(resultType)[1];
+
+                    final Map<String, Object> wireResponseMap = (Map<String, Object>) wireResponse;
+
+                    final Set<String> wireResponseKeys = wireResponseMap.keySet();
+                    for (String wireResponseKey : wireResponseKeys) {
+                        final Object wireResponseValue = wireResponseMap.get(wireResponseKey);
+                        final Object resultValue = convertToResultType(wireResponseValue, resultValueType, wireType);
+                        if (wireResponseValue != resultValue) {
+                            wireResponseMap.put(wireResponseKey, resultValue);
+                        }
+                    }
+                } else if (resultTypeToken.isSubtypeOf(RestResponse.class)) {
+                    RestResponse<?, ?> restResponse = (RestResponse<?, ?>) wireResponse;
+                    Object wireResponseBody = restResponse.body();
+
+                    Object resultBody = convertToResultType(wireResponseBody, getTypeArguments(resultType)[1], wireType);
+                    if (wireResponseBody != resultBody) {
+                        result = new RestResponse<>(restResponse.statusCode(), restResponse.headers(), restResponse.rawHeaders(), resultBody);
+                    } else {
+                        result = restResponse;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private TypeToken getEntityType() {
+        TypeToken token = TypeToken.of(methodParser.returnType());
+
+        if (token.isSubtypeOf(Single.class) || token.isSubtypeOf(Maybe.class)) {
+            token = TypeToken.of(getTypeArgument(token.getType()));
+        }
+
+        if (token.isSubtypeOf(RestResponse.class)) {
+            token = TypeToken.of(getTypeArguments(token.getType())[1]);
+        }
+
+        return token;
+    }
+
+    private Type getHeadersType() {
+        TypeToken token = TypeToken.of(methodParser.returnType());
+        Type headersType = null;
+
+        if (token.isSubtypeOf(Single.class)) {
+            token = TypeToken.of(getTypeArgument(token.getType()));
+        }
+
+        if (token.isSubtypeOf(RestResponse.class)) {
+            headersType = getTypeArguments(token.getType())[0];
+        }
+
+        return headersType;
+    }
+
+    private Object deserializeHeaders(HttpHeaders headers) throws IOException {
+            final Type deserializedHeadersType = getHeadersType();
+            if (deserializedHeadersType == null) {
+                return null;
+            } else {
+                final String headersJsonString = serializer.serialize(headers, SerializerEncoding.JSON);
+                Object deserializedHeaders = serializer.deserialize(headersJsonString, deserializedHeadersType, SerializerEncoding.JSON);
+                return deserializedHeaders;
+            }
+    }
+
+    private Exception instantiateUnexpectedException(SwaggerMethodParser methodParser, HttpResponse response, String responseContent) {
+        final int responseStatusCode = response.statusCode();
+        final Class<? extends RestException> exceptionType = methodParser.exceptionType();
+        final Class<?> exceptionBodyType = methodParser.exceptionBodyType();
+
+        String contentType = response.headerValue("Content-Type");
+        String bodyRepresentation;
+        if ("application/octet-stream".equalsIgnoreCase(contentType)) {
+            bodyRepresentation = "(" + response.headerValue("Content-Length") + "-byte body)";
+        } else {
+            bodyRepresentation = responseContent.isEmpty() ? "(empty body)" : "\"" + responseContent + "\"";
+        }
+
+        Exception result;
+        try {
+            final Constructor<? extends RestException> exceptionConstructor = exceptionType.getConstructor(String.class, HttpResponse.class, exceptionBodyType);
+
+            boolean isSerializableContentType = contentType == null || contentType.isEmpty()
+                    || contentType.startsWith("application/json")
+                    || contentType.startsWith("text/json")
+                    || contentType.startsWith("application/xml")
+                    || contentType.startsWith("text/xml");
+
+            final Object exceptionBody = responseContent.isEmpty() || !isSerializableContentType
+                    ? null
+                    : serializer.deserialize(responseContent, exceptionBodyType, SerializerEncoding.fromHeaders(response.headers()));
+
+            result = exceptionConstructor.newInstance("Status code " + responseStatusCode + ", " + bodyRepresentation, response, exceptionBody);
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException | JsonParseException e) {
+            String message = "Status code " + responseStatusCode + ", but an instance of "
+                    + exceptionType.getCanonicalName() + " cannot be created."
+                    + " Response body: " + bodyRepresentation;
+
+            result = new IOException(message, e);
+        } catch (IOException e) {
+            result = e;
+        }
+
+        return result;
+    }
+
+    Single<HttpResponse> ensureExpectedStatus(final HttpResponse response, final SwaggerMethodParser methodParser) {
+        return ensureExpectedStatus(response, methodParser, null);
+    }
+
+    /**
+     * Ensure that the provided HttpResponse has a status code that is defined in the provided
+     * SwaggerMethodParser or is in the int[] of additional allowed status codes. If the
+     * HttpResponse's status code is not allowed, then an exception will be thrown.
+     * @param response The HttpResponse to check.
+     * @param methodParser The method parser that contains information about the service interface
+     *                     method that initiated the HTTP request.
+     * @param additionalAllowedStatusCodes Additional allowed status codes that are permitted based
+     *                                     on the context of the HTTP request.
+     * @return An async-version of the provided HttpResponse.
+     */
+    public Single<HttpResponse> ensureExpectedStatus(final HttpResponse response, final SwaggerMethodParser methodParser, int[] additionalAllowedStatusCodes) {
+        final int responseStatusCode = response.statusCode();
+        final Single<HttpResponse> asyncResult;
+        if (!methodParser.isExpectedResponseStatusCode(responseStatusCode, additionalAllowedStatusCodes)) {
+            asyncResult = response.bodyAsStringAsync().flatMap(new Function<String, Single<HttpResponse>>() {
+                @Override
+                public Single<HttpResponse> apply(String responseBody) throws Exception {
+                    return Single.error(instantiateUnexpectedException(methodParser, response, responseBody));
+                }
+            });
+        } else {
+            asyncResult = Single.just(response);
+        }
+
+        return asyncResult;
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/SerializerAdapter.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/SerializerAdapter.java
@@ -7,7 +7,6 @@
 package com.microsoft.rest.v2.protocol;
 
 import com.microsoft.rest.v2.CollectionFormat;
-import com.microsoft.rest.v2.http.HttpHeaders;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/SerializerAdapter.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/SerializerAdapter.java
@@ -7,6 +7,7 @@
 package com.microsoft.rest.v2.protocol;
 
 import com.microsoft.rest.v2.CollectionFormat;
+import com.microsoft.rest.v2.http.HttpHeaders;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -20,23 +21,10 @@ import java.util.List;
  */
 public interface SerializerAdapter<T> {
     /**
-     * Represents which encoding to use for serialization.
-     */
-    enum Encoding {
-        /**
-         * JavaScript Object Notation.
-         */
-        JSON,
-
-        /**
-         * Extensible Markup Language.
-         */
-        XML
-    }
-
-    /**
+     * @deprecated original serializer type should not be exposed
      * @return the adapted original serializer
      */
+    @Deprecated
     T serializer();
 
     /**
@@ -47,7 +35,7 @@ public interface SerializerAdapter<T> {
      * @return the serialized string. Null if the object to serialize is null.
      * @throws IOException exception from serialization.
      */
-    String serialize(Object object, Encoding encoding) throws IOException;
+    String serialize(Object object, SerializerEncoding encoding) throws IOException;
 
     /**
      * @deprecated Use serialize(Object, Encoding) instead.
@@ -104,7 +92,7 @@ public interface SerializerAdapter<T> {
      * @return the deserialized object.
      * @throws IOException exception in deserialization
      */
-    <U> U deserialize(String value, Type type, Encoding encoding) throws IOException;
+    <U> U deserialize(String value, Type type, SerializerEncoding encoding) throws IOException;
 
     /**
      * Get the TypeFactory for this SerializerAdapter.

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/SerializerEncoding.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/SerializerEncoding.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
 package com.microsoft.rest.v2.protocol;
 
 
@@ -17,6 +23,11 @@ public enum SerializerEncoding {
      */
     XML;
 
+    /**
+     * Determines the serializer encoding to use based on the Content-Type header.
+     * @param headers the headers to check the encoding for
+     * @return the serializer encoding to use for the body
+     */
     public static SerializerEncoding fromHeaders(HttpHeaders headers) {
         String mimeContentType = headers.value("Content-Type");
         if (mimeContentType != null) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/SerializerEncoding.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/SerializerEncoding.java
@@ -1,0 +1,31 @@
+package com.microsoft.rest.v2.protocol;
+
+
+import com.microsoft.rest.v2.http.HttpHeaders;
+
+/**
+ * Represents which encoding to use for serialization.
+ */
+public enum SerializerEncoding {
+    /**
+     * JavaScript Object Notation.
+     */
+    JSON,
+
+    /**
+     * Extensible Markup Language.
+     */
+    XML;
+
+    public static SerializerEncoding fromHeaders(HttpHeaders headers) {
+        String mimeContentType = headers.value("Content-Type");
+        if (mimeContentType != null) {
+            String[] parts = mimeContentType.split(";");
+            if (parts[0].equalsIgnoreCase("application/xml") || parts[0].equalsIgnoreCase("text/xml")) {
+                return XML;
+            }
+        }
+
+        return JSON;
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/serializer/JacksonAdapter.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/serializer/JacksonAdapter.java
@@ -19,6 +19,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.microsoft.rest.v2.CollectionFormat;
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
+import com.microsoft.rest.v2.protocol.SerializerEncoding;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -70,12 +71,12 @@ public class JacksonAdapter implements SerializerAdapter<ObjectMapper> {
     }
 
     @Override
-    public String serialize(Object object, Encoding encoding) throws IOException {
+    public String serialize(Object object, SerializerEncoding encoding) throws IOException {
         if (object == null) {
             return null;
         }
         StringWriter writer = new StringWriter();
-        if (encoding == Encoding.XML) {
+        if (encoding == SerializerEncoding.XML) {
             xmlMapper.writeValue(writer, object);
         } else {
             serializer().writeValue(writer, object);
@@ -86,7 +87,7 @@ public class JacksonAdapter implements SerializerAdapter<ObjectMapper> {
 
     @Override
     public String serialize(Object object) throws IOException {
-        return serialize(object, Encoding.JSON);
+        return serialize(object, SerializerEncoding.JSON);
     }
 
     @Override
@@ -121,14 +122,14 @@ public class JacksonAdapter implements SerializerAdapter<ObjectMapper> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T deserialize(String value, final Type type, Encoding encoding) throws IOException {
+    public <T> T deserialize(String value, final Type type, SerializerEncoding encoding) throws IOException {
         if (value == null || value.isEmpty()) {
             return null;
         }
 
         final JacksonTypeFactory typeFactory = getTypeFactory();
         final JavaType javaType = typeFactory.create(type);
-        if (encoding == Encoding.XML) {
+        if (encoding == SerializerEncoding.XML) {
             return (T) xmlMapper.readValue(value, javaType);
         } else {
             return (T) serializer().readValue(value, javaType);
@@ -138,7 +139,7 @@ public class JacksonAdapter implements SerializerAdapter<ObjectMapper> {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T deserialize(String value, final Type type) throws IOException {
-        return deserialize(value, type, Encoding.JSON);
+        return deserialize(value, type, SerializerEncoding.JSON);
     }
 
     /**

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -8,6 +8,7 @@ package com.microsoft.rest.v2.util;
 
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
+import com.google.common.reflect.TypeToken;
 import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableOnSubscribe;
@@ -21,6 +22,8 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.CompletionHandler;
@@ -31,6 +34,23 @@ import java.util.concurrent.atomic.AtomicLong;
  * Contains helper methods for dealing with Flowables.
  */
 public class FlowableUtil {
+    /**
+     * Checks if a type is Flowable&lt;byte[]&gt;.
+     *
+     * @param entityTypeToken
+     * @return whether the type represents a Flowable that emits byte arrays
+     */
+    public static boolean isFlowableByteArray(TypeToken entityTypeToken) {
+        if (entityTypeToken.isSubtypeOf(Flowable.class)) {
+            final Type innerType = ((ParameterizedType) entityTypeToken.getType()).getActualTypeArguments()[0];
+            final TypeToken innerTypeToken = TypeToken.of(innerType);
+            if (innerTypeToken.isSubtypeOf(byte[].class)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Collects byte arrays emitted by a Flowable into a Single.
      * @param content A stream which emits byte arrays.

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -37,7 +37,7 @@ public class FlowableUtil {
     /**
      * Checks if a type is Flowable&lt;byte[]&gt;.
      *
-     * @param entityTypeToken
+     * @param entityTypeToken the entity to check
      * @return whether the type represents a Flowable that emits byte arrays
      */
     public static boolean isFlowableByteArray(TypeToken entityTypeToken) {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/CredentialsTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/CredentialsTests.java
@@ -49,7 +49,7 @@ public class CredentialsTests {
                 new CredentialsPolicyFactory(credentials),
                 auditorFactory);
 
-        HttpRequest request = new HttpRequest("basicCredentialsTest", HttpMethod.GET, new URL("http://localhost"));
+        HttpRequest request = new HttpRequest("basicCredentialsTest", HttpMethod.GET, new URL("http://localhost"), null);
         pipeline.sendRequestAsync(request).blockingGet();
     }
 
@@ -76,7 +76,7 @@ public class CredentialsTests {
                 new CredentialsPolicyFactory(credentials),
                 auditorFactory);
 
-        HttpRequest request = new HttpRequest("basicCredentialsTest", HttpMethod.GET, new URL("http://localhost"));
+        HttpRequest request = new HttpRequest("basicCredentialsTest", HttpMethod.GET, new URL("http://localhost"), null);
         pipeline.sendRequestAsync(request).blockingGet();
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithMockTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithMockTests.java
@@ -183,9 +183,9 @@ public class RestProxyWithMockTests extends RestProxyTests {
         try {
             service.get();
             fail();
-        } catch (RuntimeException ex) {
+        } catch (RestException ex) {
             assertContains(ex.getMessage(), "Status code 200");
-            assertContains(ex.getMessage(), "Response body: \"BAD JSON\"");
+            assertContains(ex.getMessage(), "\"BAD JSON\"");
         }
     }
 
@@ -231,9 +231,9 @@ public class RestProxyWithMockTests extends RestProxyTests {
         try {
             service.get();
             fail();
-        } catch (RuntimeException ex) {
+        } catch (RestException ex) {
             assertContains(ex.getMessage(), "Status code 200");
-            assertContains(ex.getMessage(), "Response body: \"BAD JSON\"");
+            assertContains(ex.getMessage(), "\"BAD JSON\"");
         }
     }
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyXMLTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyXMLTests.java
@@ -117,7 +117,7 @@ public class RestProxyXMLTests {
     public void canWriteXMLRequest() throws Exception {
         URL url = getClass().getClassLoader().getResource("GetContainerACLs.xml");
         byte[] bytes = Files.readAllBytes(Paths.get(url.toURI()));
-        HttpRequest request = new HttpRequest("canWriteXMLRequest", HttpMethod.PUT, new URL("http://unused/SetContainerACLs"));
+        HttpRequest request = new HttpRequest("canWriteXMLRequest", HttpMethod.PUT, new URL("http://unused/SetContainerACLs"), null);
         request.withBody(bytes);
 
         SignedIdentifierInner si = new SignedIdentifierInner();

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyXMLTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyXMLTests.java
@@ -26,7 +26,9 @@ import com.microsoft.rest.v2.http.HttpPipeline;
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.http.MockHttpResponse;
+import com.microsoft.rest.v2.policy.DecodingPolicyFactory;
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
+import com.microsoft.rest.v2.protocol.SerializerEncoding;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import com.microsoft.rest.v2.util.FlowableUtil;
 import io.reactivex.functions.BiConsumer;
@@ -85,7 +87,7 @@ public class RestProxyXMLTests {
 
     @Test
     public void canReadXMLResponse() throws Exception {
-        MyXMLService myXMLService = RestProxy.create(MyXMLService.class, HttpPipeline.build(new MockXMLHTTPClient()), new JacksonAdapter());
+        MyXMLService myXMLService = RestProxy.create(MyXMLService.class, HttpPipeline.build(new MockXMLHTTPClient(), new DecodingPolicyFactory()), new JacksonAdapter());
         List<SignedIdentifierInner> identifiers = myXMLService.getContainerACLs().signedIdentifiers();
         assertNotNull(identifiers);
         assertNotEquals(0, identifiers.size());
@@ -131,14 +133,14 @@ public class RestProxyXMLTests {
 
         JacksonAdapter serializer = new JacksonAdapter();
         MockXMLReceiverClient httpClient = new MockXMLReceiverClient();
-        MyXMLService myXMLService = RestProxy.create(MyXMLService.class, HttpPipeline.build(httpClient), serializer);
+        MyXMLService myXMLService = RestProxy.create(MyXMLService.class, HttpPipeline.build(httpClient, new DecodingPolicyFactory()), serializer);
         SignedIdentifiersWrapper wrapper = new SignedIdentifiersWrapper(expectedAcls);
         myXMLService.setContainerACLs(wrapper);
 
         SignedIdentifiersWrapper actualAclsWrapped = serializer.deserialize(
                 new String(httpClient.receivedBytes, Charsets.UTF_8),
                 new TypeToken<SignedIdentifiersWrapper>() {}.getType(),
-                SerializerAdapter.Encoding.XML);
+                SerializerEncoding.XML);
 
         List<SignedIdentifierInner> actualAcls = actualAclsWrapped.signedIdentifiers();
 
@@ -162,7 +164,7 @@ public class RestProxyXMLTests {
         JacksonAdapter serializer = new JacksonAdapter();
         MyXMLServiceWithAttributes myXMLService = RestProxy.create(
                 MyXMLServiceWithAttributes.class,
-                HttpPipeline.build(new MockXMLHTTPClient()),
+                HttpPipeline.build(new MockXMLHTTPClient(), new DecodingPolicyFactory()),
                 serializer);
 
         Slideshow slideshow = myXMLService.getSlideshow();
@@ -182,9 +184,9 @@ public class RestProxyXMLTests {
         assertEquals("", slideshow.slides[1].items[1]);
         assertEquals("Who buys WonderWidgets", slideshow.slides[1].items[2]);
 
-        String xml = serializer.serialize(slideshow, SerializerAdapter.Encoding.XML);
-        Slideshow newSlideshow = serializer.deserialize(xml, Slideshow.class, SerializerAdapter.Encoding.XML);
-        String newXML = serializer.serialize(newSlideshow, SerializerAdapter.Encoding.XML);
+        String xml = serializer.serialize(slideshow, SerializerEncoding.XML);
+        Slideshow newSlideshow = serializer.deserialize(xml, Slideshow.class, SerializerEncoding.XML);
+        String newXML = serializer.serialize(newSlideshow, SerializerEncoding.XML);
         assertEquals(xml, newXML);
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/UserAgentTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/UserAgentTests.java
@@ -37,7 +37,7 @@ public class UserAgentTests {
 
         HttpResponse response = pipeline.sendRequestAsync(new HttpRequest(
                 "defaultUserAgentTests",
-                HttpMethod.GET, new URL("http://localhost"))).blockingGet();
+                HttpMethod.GET, new URL("http://localhost"), null)).blockingGet();
 
         Assert.assertEquals(200, response.statusCode());
     }
@@ -55,7 +55,7 @@ public class UserAgentTests {
             },
             new UserAgentPolicyFactory("Awesome"));
 
-        HttpResponse response = pipeline.sendRequestAsync(new HttpRequest("customUserAgentTests", HttpMethod.GET, new URL("http://localhost"))).blockingGet();
+        HttpResponse response = pipeline.sendRequestAsync(new HttpRequest("customUserAgentTests", HttpMethod.GET, new URL("http://localhost"), null)).blockingGet();
         Assert.assertEquals(200, response.statusCode());
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpPipelineTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpPipelineTests.java
@@ -24,7 +24,7 @@ public class HttpPipelineTests {
             }
         });
 
-        final HttpResponse response = httpPipeline.sendRequestAsync(new HttpRequest("MOCK_CALLER_METHOD", expectedHttpMethod, expectedUrl)).blockingGet();
+        final HttpResponse response = httpPipeline.sendRequestAsync(new HttpRequest("MOCK_CALLER_METHOD", expectedHttpMethod, expectedUrl, null)).blockingGet();
         assertNotNull(response);
         assertEquals(200, response.statusCode());
     }
@@ -48,7 +48,7 @@ public class HttpPipelineTests {
                 .withHttpClient(httpClient)
                 .withUserAgent(expectedUserAgent)
                 .build();
-        final HttpResponse response = httpPipeline.sendRequestAsync(new HttpRequest("MOCK_CALLER_METHOD", expectedHttpMethod, expectedUrl)).blockingGet();
+        final HttpResponse response = httpPipeline.sendRequestAsync(new HttpRequest("MOCK_CALLER_METHOD", expectedHttpMethod, expectedUrl, null)).blockingGet();
         assertNotNull(response);
         assertEquals(200, response.statusCode());
     }
@@ -72,7 +72,7 @@ public class HttpPipelineTests {
                     }
                 },
                 new RequestIdPolicyFactory());
-        final HttpResponse response = httpPipeline.sendRequestAsync(new HttpRequest("MOCK_CALLER_METHOD", expectedHttpMethod, expectedUrl)).blockingGet();
+        final HttpResponse response = httpPipeline.sendRequestAsync(new HttpRequest("MOCK_CALLER_METHOD", expectedHttpMethod, expectedUrl, null)).blockingGet();
         assertNotNull(response);
         assertEquals(200, response.statusCode());
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpRequestTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/HttpRequestTests.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 public class HttpRequestTests {
     @Test
     public void constructor() throws MalformedURLException {
-        final HttpRequest request = new HttpRequest("request caller method", HttpMethod.fromString("request http method"), new URL("http://request.url"));
+        final HttpRequest request = new HttpRequest("request caller method", HttpMethod.fromString("request http method"), new URL("http://request.url"), null);
         assertEquals("request caller method", request.callerMethod());
         assertEquals(HttpMethod.fromString("request http method"), request.httpMethod());
         assertEquals(new URL("http://request.url"), request.url());
@@ -29,7 +29,7 @@ public class HttpRequestTests {
                 HttpMethod.fromString("request http method"),
                 new URL("http://request.url"),
                 headers,
-                Flowable.just(new byte[0]));
+                Flowable.just(new byte[0]), null);
 
         final HttpRequest bufferedRequest = request.buffer();
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
@@ -10,12 +10,9 @@ import com.microsoft.rest.v2.protocol.SerializerAdapter;
 import com.microsoft.rest.v2.protocol.SerializerEncoding;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import io.reactivex.Flowable;
-import io.reactivex.Observable;
 import io.reactivex.Single;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 public class MockHttpResponse extends HttpResponse {
     private final static SerializerAdapter<?> serializer = new JacksonAdapter();
@@ -29,7 +26,7 @@ public class MockHttpResponse extends HttpResponse {
     public MockHttpResponse(int statusCode, HttpHeaders headers, byte[] bodyBytes) {
         this.statusCode = statusCode;
         this.headers = headers;
-         this.bodyBytes = bodyBytes;
+        this.bodyBytes = bodyBytes;
     }
 
     public MockHttpResponse(int statusCode, byte[] bodyBytes) {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
@@ -7,6 +7,7 @@
 package com.microsoft.rest.v2.http;
 
 import com.microsoft.rest.v2.protocol.SerializerAdapter;
+import com.microsoft.rest.v2.protocol.SerializerEncoding;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
@@ -28,7 +29,7 @@ public class MockHttpResponse extends HttpResponse {
     public MockHttpResponse(int statusCode, HttpHeaders headers, byte[] bodyBytes) {
         this.statusCode = statusCode;
         this.headers = headers;
-        this.bodyBytes = bodyBytes;
+         this.bodyBytes = bodyBytes;
     }
 
     public MockHttpResponse(int statusCode, byte[] bodyBytes) {
@@ -36,11 +37,11 @@ public class MockHttpResponse extends HttpResponse {
     }
 
     public MockHttpResponse(int statusCode) {
-        this(statusCode, (byte[])null);
+        this(statusCode, new byte[0]);
     }
 
     public MockHttpResponse(int statusCode, String string) {
-        this(statusCode, new HttpHeaders(), string == null ? null : string.getBytes());
+        this(statusCode, new HttpHeaders(), string == null ? new byte[0] : string.getBytes());
     }
 
     public MockHttpResponse(int statusCode, HttpHeaders headers, Object serializable) {
@@ -54,7 +55,7 @@ public class MockHttpResponse extends HttpResponse {
     private static byte[] serialize(Object serializable) {
         byte[] result = null;
         try {
-            final String serializedString = serializer.serialize(serializable);
+            final String serializedString = serializer.serialize(serializable, SerializerEncoding.JSON);
             result = serializedString == null ? null : serializedString.getBytes();
         } catch (IOException e) {
             e.printStackTrace();

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
@@ -78,11 +78,6 @@ public class MockHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Single<? extends InputStream> bodyAsInputStreamAsync() {
-        return Single.just(new ByteArrayInputStream(bodyBytes));
-    }
-
-    @Override
     public Single<byte[]> bodyAsByteArrayAsync() {
         return Single.just(bodyBytes);
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/policy/HostPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/policy/HostPolicyTests.java
@@ -39,6 +39,6 @@ public class HostPolicyTests {
     }
 
     private static HttpRequest createHttpRequest(String url) throws MalformedURLException {
-        return new HttpRequest("mock.caller", HttpMethod.GET, new URL(url));
+        return new HttpRequest("mock.caller", HttpMethod.GET, new URL(url), null);
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/policy/ProtocolPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/policy/ProtocolPolicyTests.java
@@ -44,6 +44,6 @@ public class ProtocolPolicyTests {
     }
 
     private static HttpRequest createHttpRequest(String url) throws MalformedURLException {
-        return new HttpRequest("mock.caller", HttpMethod.GET, new URL(url));
+        return new HttpRequest("mock.caller", HttpMethod.GET, new URL(url), null);
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/policy/ProxyAuthenticationPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/policy/ProxyAuthenticationPolicyTests.java
@@ -39,7 +39,7 @@ public class ProxyAuthenticationPolicyTests {
                     }
                 });
 
-        pipeline.sendRequestAsync(new HttpRequest("test", HttpMethod.GET, new URL("http://localhost")))
+        pipeline.sendRequestAsync(new HttpRequest("test", HttpMethod.GET, new URL("http://localhost"), null))
                 .blockingGet();
 
         if (!auditorVisited.get()) {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/policy/RequestIdPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/policy/RequestIdPolicyTests.java
@@ -40,16 +40,6 @@ public class RequestIdPolicyTests {
         }
 
         @Override
-        public Single<? extends InputStream> bodyAsInputStreamAsync() {
-            return Single.just(new InputStream() {
-                @Override
-                public int read() throws IOException {
-                    return -1;
-                }
-            });
-        }
-
-        @Override
         public Single<byte[]> bodyAsByteArrayAsync() {
             return Single.just(new byte[0]);
         }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/policy/RequestIdPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/policy/RequestIdPolicyTests.java
@@ -14,12 +14,10 @@ import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.http.MockHttpClient;
 import io.reactivex.Flowable;
+import io.reactivex.Single;
 import org.junit.Assert;
 import org.junit.Test;
-import io.reactivex.Single;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 
 public class RequestIdPolicyTests {
@@ -81,8 +79,8 @@ public class RequestIdPolicyTests {
             })
             .build();
 
-        pipeline.sendRequestAsync(new HttpRequest("newRequestIdForEachCall", HttpMethod.GET, new URL("http://localhost/"))).blockingGet();
-        pipeline.sendRequestAsync(new HttpRequest("newRequestIdForEachCall", HttpMethod.GET, new URL("http://localhost/"))).blockingGet();
+        pipeline.sendRequestAsync(new HttpRequest("newRequestIdForEachCall", HttpMethod.GET, new URL("http://localhost/"), null)).blockingGet();
+        pipeline.sendRequestAsync(new HttpRequest("newRequestIdForEachCall", HttpMethod.GET, new URL("http://localhost/"), null)).blockingGet();
     }
 
     @Test
@@ -108,6 +106,6 @@ public class RequestIdPolicyTests {
             new RequestIdPolicyFactory(),
             new RetryPolicyFactory(1));
 
-        pipeline.sendRequestAsync(new HttpRequest("sameRequestIdForRetry", HttpMethod.GET, new URL("http://localhost/"))).blockingGet();
+        pipeline.sendRequestAsync(new HttpRequest("sameRequestIdForRetry", HttpMethod.GET, new URL("http://localhost/"), null)).blockingGet();
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/policy/RetryPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/policy/RetryPolicyTests.java
@@ -34,7 +34,7 @@ public class RetryPolicyTests {
                 new HttpRequest(
                         "exponentialRetryEndOn501",
                         HttpMethod.GET,
-                        new URL("http://localhost/"))).blockingGet();
+                        new URL("http://localhost/"), null)).blockingGet();
 
         Assert.assertEquals(501, response.statusCode());
     }
@@ -58,7 +58,7 @@ public class RetryPolicyTests {
                 new HttpRequest(
                         "exponentialRetryMax",
                         HttpMethod.GET,
-                        new URL("http://localhost/"))).blockingGet();
+                        new URL("http://localhost/"), null)).blockingGet();
 
         Assert.assertEquals(500, response.statusCode());
     }


### PR DESCRIPTION
- SerializerAdapter.Encoding is now SerializerEncoding
- Adds `Object deserializedHeaders` and `Object deserializedBody` members to HttpResponse
- Adds HttpResponseDecoder which needs to get attached to the HttpResponse in order for decoding to work. I'm slightly concerned about using `withResponseDecoder()` instead of requiring a constructor parameter. It's just a lot of code churn if I add a constructor parameter. Let me know what you think.
- Removes `bodyAsInputStreamAsync()` from HttpResponse
  - We were never actually streaming in impls of this and it doesn't seem worth it at this time to provide an alternative mechanism for streaming.
  - If we bring it back down the line (say in order to let people implement other HttpClients more faithfully) then I think it should return simply InputStream instead of Single<InputStream> because just obtaining the InputStream shouldn't be waiting for async reads to take place
- HttpResponse and RestResponse are now Closeable
  - These close methods only have an effect if a streaming body is present
