### PR TITLE
Add support for x-ms-header-collection-prefix extension

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -291,9 +291,9 @@ public class SwaggerMethodParser {
                 if (0 <= parameterIndex && parameterIndex < swaggerMethodArguments.length) {
                     final Object methodArgument = swaggerMethodArguments[headerSubstitution.methodParameterIndex()];
                     if (methodArgument instanceof Map) {
-                        final Map<String,?> headerCollection = (Map<String,?>)methodArgument;
+                        final Map<String, ?> headerCollection = (Map<String, ?>) methodArgument;
                         final String headerCollectionPrefix = headerSubstitution.urlParameterName();
-                        for (final Map.Entry<String,?> headerCollectionEntry : headerCollection.entrySet()) {
+                        for (final Map.Entry<String, ?> headerCollectionEntry : headerCollection.entrySet()) {
                             final String headerName = headerCollectionPrefix + headerCollectionEntry.getKey();
                             final String headerValue = headerCollectionEntry.getValue() == null ? null : headerCollectionEntry.getValue().toString();
                             result.set(headerName, headerValue);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -36,6 +36,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class parses details of a specific Swagger REST API call from a provided Swagger interface
@@ -254,7 +255,26 @@ public class SwaggerMethodParser {
      * @return An Iterable with the encoded query parameters.
      */
     public Iterable<EncodedParameter> encodedQueryParameters(Object[] swaggerMethodArguments) {
-        return getEncodedParameters(querySubstitutions, swaggerMethodArguments, UrlEscapers.urlFormParameterEscaper());
+        final List<EncodedParameter> result = new ArrayList<>();
+        if (querySubstitutions != null) {
+            final Escaper escaper = UrlEscapers.urlFormParameterEscaper();
+
+            for (Substitution querySubstitution : querySubstitutions) {
+                final int parameterIndex = querySubstitution.methodParameterIndex();
+                if (0 <= parameterIndex && parameterIndex < swaggerMethodArguments.length) {
+                    final Object methodArgument = swaggerMethodArguments[querySubstitution.methodParameterIndex()];
+                    String parameterValue = methodArgument == null ? null : methodArgument.toString();
+                    if (parameterValue != null) {
+                        if (querySubstitution.shouldEncode() && escaper != null) {
+                            parameterValue = escaper.escape(parameterValue);
+                        }
+
+                        result.add(new EncodedParameter(querySubstitution.urlParameterName(), parameterValue));
+                    }
+                }
+            }
+        }
+        return result;
     }
 
     /**
@@ -265,9 +285,26 @@ public class SwaggerMethodParser {
     public Iterable<HttpHeader> headers(Object[] swaggerMethodArguments) {
         final HttpHeaders result = new HttpHeaders(headers);
 
-        final Iterable<EncodedParameter> substitutedHeaders = getEncodedParameters(headerSubstitutions, swaggerMethodArguments, null);
-        for (final EncodedParameter substitutedHeader : substitutedHeaders) {
-            result.set(substitutedHeader.name(), substitutedHeader.encodedValue());
+        if (headerSubstitutions != null) {
+            for (Substitution headerSubstitution : headerSubstitutions) {
+                final int parameterIndex = headerSubstitution.methodParameterIndex();
+                if (0 <= parameterIndex && parameterIndex < swaggerMethodArguments.length) {
+                    final Object methodArgument = swaggerMethodArguments[headerSubstitution.methodParameterIndex()];
+                    if (methodArgument instanceof Map) {
+                        final Map<String,?> headerCollection = (Map<String,?>)methodArgument;
+                        final String headerCollectionPrefix = headerSubstitution.urlParameterName();
+                        for (final Map.Entry<String,?> headerCollectionEntry : headerCollection.entrySet()) {
+                            final String headerName = headerCollectionPrefix + headerCollectionEntry.getKey();
+                            final String headerValue = headerCollectionEntry.getValue() == null ? null : headerCollectionEntry.getValue().toString();
+                            result.set(headerName, headerValue);
+                        }
+                    } else {
+                        final String headerName = headerSubstitution.urlParameterName();
+                        final String headerValue = methodArgument == null ? null : methodArgument.toString();
+                        result.set(headerName, headerValue);
+                    }
+                }
+            }
         }
 
         return result;
@@ -460,29 +497,6 @@ public class SwaggerMethodParser {
                     }
 
                     result = result.replace("{" + substitution.urlParameterName() + "}", substitutionValue);
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private static Iterable<EncodedParameter> getEncodedParameters(Iterable<Substitution> substitutions, Object[] methodArguments, Escaper escaper) {
-        final List<EncodedParameter> result = new ArrayList<>();
-
-        if (substitutions != null) {
-            for (Substitution substitution : substitutions) {
-                final int parameterIndex = substitution.methodParameterIndex();
-                if (0 <= parameterIndex && parameterIndex < methodArguments.length) {
-                    final Object methodArgument = methodArguments[substitution.methodParameterIndex()];
-                    String parameterValue = methodArgument == null ? null : methodArgument.toString();
-                    if (parameterValue != null) {
-                        if (substitution.shouldEncode() && escaper != null) {
-                            parameterValue = escaper.escape(parameterValue);
-                        }
-
-                        result.add(new EncodedParameter(substitution.urlParameterName(), parameterValue));
-                    }
                 }
             }
         }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/annotations/HeaderParam.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/annotations/HeaderParam.java
@@ -14,8 +14,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Replaces the header with the value of its target. The value specified here
- * replaces headers specified statically in the {@link Headers}, headers added
- * in any interceptors, and headers added by the HTTP itself.
+ * replaces headers specified statically in the {@link Headers}.
+ * If the parameter this annotation is attached to is a Map type, then this will
+ * be treated as a header collection. In that case each of the entries in the
+ * argument's map will be individual header values that use the value of this
+ * annotation as a prefix to their key/header name.
  *
  * Example 1:
  *   {@literal @}PUT("{functionId}")
@@ -34,6 +37,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *   {@literal Single<RestResponse<Headers, Body>>} list(@Path("subscriptionId") String subscriptionId, @Header("Authorization") String token);
  *
  *   The token parameter will replace the effect of any credentials in the HTTP pipeline.
+ *
+ * Example 4:
+ *   {@literal @}PUT("{containerName}/{blob}")
+ *   {@literal @}ExpectedResponses({200})
+ *   {@literal Single<RestResponse<BlobSetMetadataHeaders, Void>>} setMetadata(@HostParam("url") String url, @QueryParam("timeout") Integer timeout, @HeaderParam("x-ms-meta-") Map<String, String> metadata, @HeaderParam("x-ms-lease-id") String leaseId, @HeaderParam("If-Modified-Since") String ifModifiedSince, @HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince, @HeaderParam("If-Match") String ifMatches, @HeaderParam("If-None-Match") String ifNoneMatch, @HeaderParam("x-ms-version") String version, @HeaderParam("x-ms-client-request-id") String requestId, @QueryParam("comp") String comp);
+ *
+ *   The metadata parameter will be expanded out so that each entry becomes "x-ms-meta-{@literal <entryKey>}: {@literal <entryValue>}".
  */
 @Retention(RUNTIME)
 @Target(PARAMETER)

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -40,6 +40,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -1380,6 +1381,24 @@ public abstract class RestProxyTests {
         assertEquals(28, bytes.length);
     }
 
+    @Host("http://httpbin.org/")
+    interface Service24 {
+        @PUT("put")
+        HttpBinJSON put(@HeaderParam("ABC") Map<String,String> headerCollection);
+    }
+
+    @Test
+    public void service24Put() {
+        final Map<String,String> headerCollection = new HashMap<>();
+        headerCollection.put("DEF", "GHIJ");
+        headerCollection.put("123", "45");
+        final HttpBinJSON result = createService(Service24.class)
+            .put(headerCollection);
+        assertNotNull(result.headers);
+        final HttpHeaders resultHeaders = new HttpHeaders(result.headers);
+        assertEquals("GHIJ", resultHeaders.value("ABCDEF"));
+        assertEquals("45", resultHeaders.value("ABC123"));
+    }
 
     // Helpers
     protected <T> T createService(Class<T> serviceClass) {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
@@ -151,12 +151,14 @@ public class MockHttpClient extends HttpClient {
                     final HttpBinJSON json = new HttpBinJSON();
                     json.url = request.url().toString();
                     json.data = bodyToString(request);
+                    json.headers = toMap(request.headers());
                     response = new MockHttpResponse(200, json);
                 }
                 else if (requestPathLower.equals("/put")) {
                     final HttpBinJSON json = new HttpBinJSON();
                     json.url = request.url().toString();
                     json.data = bodyToString(request);
+                    json.headers = toMap(request.headers());
                     response = new MockHttpResponse(200, responseHeaders, json);
                 }
                 else if (requestPathLower.startsWith("/status/")) {


### PR DESCRIPTION
This adds support for writing x-ms-header-collection-prefix header parameters. It doesn't support reading x-ms-header-collection-prefix headers from a response. That needs to be done in a separate pull request.