### PR TITLE
Add FlowableUtil.collectBytesInBuffer()

### DIFF
--- a/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/RefreshTokenClientTests.java
+++ b/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/RefreshTokenClientTests.java
@@ -1,7 +1,6 @@
 package com.microsoft.azure.v2.credentials;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
 import com.microsoft.azure.v2.credentials.http.MockHttpClient;
 import com.microsoft.rest.v2.http.HttpMethod;
 import com.microsoft.rest.v2.http.HttpRequest;
@@ -9,7 +8,6 @@ import com.microsoft.rest.v2.util.FlowableUtil;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import static org.junit.Assert.*;
 
@@ -27,7 +25,7 @@ public class RefreshTokenClientTests {
         assertEquals("com.microsoft.azure.v2.credentials.RefreshTokenClient$RefreshTokenService.refreshToken", request.callerMethod());
         assertEquals("http://my.base.url/mockTenant/oauth2/token", request.url().toString());
 
-        String receivedContent = new String(FlowableUtil.collectBytes(request.body()).blockingGet(), Charsets.UTF_8);
+        String receivedContent = new String(FlowableUtil.collectBytesInArray(request.body()).blockingGet(), Charsets.UTF_8);
         assertEquals("client_id=mockClientId&grant_type=refresh_token&resource=mockResource&refresh_token=mockRefreshToken", receivedContent);
     }
 }

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpClient.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpClient.java
@@ -296,7 +296,7 @@ public class MockAzureHttpClient extends HttpClient {
     }
 
     private static String bodyToString(HttpRequest request) throws IOException {
-        Single<String> asyncString = FlowableUtil.collectBytes(request.body()).map(new Function<byte[], String>() {
+        Single<String> asyncString = FlowableUtil.collectBytesInArray(request.body()).map(new Function<byte[], String>() {
             @Override
             public String apply(byte[] bytes) throws Exception {
                 return new String(bytes, Charsets.UTF_8);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/HttpLoggingPolicyFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/HttpLoggingPolicyFactory.java
@@ -116,7 +116,7 @@ public class HttpLoggingPolicyFactory implements RequestPolicyFactory {
 
                     if (contentLength < MAX_BODY_LOG_SIZE && isHumanReadableContentType) {
                         try {
-                            Single<byte[]> collectedBytes = FlowableUtil.collectBytes(request.body());
+                            Single<byte[]> collectedBytes = FlowableUtil.collectBytesInArray(request.body());
                             bodyLoggingTask = collectedBytes.flatMapCompletable(new Function<byte[], CompletableSource>() {
                                 @Override
                                 public CompletableSource apply(byte[] bytes) throws Exception {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -55,10 +55,10 @@ public final class FlowableUtil {
 
     /**
      * Collects byte buffers emitted by a Flowable into a byte array.
-     * @param content A stream which emits byte arrays.
+     * @param content A stream which emits byte buffers.
      * @return A Single which emits the concatenation of all the byte buffers given by the source Flowable.
      */
-    public static Single<byte[]> collectBytes(Flowable<ByteBuffer> content) {
+    public static Single<byte[]> collectBytesInArray(Flowable<ByteBuffer> content) {
         return content.collectInto(ByteStreams.newDataOutput(), new BiConsumer<ByteArrayDataOutput, ByteBuffer>() {
             @Override
             public void accept(ByteArrayDataOutput out, ByteBuffer chunk) throws Exception {
@@ -73,6 +73,21 @@ public final class FlowableUtil {
                 return out.toByteArray();
             }
         });
+    }
+
+    /**
+     * Collects byte buffers emitted by a Flowable into a ByteBuffer.
+     * @param content A stream which emits byte arrays.
+     * @return A Single which emits the concatenation of all the byte buffers given by the source Flowable.
+     */
+    public static Single<ByteBuffer> collectBytesInBuffer(Flowable<ByteBuffer> content) {
+        return collectBytesInArray(content)
+            .map(new Function<byte[], ByteBuffer>() {
+                @Override
+                public ByteBuffer apply(byte[] bytes) throws Exception {
+                    return ByteBuffer.wrap(bytes);
+                }
+            });
     }
 
     /**

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyXMLTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyXMLTests.java
@@ -8,8 +8,6 @@
 package com.microsoft.rest.v2;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.GET;
@@ -27,18 +25,15 @@ import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.http.MockHttpResponse;
 import com.microsoft.rest.v2.policy.DecodingPolicyFactory;
-import com.microsoft.rest.v2.protocol.SerializerAdapter;
 import com.microsoft.rest.v2.protocol.SerializerEncoding;
 import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import com.microsoft.rest.v2.util.FlowableUtil;
-import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Function;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import io.reactivex.Single;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -99,7 +94,7 @@ public class RestProxyXMLTests {
         @Override
         public Single<HttpResponse> sendRequestAsync(HttpRequest request) {
             if (request.url().toString().endsWith("SetContainerACLs")) {
-                return FlowableUtil.collectBytes(request.body())
+                return FlowableUtil.collectBytesInArray(request.body())
                         .map(new Function<byte[], HttpResponse>() {
                             @Override
                             public HttpResponse apply(byte[] bytes) throws Exception {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
@@ -180,7 +180,7 @@ public class MockHttpClient extends HttpClient {
     private static String bodyToString(HttpRequest request) throws IOException {
         String body = "";
         if (request.body() != null) {
-            Single<String> asyncString = FlowableUtil.collectBytes(request.body())
+            Single<String> asyncString = FlowableUtil.collectBytesInArray(request.body())
                     .map(new Function<byte[], String>() {
                 @Override
                 public String apply(byte[] bytes) throws Exception {


### PR DESCRIPTION
There is a FlowableUtil.collectBytes() method that produces a `Single<byte[]>`, but we're transitioning over to using `ByteBuffer` instead of `byte[]`, so I renamed that method and created a new one that returns a `Single<ByteBuffer>`.