### PR TITLE
Added option to set SSLSocketFactory on ApplicationTokenCredentials

### DIFF
--- a/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/ApplicationTokenCredentials.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/credentials/ApplicationTokenCredentials.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.Proxy;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -33,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Token based credentials for use with a REST Service Client.
@@ -149,6 +151,9 @@ public class ApplicationTokenCredentials extends AzureTokenCredentials {
         if (proxy() != null) {
             context.setProxy(proxy());
         }
+        if (sslSocketFactory() != null) {
+            context.setSslSocketFactory(sslSocketFactory());
+        }
         try {
             if (clientSecret != null) {
                 return context.acquireToken(
@@ -204,5 +209,25 @@ public class ApplicationTokenCredentials extends AzureTokenCredentials {
         } catch (CertificateException e) {
             throw new RuntimeException(e);
         }
+    }
+
+     /**
+     * Set the proxy used for accessing Active Directory.
+     * @param proxy the proxy to use
+     * @return the credential itself
+     */
+    public ApplicationTokenCredentials withProxy(Proxy proxy) {
+        this.setProxy(proxy);
+        return this;
+    }
+        
+    /**
+     * Set the ssl socket factory used for accessing Active Directory.
+     * @param sslSocketFactory the SSLSocketFactory to use
+     * @return the credential itself
+     */
+    public ApplicationTokenCredentials withSSLSocketFactory(SSLSocketFactory sslSocketFactory) {
+        this.setSslSocketFactory(sslSocketFactory);
+        return this;
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/credentials/AzureTokenCredentials.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/credentials/AzureTokenCredentials.java
@@ -20,6 +20,7 @@ import java.net.Proxy;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * AzureTokenCredentials represents a credentials object with access to Azure
@@ -31,6 +32,7 @@ public abstract class AzureTokenCredentials extends TokenCredentials {
     private String defaultSubscription;
 
     private Proxy proxy;
+    private SSLSocketFactory sslSocketFactory;
 
     /**
      * Initializes a new instance of the AzureTokenCredentials.
@@ -115,15 +117,26 @@ public abstract class AzureTokenCredentials extends TokenCredentials {
     }
 
     /**
-     * Set the proxy used for accessing Active Directory.
-     * @param proxy the proxy to use
-     * @return the credential itself
+     * @return the ssl socket factory.
      */
-    public AzureTokenCredentials withProxy(Proxy proxy) {
-        this.proxy = proxy;
-        return this;
+    public SSLSocketFactory sslSocketFactory(){
+        return sslSocketFactory;
     }
 
+    /**
+     * @param proxy the proxy being used for accessing Active Directory.
+     */
+    public void setProxy(Proxy proxy) {
+        this.proxy = proxy;
+    }
+
+    /**
+     * @param sslSocketFactory the ssl socket factory.
+     */
+    public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+        this.sslSocketFactory = sslSocketFactory;
+    }
+    
     @Override
     public void applyCredentialsFilter(OkHttpClient.Builder clientBuilder) {
         clientBuilder.interceptors().add(new AzureTokenCredentialsInterceptor(this));

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/credentials/AzureTokenCredentials.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/credentials/AzureTokenCredentials.java
@@ -119,7 +119,7 @@ public abstract class AzureTokenCredentials extends TokenCredentials {
     /**
      * @return the ssl socket factory.
      */
-    public SSLSocketFactory sslSocketFactory(){
+    public SSLSocketFactory sslSocketFactory() {
         return sslSocketFactory;
     }
 


### PR DESCRIPTION
Truststore with certs loaded at runtime fail if the SSLSocketFactory is not set.

We use a custom truststore for certs, The certs are loaded at runtime and even though we pass the RestClient with the OkHttpClient and SSLSocketFactory the certs loaded at runtime are not identified.

We get the error:
javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
at sun.security.ssl.Alerts.getSSLException(Alerts.java:192)

Since SslSocketFactory was never passed to AuthenticationContext it was not able to detect the certs loaded at runtime. With the change above we can now pass SslSocketFactory at runtime.

ApplicationTokenCredentials credentials = new ApplicationTokenCredentials(connectionInfo.getClientId(), connectionInfo.getTenantId(), connectionInfo.getClientSecret(), AzureEnvironment.AZURE).withSSLSocketFactory(getYourOwnCustomSSLSocketFactory());
