### PR TITLE
Update to Netty 4.1.21 and test read-only memory mapped file

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -15,7 +15,6 @@ import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.pool.ChannelPoolHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -80,8 +79,7 @@ public class SharedChannelPool implements ChannelPool {
         this.available = new ConcurrentMultiHashMap<>();
         this.leased = new ConcurrentMultiHashMap<>();
         try {
-            sslContext = SslContextBuilder.forClient()
-                    .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+            sslContext = SslContextBuilder.forClient().build();
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -311,9 +311,8 @@ public class RestProxyStressTests {
                 .zipWith(md5s, new BiFunction<Integer, byte[], Completable>() {
                     @Override
                     public Completable apply(Integer id, final byte[] md5) throws Exception {
-                        // Must memory map in read/write mode for native transports until Netty 4.1.21.Final release.
-                        final FileChannel fileStream = FileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"), StandardOpenOption.READ, StandardOpenOption.WRITE);
-                        Flowable<ByteBuffer> stream = FlowableUtil.split(fileStream.map(FileChannel.MapMode.READ_WRITE, 0, fileStream.size()), CHUNK_SIZE);
+                        final FileChannel fileStream = FileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"), StandardOpenOption.READ);
+                        Flowable<ByteBuffer> stream = FlowableUtil.split(fileStream.map(FileChannel.MapMode.READ_ONLY, 0, fileStream.size()), CHUNK_SIZE);
                         return service.upload100MB(String.valueOf(id), sas, "BlockBlob", stream, FILE_SIZE).flatMapCompletable(new Function<RestResponse<Void, Void>, CompletableSource>() {
                             @Override
                             public CompletableSource apply(RestResponse<Void, Void> response) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </scm>
 
   <properties>
-    <netty.version>4.1.20.Final</netty.version>
+    <netty.version>4.1.21.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <legal><![CDATA[[INFO] Any downloads listed may be third party software.  Microsoft grants you no rights for third party software.]]></legal>
   </properties>


### PR DESCRIPTION
- Gets rid of [https://netty.io/4.1/api/io/netty/handler/ssl/util/InsecureTrustManagerFactory.html](InsecureTrustManagerFactory) so that Netty will use the system default TrustManager instead.
- Bumps to Netty 4.1.21 so that we get the ReadOnlyDirectByteBuffer fix for native transports