### PR TITLE
Always specify charset when using new String()

### DIFF
--- a/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/AuthFile.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/AuthFile.java
@@ -7,7 +7,6 @@
 package com.microsoft.azure.v2.credentials;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.azure.v2.AzureEnvironment;
@@ -19,6 +18,7 @@ import com.microsoft.rest.v2.serializer.JacksonAdapter;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -55,7 +55,7 @@ final class AuthFile {
      * @throws IOException thrown when the auth file or the certificate file cannot be read or parsed
      */
     static AuthFile parse(File file) throws IOException {
-        String content = Files.toString(file, Charsets.UTF_8).trim();
+        String content = Files.toString(file, StandardCharsets.UTF_8).trim();
 
         AuthFile authFile;
         if (isJsonBased(content)) {

--- a/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/RefreshTokenClientTests.java
+++ b/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/RefreshTokenClientTests.java
@@ -1,6 +1,5 @@
 package com.microsoft.azure.v2.credentials;
 
-import com.google.common.base.Charsets;
 import com.microsoft.azure.v2.credentials.http.MockHttpClient;
 import com.microsoft.rest.v2.http.HttpMethod;
 import com.microsoft.rest.v2.http.HttpRequest;
@@ -8,6 +7,7 @@ import com.microsoft.rest.v2.util.FlowableUtil;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.*;
 
@@ -25,7 +25,7 @@ public class RefreshTokenClientTests {
         assertEquals("com.microsoft.azure.v2.credentials.RefreshTokenClient$RefreshTokenService.refreshToken", request.callerMethod());
         assertEquals("http://my.base.url/mockTenant/oauth2/token", request.url().toString());
 
-        String receivedContent = new String(FlowableUtil.collectBytesInArray(request.body()).blockingGet(), Charsets.UTF_8);
+        String receivedContent = new String(FlowableUtil.collectBytesInArray(request.body()).blockingGet(), StandardCharsets.UTF_8);
         assertEquals("client_id=mockClientId&grant_type=refresh_token&resource=mockResource&refresh_token=mockRefreshToken", receivedContent);
     }
 }

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpClient.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpClient.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.azure.v2.http;
 
-import com.google.common.base.Charsets;
 import com.microsoft.azure.v2.AsyncOperationResource;
 import com.microsoft.azure.v2.AzureAsyncOperationPollStrategy;
 import com.microsoft.azure.v2.MockResource;
@@ -25,6 +24,7 @@ import io.reactivex.functions.Function;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -299,7 +299,7 @@ public class MockAzureHttpClient extends HttpClient {
         Single<String> asyncString = FlowableUtil.collectBytesInArray(request.body()).map(new Function<byte[], String>() {
             @Override
             public String apply(byte[] bytes) throws Exception {
-                return new String(bytes, Charsets.UTF_8);
+                return new String(bytes, StandardCharsets.UTF_8);
             }
         });
 

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpResponse.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpResponse.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 public class MockAzureHttpResponse extends HttpResponse {
     private final static SerializerAdapter<?> serializer = new JacksonAdapter();
@@ -85,7 +86,7 @@ public class MockAzureHttpResponse extends HttpResponse {
 
     @Override
     public Single<String> bodyAsStringAsync() {
-        return Single.just(new String(bodyBytes));
+        return Single.just(new String(bodyBytes, StandardCharsets.UTF_8));
     }
 
     public MockAzureHttpResponse withHeader(String headerName, String headerValue) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
@@ -12,6 +12,7 @@ import io.reactivex.functions.Function;
 import org.reactivestreams.Publisher;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 /**
  * HTTP response which will buffer the response's body when/if it is read.
@@ -75,7 +76,7 @@ public final class BufferedHttpResponse extends HttpResponse {
                 .map(new Function<byte[], String>() {
                     @Override
                     public String apply(byte[] bytes) {
-                        return bytes == null ? null : new String(bytes);
+                        return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
                     }
                 });
     }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.rest.v2.http;
 
-import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.reactivex.Flowable;
@@ -16,6 +15,7 @@ import io.reactivex.functions.Function;
 import org.reactivestreams.Subscription;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -96,7 +96,7 @@ class NettyResponse extends HttpResponse {
         return collectContent().map(new Function<ByteBuf, String>() {
             @Override
             public String apply(ByteBuf byteBuf) {
-                return byteBuf.toString(Charsets.UTF_8);
+                return byteBuf.toString(StandardCharsets.UTF_8);
             }
         });
     }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/ProxyAuthenticationPolicyFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/ProxyAuthenticationPolicyFactory.java
@@ -6,11 +6,12 @@
 
 package com.microsoft.rest.v2.policy;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import io.reactivex.Single;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Creates a RequestPolicy that adds basic proxy authentication to outgoing HTTP requests.
@@ -44,7 +45,7 @@ public class ProxyAuthenticationPolicyFactory implements RequestPolicyFactory {
         @Override
         public Single<HttpResponse> sendAsync(HttpRequest request) {
             String auth = username + ":" + password;
-            String encodedAuth = BaseEncoding.base64().encode(auth.getBytes(Charsets.UTF_8));
+            String encodedAuth = BaseEncoding.base64().encode(auth.getBytes(StandardCharsets.UTF_8));
             request.withHeader("Proxy-Authentication", "Basic " + encodedAuth);
             return next.sendAsync(request);
         }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithMockTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithMockTests.java
@@ -1,6 +1,5 @@
 package com.microsoft.rest.v2;
 
-import com.google.common.base.Charsets;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
 import com.microsoft.rest.v2.annotations.GET;
 import com.microsoft.rest.v2.annotations.HeaderCollection;
@@ -18,6 +17,7 @@ import io.reactivex.Single;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -163,7 +163,7 @@ public class RestProxyWithMockTests extends RestProxyTests {
                         headers.set("Content-Type", "application/json");
 
                         HttpResponse response = new MockHttpResponse(200, headers,
-                                "{ \"error\": \"Something went wrong, but at least this JSON is valid.\"}".getBytes(Charsets.UTF_8));
+                                "{ \"error\": \"Something went wrong, but at least this JSON is valid.\"}".getBytes(StandardCharsets.UTF_8));
                         return Single.just(response);
                     }
                 }));
@@ -186,7 +186,7 @@ public class RestProxyWithMockTests extends RestProxyTests {
                         HttpHeaders headers = new HttpHeaders();
                         headers.set("Content-Type", "application/json");
 
-                        HttpResponse response = new MockHttpResponse(200, headers, "BAD JSON".getBytes(Charsets.UTF_8));
+                        HttpResponse response = new MockHttpResponse(200, headers, "BAD JSON".getBytes(StandardCharsets.UTF_8));
                         return Single.just(response);
                     }
                 }));
@@ -211,7 +211,7 @@ public class RestProxyWithMockTests extends RestProxyTests {
                         headers.set("Content-Type", "application/json; charset=UTF-8");
 
                         HttpResponse response = new MockHttpResponse(200, headers,
-                                "{ \"error\": \"Something went wrong, but at least this JSON is valid.\"}".getBytes(Charsets.UTF_8));
+                                "{ \"error\": \"Something went wrong, but at least this JSON is valid.\"}".getBytes(StandardCharsets.UTF_8));
                         return Single.just(response);
                     }
                 }));
@@ -234,7 +234,7 @@ public class RestProxyWithMockTests extends RestProxyTests {
                         HttpHeaders headers = new HttpHeaders();
                         headers.set("Content-Type", "application/json; charset=UTF-8");
 
-                        HttpResponse response = new MockHttpResponse(200, headers, "BAD JSON".getBytes(Charsets.UTF_8));
+                        HttpResponse response = new MockHttpResponse(200, headers, "BAD JSON".getBytes(StandardCharsets.UTF_8));
                         return Single.just(response);
                     }
                 }));

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyXMLTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyXMLTests.java
@@ -7,7 +7,6 @@
 
 package com.microsoft.rest.v2;
 
-import com.google.common.base.Charsets;
 import com.google.common.reflect.TypeToken;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.GET;
@@ -36,6 +35,7 @@ import io.reactivex.Single;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -133,7 +133,7 @@ public class RestProxyXMLTests {
         myXMLService.setContainerACLs(wrapper);
 
         SignedIdentifiersWrapper actualAclsWrapped = serializer.deserialize(
-                new String(httpClient.receivedBytes, Charsets.UTF_8),
+                new String(httpClient.receivedBytes, StandardCharsets.UTF_8),
                 new TypeToken<SignedIdentifiersWrapper>() {}.getType(),
                 SerializerEncoding.XML);
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.rest.v2.http;
 
-import com.google.common.base.Charsets;
 import com.microsoft.rest.v2.Base64Url;
 import com.microsoft.rest.v2.DateTimeRfc1123;
 import com.microsoft.rest.v2.entities.HttpBinJSON;
@@ -17,6 +16,7 @@ import io.reactivex.Single;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -186,7 +186,7 @@ public class MockHttpClient extends HttpClient {
                     .map(new Function<byte[], String>() {
                 @Override
                 public String apply(byte[] bytes) throws Exception {
-                    return new String(bytes, Charsets.UTF_8);
+                    return new String(bytes, StandardCharsets.UTF_8);
                 }
             });
             body = asyncString.blockingGet();


### PR DESCRIPTION
- There were some runtime errors on the Windows command line because we were using `new String(byte[])` instead of `new String(byte[], StandardCharsets.UTF_8)`.
- Changed all current usages of Guava Charsets to use StandardCharsets in the hope of loosening our grip on that dependency