### PR TITLE
Add shutdown() method to HttpClient.Factory

### DIFF
--- a/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/RefreshTokenClient.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/RefreshTokenClient.java
@@ -11,16 +11,17 @@ import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
 import com.microsoft.aad.adal4j.AuthenticationResult;
 import com.microsoft.azure.management.apigeneration.Beta;
-import com.microsoft.rest.v2.annotations.Host;
-import com.microsoft.rest.v2.annotations.HostParam;
-import com.microsoft.rest.v2.http.ContentType;
-import com.microsoft.rest.v2.http.HttpPipeline;
 import com.microsoft.rest.v2.RestProxy;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
+import com.microsoft.rest.v2.annotations.Host;
+import com.microsoft.rest.v2.annotations.HostParam;
 import com.microsoft.rest.v2.annotations.POST;
 import com.microsoft.rest.v2.annotations.PathParam;
+import com.microsoft.rest.v2.http.ContentType;
 import com.microsoft.rest.v2.http.HttpClient;
+import com.microsoft.rest.v2.http.HttpClientConfiguration;
+import com.microsoft.rest.v2.http.HttpPipeline;
 import com.microsoft.rest.v2.http.NettyClient;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
@@ -47,7 +48,7 @@ final class RefreshTokenClient {
 
     private static HttpClient createHttpClient(Proxy proxy) {
         return new NettyClient.Factory()
-                .create(new HttpClient.Configuration(proxy));
+                .create(new HttpClientConfiguration(proxy));
     }
 
     AuthenticationResult refreshToken(String tenant, String clientId, String resource, String refreshToken, boolean isMultipleResoureRefreshToken) {

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyToRestProxyWithNettyTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyToRestProxyWithNettyTests.java
@@ -1,17 +1,14 @@
 package com.microsoft.azure.v2;
 
 import com.microsoft.rest.v2.http.HttpClient;
-import com.microsoft.rest.v2.http.HttpClient.Configuration;
+import com.microsoft.rest.v2.http.HttpClientConfiguration;
 import com.microsoft.rest.v2.http.NettyClient;
-import com.microsoft.rest.v2.policy.RequestPolicy;
-
-import java.util.Collections;
 
 public class AzureProxyToRestProxyWithNettyTests extends AzureProxyToRestProxyTests {
     private final NettyClient.Factory nettyClientFactory = new NettyClient.Factory();
 
     @Override
     protected HttpClient createHttpClient() {
-        return nettyClientFactory.create(new Configuration(null));
+        return nettyClientFactory.create(new HttpClientConfiguration(null));
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClient.java
@@ -6,10 +6,10 @@
 
 package com.microsoft.rest.v2.http;
 
+import io.reactivex.Completable;
 import io.reactivex.Single;
 
 import java.net.Proxy;
-import java.util.concurrent.Future;
 
 /**
  * A generic interface for sending HTTP requests and getting responses.
@@ -79,11 +79,12 @@ public abstract class HttpClient {
         HttpClient create(Configuration configuration);
 
         /**
-         * Synchronously awaits completion of in-flight tasks,
+         * Asynchronously awaits completion of in-flight tasks,
          * then closes shared resources associated with this HttpClient.Factory.
+         * After this Completable completes, HttpClients created from this Factory can no longer be used.
          *
-         * @return a Future which completes when shutdown finishes.
+         * @return a Completable which shuts down the factory when subscribed to.
          */
-        Future<?> shutdown();
+        Completable shutdown();
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClient.java
@@ -8,6 +8,7 @@ package com.microsoft.rest.v2.http;
 
 import io.reactivex.Single;
 
+import java.io.Closeable;
 import java.net.Proxy;
 
 /**
@@ -21,9 +22,7 @@ public abstract class HttpClient {
      */
     public abstract Single<HttpResponse> sendRequestAsync(HttpRequest request);
 
-    private static HttpClient.Factory defaultHttpClientFactory() {
-        return new NettyClient.Factory();
-    }
+    private static HttpClient.Factory defaultHttpClientFactory = new NettyClient.Factory();
 
     /**
      * Create an instance of the default HttpClient type.
@@ -39,7 +38,7 @@ public abstract class HttpClient {
      * @return an instance of the default HttpClient type.
      */
     public static HttpClient createDefault(HttpClient.Configuration configuration) {
-        return defaultHttpClientFactory().create(configuration);
+        return defaultHttpClientFactory.create(configuration);
     }
 
     /**
@@ -67,12 +66,19 @@ public abstract class HttpClient {
     /**
      * Creates an HttpClient from a Configuration.
      */
-    public interface Factory {
+    public interface Factory extends Closeable {
         /**
          * Creates an HttpClient with the given Configuration.
          * @param configuration the configuration.
          * @return the HttpClient.
          */
         HttpClient create(Configuration configuration);
+
+        /**
+         * Synchronously awaits completion of in-flight tasks,
+         * then closes shared resources associated with this HttpClient.Factory.
+         */
+        @Override
+        void close();
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClient.java
@@ -6,10 +6,7 @@
 
 package com.microsoft.rest.v2.http;
 
-import io.reactivex.Completable;
 import io.reactivex.Single;
-
-import java.net.Proxy;
 
 /**
  * A generic interface for sending HTTP requests and getting responses.
@@ -25,7 +22,7 @@ public abstract class HttpClient {
     private static final class DefaultHttpClientHolder {
         // Putting this field in an inner class makes it so it is only instantiated when
         // one of the createDefault() methods instead of instantiating when any members are accessed.
-        private static HttpClient.Factory defaultHttpClientFactory = new NettyClient.Factory();
+        private static HttpClientFactory defaultHttpClientFactory = new NettyClient.Factory();
     }
 
     /**
@@ -41,50 +38,7 @@ public abstract class HttpClient {
      * @param configuration The configuration to apply to the HttpClient.
      * @return an instance of the default HttpClient type.
      */
-    public static HttpClient createDefault(HttpClient.Configuration configuration) {
+    public static HttpClient createDefault(HttpClientConfiguration configuration) {
         return DefaultHttpClientHolder.defaultHttpClientFactory.create(configuration);
-    }
-
-    /**
-     * The set of parameters used to create an HTTP client.
-     */
-    public static final class Configuration {
-        private final Proxy proxy;
-
-        /**
-         * @return The optional proxy to use.
-         */
-        public Proxy proxy() {
-            return proxy;
-        }
-
-        /**
-         * Creates a Configuration.
-         * @param proxy The optional proxy to use.
-         */
-        public Configuration(Proxy proxy) {
-            this.proxy = proxy;
-        }
-    }
-
-    /**
-     * Creates an HttpClient from a Configuration.
-     */
-    public interface Factory {
-        /**
-         * Creates an HttpClient with the given Configuration.
-         * @param configuration the configuration.
-         * @return the HttpClient.
-         */
-        HttpClient create(Configuration configuration);
-
-        /**
-         * Asynchronously awaits completion of in-flight tasks,
-         * then closes shared resources associated with this HttpClient.Factory.
-         * After this Completable completes, HttpClients created from this Factory can no longer be used.
-         *
-         * @return a Completable which shuts down the factory when subscribed to.
-         */
-        Completable shutdown();
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientConfiguration.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientConfiguration.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2.http;
+
+import java.net.Proxy;
+
+/**
+ * The set of parameters used to create an HTTP client.
+ */
+public class HttpClientConfiguration {
+    private final Proxy proxy;
+
+    /**
+     * @return The optional proxy to use.
+     */
+    public Proxy proxy() {
+        return proxy;
+    }
+
+    /**
+     * Creates an HttpClientConfiguration.
+     * @param proxy The optional proxy to use.
+     */
+    public HttpClientConfiguration(Proxy proxy) {
+        this.proxy = proxy;
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientFactory.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2.http;
+
+import io.reactivex.Completable;
+
+/**
+ * Creates an HttpClient from a Configuration.
+ */
+public interface HttpClientFactory {
+    /**
+     * Creates an HttpClient with the given Configuration.
+     * @param configuration the configuration.
+     * @return the HttpClient.
+     */
+    HttpClient create(HttpClientConfiguration configuration);
+
+    /**
+     * Asynchronously awaits completion of in-flight requests,
+     * then closes shared resources associated with this HttpClient.Factory.
+     * After this Completable completes, HttpClients created from this Factory can no longer be used.
+     *
+     * @return a Completable which shuts down the factory when subscribed to.
+     */
+    Completable shutdown();
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -66,7 +66,7 @@ public final class NettyClient extends HttpClient {
      * @param configuration the HTTP client configuration.
      * @param adapter the adapter to Netty
      */
-    private NettyClient(HttpClient.Configuration configuration, NettyAdapter adapter) {
+    private NettyClient(HttpClientConfiguration configuration, NettyAdapter adapter) {
         this.adapter = adapter;
         this.proxy = configuration == null ? null : configuration.proxy();
     }
@@ -567,7 +567,7 @@ public final class NettyClient extends HttpClient {
     /**
      * The factory for creating a NettyClient.
      */
-    public static class Factory implements HttpClient.Factory {
+    public static class Factory implements HttpClientFactory {
         private final NettyAdapter adapter;
 
         /**
@@ -588,7 +588,7 @@ public final class NettyClient extends HttpClient {
         }
 
         @Override
-        public HttpClient create(final Configuration configuration) {
+        public HttpClient create(final HttpClientConfiguration configuration) {
             return new NettyClient(configuration, adapter);
         }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -598,6 +598,7 @@ public final class NettyClient extends HttpClient {
 
         @Override
         public void close() {
+            LoggerFactory.getLogger(getClass()).info("Shutting down NettyAdapter");
             Future<?> result = this.adapter.shutdownGracefully().awaitUninterruptibly();
             if (!result.isSuccess()) {
                 throw Exceptions.propagate(result.cause());

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -192,7 +192,7 @@ public final class NettyClient extends HttpClient {
                             "SocketAddress on java.net.Proxy must be an InetSocketAddress. Found proxy: " + proxy);
                 }
 
-                request.withHeader(io.netty.handler.codec.http.HttpHeaders.Names.HOST, channelAddress.getHost());
+                request.withHeader(io.netty.handler.codec.http.HttpHeaders.Names.HOST, request.url().getHost());
                 request.withHeader(io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION, io.netty.handler.codec.http.HttpHeaders.Values.KEEP_ALIVE);
             } catch (URISyntaxException e) {
                 return Single.error(e);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.reactivex.Completable;
@@ -54,6 +55,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -103,28 +105,25 @@ public final class NettyClient extends HttpClient {
             }
         }
 
-        private static MultithreadEventLoopGroup loadEventLoopGroup(String className, Integer optionalSize) throws ReflectiveOperationException {
-            MultithreadEventLoopGroup result;
-            if (optionalSize == null) {
-                result = (MultithreadEventLoopGroup) Class.forName(className).getConstructor().newInstance();
-            } else {
-                result = (MultithreadEventLoopGroup) Class.forName(className).getConstructor(Integer.TYPE).newInstance(optionalSize);
-            }
+        private static MultithreadEventLoopGroup loadEventLoopGroup(String className, int size) throws ReflectiveOperationException {
+            Class<?> cls = Class.forName(className);
+            ThreadFactory factory = new DefaultThreadFactory(cls, true);
+            MultithreadEventLoopGroup result = (MultithreadEventLoopGroup) cls.getConstructor(Integer.TYPE, ThreadFactory.class).newInstance(size, factory);
             return result;
         }
 
         @SuppressWarnings("unchecked")
-        private static TransportConfig loadTransport(Integer optionalGroupSize) {
+        private static TransportConfig loadTransport(int groupSize) {
             TransportConfig result = null;
             try {
                 final String osName = System.getProperty("os.name");
                 if (osName.contains("Linux")) {
                     result = new TransportConfig(
-                            loadEventLoopGroup(EPOLL_GROUP_CLASS_NAME, optionalGroupSize),
+                            loadEventLoopGroup(EPOLL_GROUP_CLASS_NAME, groupSize),
                             (Class<? extends SocketChannel>) Class.forName(EPOLL_SOCKET_CLASS_NAME));
                 } else if (osName.contains("Mac")) {
                     result = new TransportConfig(
-                            loadEventLoopGroup(KQUEUE_GROUP_CLASS_NAME, optionalGroupSize),
+                            loadEventLoopGroup(KQUEUE_GROUP_CLASS_NAME, groupSize),
                             (Class<? extends SocketChannel>) Class.forName(KQUEUE_SOCKET_CLASS_NAME));
                 }
             } catch (Exception e) {
@@ -139,7 +138,7 @@ public final class NettyClient extends HttpClient {
             }
 
             if (result == null) {
-                result = new TransportConfig(new NioEventLoopGroup(), NioSocketChannel.class);
+                result = new TransportConfig(new NioEventLoopGroup(groupSize, new DefaultThreadFactory(NioEventLoopGroup.class, true)), NioSocketChannel.class);
             }
 
             return result;
@@ -163,9 +162,9 @@ public final class NettyClient extends HttpClient {
         }
 
         private NettyAdapter() {
-            TransportConfig config = loadTransport(null);
+            TransportConfig config = loadTransport(0);
             this.eventLoopGroup = config.eventLoopGroup;
-            this.channelPool = createChannelPool(this, config, eventLoopGroup.executorCount() * 2);
+            this.channelPool = createChannelPool(this, config, eventLoopGroup.executorCount() * 16);
         }
 
         private NettyAdapter(int eventLoopGroupSize, int channelPoolSize) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -32,6 +32,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.reactivex.Completable;
+import io.reactivex.CompletableSource;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableSubscriber;
 import io.reactivex.Scheduler;
@@ -52,6 +53,7 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -590,7 +592,12 @@ public final class NettyClient extends HttpClient {
 
         @Override
         public Completable shutdown() {
-            return Completable.fromFuture(this.adapter.shutdownGracefully());
+            return Completable.defer(new Callable<CompletableSource>() {
+                @Override
+                public CompletableSource call() throws Exception {
+                    return Completable.fromFuture(adapter.shutdownGracefully());
+                }
+            });
         }
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.rest.v2.http;
 
-import com.microsoft.rest.v2.RestException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.reactivex.Flowable;
@@ -52,13 +51,18 @@ class NettyResponse extends HttpResponse {
     }
 
     private Single<ByteBuf> collectContent() {
+        ByteBuf allContent = null;
         String contentLengthString = headerValue("Content-Length");
-        final ByteBuf allContent;
-        try {
-            int contentLength = Integer.parseInt(contentLengthString);
-            allContent = Unpooled.buffer(contentLength);
-        } catch (NumberFormatException e) {
-            return Single.error(new RestException("Unexpected format for Content-Length header: " + contentLengthString, this, e));
+        if (contentLengthString != null) {
+            try {
+                int contentLength = Integer.parseInt(contentLengthString);
+                allContent = Unpooled.buffer(contentLength);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        if (allContent == null) {
+            allContent = Unpooled.buffer();
         }
 
         return contentStream.collectInto(allContent, new BiConsumer<ByteBuf, ByteBuf>() {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -18,6 +18,8 @@ import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
+import io.reactivex.exceptions.Exceptions;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
 import java.net.URI;
@@ -27,6 +29,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A Netty channel pool implementation shared between multiple requests.
@@ -62,6 +65,8 @@ public class SharedChannelPool implements ChannelPool {
      * @param size the upper limit of total number of channels
      */
     public SharedChannelPool(final Bootstrap bootstrap, final ChannelPoolHandler handler, int size) {
+        LoggerFactory.getLogger(getClass()).info("Creating channel pool.");
+
         this.bootstrap = bootstrap.clone().handler(new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
@@ -89,6 +94,7 @@ public class SharedChannelPool implements ChannelPool {
                         final ChannelFuture channelFuture;
                         synchronized (requests) {
                             while (requests.isEmpty() && !closed) {
+                                LoggerFactory.getLogger(getClass()).info("Waiting for request. Closed: " + closed);
                                 requests.wait(1000);
                             }
                         }
@@ -241,7 +247,11 @@ public class SharedChannelPool implements ChannelPool {
     @Override
     public void close() {
         closed = true;
-        executor.shutdown();
+        try {
+            executor.awaitTermination(24, TimeUnit.HOURS);
+        } catch (InterruptedException e) {
+            throw Exceptions.propagate(e);
+        }
     }
 
     private static class ChannelRequest {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * A Netty channel pool implementation shared between multiple requests.
@@ -79,7 +80,15 @@ public class SharedChannelPool implements ChannelPool {
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }
-        this.executor = Executors.newSingleThreadExecutor();
+        this.executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r, "SharedChannelPool-worker");
+                thread.setDaemon(true);
+                return thread;
+            }
+        });
+
         executor.submit(new Runnable() {
             @Override
             public void run() {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithHttpProxyNettyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithHttpProxyNettyTests.java
@@ -1,13 +1,12 @@
 package com.microsoft.rest.v2;
 
 import com.microsoft.rest.v2.http.HttpClient;
+import com.microsoft.rest.v2.http.HttpClientConfiguration;
 import com.microsoft.rest.v2.http.NettyClient;
-import com.microsoft.rest.v2.policy.RequestPolicy;
 import org.junit.Ignore;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.util.Collections;
 
 @Ignore("Should only be run manually when a local proxy server (e.g. Fiddler) is running")
 public class RestProxyWithHttpProxyNettyTests extends RestProxyTests {
@@ -17,6 +16,6 @@ public class RestProxyWithHttpProxyNettyTests extends RestProxyTests {
     protected HttpClient createHttpClient() {
         InetSocketAddress address = new InetSocketAddress("127.0.0.1", 8888);
         Proxy proxy = new Proxy(Proxy.Type.HTTP, address);
-        return nettyClientFactory.create(new HttpClient.Configuration(proxy));
+        return nettyClientFactory.create(new HttpClientConfiguration(proxy));
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithNettyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithNettyTests.java
@@ -1,7 +1,7 @@
 package com.microsoft.rest.v2;
 
 import com.microsoft.rest.v2.http.HttpClient;
-import com.microsoft.rest.v2.http.HttpClient.Configuration;
+import com.microsoft.rest.v2.http.HttpClientConfiguration;
 import com.microsoft.rest.v2.http.NettyClient;
 
 public class RestProxyWithNettyTests extends RestProxyTests {
@@ -9,6 +9,6 @@ public class RestProxyWithNettyTests extends RestProxyTests {
 
     @Override
     protected HttpClient createHttpClient() {
-        return nettyClientFactory.create(new Configuration(null));
+        return nettyClientFactory.create(new HttpClientConfiguration(null));
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -28,8 +28,10 @@ public class NettyClientTests {
         HttpClient client = factory.create(null);
         HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
 
+        LoggerFactory.getLogger(getClass()).info("Closing factory");
         factory.close();
         try {
+            LoggerFactory.getLogger(getClass()).info("Sending request");
             client.sendRequestAsync(request).blockingGet();
             fail();
         } catch (RejectedExecutionException ignored) {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 public class NettyClientTests {
     @Test
     public void testRequestBeforeShutdownSucceeds() throws Exception {
-        final HttpClient.Factory factory = new NettyClient.Factory();
+        final HttpClientFactory factory = new NettyClient.Factory();
         HttpClient client = factory.create(null);
         HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
 
@@ -25,7 +25,7 @@ public class NettyClientTests {
 
     @Test
     public void testRequestAfterShutdownIsRejected() throws Exception {
-        final HttpClient.Factory factory = new NettyClient.Factory();
+        final HttpClientFactory factory = new NettyClient.Factory();
         HttpClient client = factory.create(null);
         HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
 
@@ -46,7 +46,7 @@ public class NettyClientTests {
     public void testInFlightRequestSucceedsAfterCancellation() throws Exception {
         // Retry a few times in case shutdown begins before the request is submitted to Netty
         for (int i = 0; i < 3; i++) {
-            final HttpClient.Factory factory = new NettyClient.Factory();
+            final HttpClientFactory factory = new NettyClient.Factory();
             HttpClient client = factory.create(null);
             HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -1,0 +1,71 @@
+package com.microsoft.rest.v2.http;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+public class NettyClientTests {
+    @Test
+    public void testRequestBeforeShutdownSucceeds() throws Exception {
+        final HttpClient.Factory factory = new NettyClient.Factory();
+        HttpClient client = factory.create(null);
+        HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
+
+        client.sendRequestAsync(request).blockingGet();
+        factory.close();
+    }
+
+    @Test
+    public void testRequestAfterShutdownIsRejected() throws Exception {
+        final HttpClient.Factory factory = new NettyClient.Factory();
+        HttpClient client = factory.create(null);
+        HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
+
+        factory.close();
+        try {
+            client.sendRequestAsync(request).blockingGet();
+            fail();
+        } catch (RejectedExecutionException ignored) {
+            // expected
+        }
+    }
+
+    @Test
+    @Ignore("Passes inconsistently due to race condition")
+    public void testInFlightRequestSucceedsAfterCancellation() throws Exception {
+        // Retry a few times in case shutdown begins before the request is submitted to Netty
+        for (int i = 0; i < 3; i++) {
+            final HttpClient.Factory factory = new NettyClient.Factory();
+            HttpClient client = factory.create(null);
+            HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
+
+            Future<HttpResponse> asyncResponse = client.sendRequestAsync(request).toFuture();
+            Thread.sleep(100);
+            factory.close();
+
+            boolean shouldRetry = false;
+            try {
+                asyncResponse.get(5, TimeUnit.SECONDS);
+            } catch (IllegalStateException e) {
+                shouldRetry = true;
+            }
+
+            if (!shouldRetry) {
+                break;
+            }
+
+            if (i == 2) {
+                fail();
+            } else {
+                LoggerFactory.getLogger(getClass()).info("Shutdown started before sending request. Retry attempt " + i+1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Users should be able to free the resources associated with an HttpClient when they're done using it. This PR makes it so:
- All default HTTP pipelines share a static, lazy instantiated HttpClientFactory so that we don't leak the implicitly created resources (EventLoopGroups, channels)
- Manually created HttpPipelines require users to hold on to the HttpClientFactory and close it if they want to reclaim the resources
  - The only alternative I can really think of for this is to add shutdown() methods to HttpPipeline and/or HttpClient themselves and to put a ref count on the HttpClient.Factory-- seems overly complicated

Addresses #372.