### PR TITLE
Wrap exceptions generated from deserialization and other minor tweaks

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestException.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestException.java
@@ -47,6 +47,18 @@ public class RestException extends RuntimeException {
     }
 
     /**
+     * Initializes a new instance of the RestException class.
+     *
+     * @param message the exception message or the response content if a message is not available
+     * @param response the HTTP response
+     * @param cause the Throwable which caused the creation of this RestException
+     */
+    public RestException(String message, HttpResponse response, Throwable cause) {
+        super(message, cause);
+        this.response = response;
+    }
+
+    /**
      * @return information about the associated HTTP response
      */
     public HttpResponse response() {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -324,7 +324,7 @@ public class RestProxy implements InvocationHandler {
 
         final Maybe<?> asyncResult;
         if (httpMethod == HttpMethod.HEAD
-                && (entityTypeToken.isSubtypeOf(boolean.class) || entityTypeToken.isSubtypeOf(Boolean.class))) {
+                && (entityTypeToken.isSubtypeOf(Boolean.TYPE) || entityTypeToken.isSubtypeOf(Boolean.class))) {
             boolean isSuccess = (responseStatusCode / 100) == 2;
             asyncResult = Maybe.just(isSuccess);
         } else if (entityTypeToken.isSubtypeOf(byte[].class)) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -146,7 +146,6 @@ public class SharedChannelPool implements ChannelPool {
                                         request.promise.setSuccess(channelFuture.channel());
                                     } else {
                                         request.promise.setFailure(channelFuture.cause());
-                                        throw new RuntimeException(channelFuture.cause());
                                     }
                                 }
                             });


### PR DESCRIPTION
Directly passing exceptions that say stuff like "unexpected EOF" or "expected ')'," or stuff like that seems not so useful to users as simply saying there were malformed headers or a malformed body on the response.

Also going on my radar is the idea of detecting if a response has not yet been decoded in RestProxy and if so simply decoding it.. it's cumbersome to track down failures where we forgot to put a DecodingPolicyFactory in the pipeline. It's a rare REST method which has no schema defined for its response headers, response body, or error body.