### PR TITLE
Add client-runtime-native module

### DIFF
--- a/client-runtime-native/pom.xml
+++ b/client-runtime-native/pom.xml
@@ -20,16 +20,6 @@
     </description>
     <url>https://github.com/Azure/autorest-clientruntime-for-java</url>
 
-    <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
-            </extension>
-        </extensions>
-    </build>
-
     <profiles>
         <profile>
             <id>osx</id>
@@ -37,6 +27,10 @@
                 <os>
                     <name>Mac OS X</name>
                 </os>
+                <property>
+                    <name>os.detected.arch</name>
+                    <value>x86_64</value>
+                </property>
             </activation>
             <dependencies>
                 <dependency>
@@ -60,6 +54,10 @@
                 <os>
                     <name>Linux</name>
                 </os>
+                <property>
+                    <name>os.detected.arch</name>
+                    <value>x86_64</value>
+                </property>
             </activation>
             <dependencies>
                 <dependency>
@@ -83,6 +81,10 @@
                 <os>
                     <name>Windows</name>
                 </os>
+                <property>
+                    <name>os.detected.arch</name>
+                    <value>x86_64</value>
+                </property>
             </activation>
             <dependencies>
                 <dependency>

--- a/client-runtime-native/pom.xml
+++ b/client-runtime-native/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>autorest-clientruntime-for-java</artifactId>
+        <groupId>com.microsoft.azure.v2</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+
+    <groupId>com.microsoft.rest.v2</groupId>
+    <artifactId>client-runtime-native</artifactId>
+
+    <name>Native Modules for AutoRest Client Runtime for Java</name>
+    <description>
+        This package contains native dependencies for the AutoRest Client Runtime for Java which can improve performance.
+        Simply including this package in your dependencies is sufficient to cause all native modules available on your OS and architecture to be used.
+    </description>
+    <url>https://github.com/Azure/autorest-clientruntime-for-java</url>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>osx</id>
+            <activation>
+                <os>
+                    <name>Mac OS X</name>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-kqueue</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <version>2.0.7.Final</version>
+                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>linux</id>
+            <activation>
+                <os>
+                    <name>Linux</name>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                    <version>${netty.version}</version>
+                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <version>2.0.7.Final</version>
+                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <name>Windows</name>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <version>2.0.7.Final</version>
+                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/client-runtime-native/pom.xml
+++ b/client-runtime-native/pom.xml
@@ -16,33 +16,42 @@
     <name>Native Modules for AutoRest Client Runtime for Java</name>
     <description>
         This package contains native dependencies for the AutoRest Client Runtime for Java which can improve performance.
-        Simply including this package in your dependencies is sufficient to cause all native modules available on your OS and architecture to be used.
+        Including this package in your dependencies will cause all native modules available on your OS to be used.
+        Currently, only x86_64 architectures are supported.
     </description>
     <url>https://github.com/Azure/autorest-clientruntime-for-java</url>
 
     <profiles>
         <profile>
+            <id>boringssl</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <version>2.0.7.Final</version>
+                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <id>osx</id>
             <activation>
-                <os>
-                    <name>Mac OS X</name>
-                </os>
                 <property>
-                    <name>os.detected.arch</name>
-                    <value>x86_64</value>
+                    <name>os.detected.name</name>
+                    <value>osx</value>
                 </property>
             </activation>
+
             <dependencies>
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-transport-native-kqueue</artifactId>
                     <version>${netty.version}</version>
-                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
-                </dependency>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <version>2.0.7.Final</version>
                     <classifier>${os.detected.name}-${os.detected.arch}</classifier>
                 </dependency>
             </dependencies>
@@ -51,12 +60,9 @@
         <profile>
             <id>linux</id>
             <activation>
-                <os>
-                    <name>Linux</name>
-                </os>
                 <property>
-                    <name>os.detected.arch</name>
-                    <value>x86_64</value>
+                    <name>os.detected.name</name>
+                    <value>linux</value>
                 </property>
             </activation>
             <dependencies>
@@ -64,33 +70,6 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-transport-native-epoll</artifactId>
                     <version>${netty.version}</version>
