### PR TITLE
Fix Void response body connection leak

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -298,7 +298,8 @@ public class RestProxy implements InvocationHandler {
 
             final TypeToken bodyTypeToken = TypeToken.of(bodyType);
             if (bodyTypeToken.isSubtypeOf(Void.class)) {
-                asyncResult = Single.just(new RestResponse<>(responseStatusCode, deserializedHeaders, responseHeaders.toMap(), null));
+                asyncResult = response.streamBodyAsync().lastElement().ignoreElement()
+                        .andThen(Single.just(new RestResponse<>(responseStatusCode, deserializedHeaders, responseHeaders.toMap(), null)));
             } else {
                 final Map<String, String> rawHeaders = responseHeaders.toMap();
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
@@ -43,7 +43,7 @@ public class MockHttpResponse extends HttpResponse {
     }
 
     public MockHttpResponse(int statusCode, HttpHeaders headers) {
-        this(statusCode, headers, null);
+        this(statusCode, headers, new byte[0]);
     }
 
     public MockHttpResponse(int statusCode, HttpHeaders headers, Object serializable) {


### PR DESCRIPTION
A tester found an interesting problem where when we issue many HttpRequests, the responses eventually hang. This was tracked down to the fact that the RestResponse body type was Void and we were discarding the HttpResponse instead of either closing it or reading it. This normally wouldn't be a problem, except with a chunked encoding where there are still body bytes to read to basically indicate the end of the response content.

This fix assumes that the only content to read is going to be such a content, like a trailing `"0\n"` string or similar. I read and discard the body content when the body is Void because it seems preferable to closing the response which would result in the connection being closed.