-                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
-                </dependency>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <version>2.0.7.Final</version>
-                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>windows</id>
-            <activation>
-                <os>
-                    <name>Windows</name>
-                </os>
-                <property>
-                    <name>os.detected.arch</name>
-                    <value>x86_64</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <version>2.0.7.Final</version>
                     <classifier>${os.detected.name}-${os.detected.arch}</classifier>
                 </dependency>
             </dependencies>

--- a/client-runtime-native/pom.xml
+++ b/client-runtime-native/pom.xml
@@ -21,6 +21,9 @@
     </description>
     <url>https://github.com/Azure/autorest-clientruntime-for-java</url>
 
+    <properties>
+        <netty-boringssl.version>2.0.7.Final</netty-boringssl.version>
+    </properties>
     <profiles>
         <profile>
             <id>boringssl</id>
@@ -32,7 +35,7 @@
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <version>2.0.7.Final</version>
+                    <version>${netty-boringssl.version}</version>
                     <classifier>${os.detected.name}-${os.detected.arch}</classifier>
                 </dependency>
             </dependencies>
@@ -54,6 +57,13 @@
                     <version>${netty.version}</version>
                     <classifier>${os.detected.name}-${os.detected.arch}</classifier>
                 </dependency>
+
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <version>${netty-boringssl.version}</version>
+                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+                </dependency>
             </dependencies>
         </profile>
 
@@ -70,6 +80,13 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-transport-native-epoll</artifactId>
                     <version>${netty.version}</version>
+                    <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+                </dependency>
+
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <version>${netty-boringssl.version}</version>
                     <classifier>${os.detected.name}-${os.detected.arch}</classifier>
                 </dependency>
             </dependencies>

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -97,12 +97,12 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>com.microsoft.rest.v2</groupId>
       <artifactId>client-runtime-native</artifactId>
       <version>2.0.0-SNAPSHOT</version>
       <type>pom</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -97,16 +97,15 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.microsoft.rest.v2</groupId>
+      <artifactId>client-runtime-native</artifactId>
+      <version>2.0.0-SNAPSHOT</version>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
-      </extension>
-    </extensions>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -136,45 +135,6 @@
 <br />*/</code>]]></bottom>
         </configuration>
       </plugin>
-
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>osx</id>
-      <activation>
-        <os>
-          <name>Mac OS X</name>
-        </os>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${netty.version}</version>
-          <classifier>${os.detected.name}-${os.detected.arch}</classifier>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>linux</id>
-      <activation>
-        <os>
-          <name>Linux</name>
-        </os>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${netty.version}</version>
-          <classifier>${os.detected.name}-${os.detected.arch}</classifier>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -1324,7 +1324,7 @@ public abstract class RestProxyTests {
         assertEquals(30720, count);
     }
 
-    @Host("http://httpbin.org")
+    @Host("https://httpbin.org")
     interface FlowableUploadService {
         @PUT("/put")
         RestResponse<Void, HttpBinJSON> put(@BodyParam("text/plain") Flowable<ByteBuffer> content, @HeaderParam("Content-Length") long contentLength);

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,14 @@
   </dependencyManagement>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -215,5 +215,6 @@
     <module>client-runtime</module>
     <module>azure-client-runtime</module>
     <module>azure-client-authentication</module>
+    <module>client-runtime-native</module>
   </modules>
 </project>


### PR DESCRIPTION
This is my proposal for #362. By default, people who grab our runtime and libraries that depend on our runtime will use the transport and SSL based on the Java standard library. But if they want the increased performance (and potential bugs) they can add this dependency:

```xml
<dependency>
  <groupId>com.microsoft.rest.v2</groupId>
  <artifactId>client-runtime-native</artifactId>
  <version>2.0.0-SNAPSHOT</version>
  <type>pom</type>
</dependency>
```

Then each SDK's README should show this dependency in the "how to install" section next to the SDK dependency itself.

This will add either epoll or kqueue transport if applicable, and will also add a statically-linked boringssl dependency on windows/linux/mac. Users who want fine grained control over the SSL implementation used (e.g., I know we'll have OpenSSL already installed on the server, I want to use that, etc.) would not use client-runtime-native and would instead just add the appropriate native dependencies individually themselves.

Instead of needing to know which Netty version is being used in the runtime, they'll need to know what version of the runtime is being used by the particular Azure SDK-- so it's not perfect, but it's probably an improvement over making them know the right versions of Netty native modules.