### PR TITLE
Add RestResponse subtypes and handling

### DIFF
--- a/azure-client-authentication/pom.xml
+++ b/azure-client-authentication/pom.xml
@@ -73,8 +73,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/azure-client-runtime/pom.xml
+++ b/azure-client-runtime/pom.xml
@@ -63,8 +63,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -112,8 +112,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/BodyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/BodyResponse.java
@@ -15,14 +15,14 @@ import java.util.Map;
  */
 public final class BodyResponse<TBody> extends RestResponse<Void, TBody> {
     /**
-     * Create a new RestResponse object.
+     * Creates a new BodyResponse object.
      *
-     * @param statusCode The status code of the HTTP response.
-     * @param rawHeaders The raw headers of the HTTP response.
-     * @param tBody      The deserialized body.
+     * @param statusCode the status code of the HTTP response
+     * @param rawHeaders the raw headers of the HTTP response
+     * @param body the deserialized body
      */
-    public BodyResponse(int statusCode, Map<String, String> rawHeaders, TBody tBody) {
-        super(statusCode, null, rawHeaders, tBody);
+    public BodyResponse(int statusCode, Map<String, String> rawHeaders, TBody body) {
+        super(statusCode, null, rawHeaders, body);
     }
 
     // Used for uniform reflective creation in RestProxy.
@@ -32,8 +32,7 @@ public final class BodyResponse<TBody> extends RestResponse<Void, TBody> {
     }
 
     /**
-     * The deserialized body of the HTTP response.
-     * @return The deserialized body of the HTTP response.
+     * @return the deserialized body of the HTTP response
      */
     public TBody body() {
         return super.body();

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/BodyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/BodyResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2;
+
+import java.util.Map;
+
+/**
+ * A response to a REST call with a strongly-typed body specified.
+ *
+ * @param <TBody> The deserialized type of the response body.
+ */
+public final class BodyResponse<TBody> extends RestResponse<Void, TBody> {
+    /**
+     * Create a new RestResponse object.
+     *
+     * @param statusCode The status code of the HTTP response.
+     * @param rawHeaders The raw headers of the HTTP response.
+     * @param tBody      The deserialized body.
+     */
+    public BodyResponse(int statusCode, Map<String, String> rawHeaders, TBody tBody) {
+        super(statusCode, null, rawHeaders, tBody);
+    }
+
+    // Used for uniform reflective creation in RestProxy.
+    @SuppressWarnings("unused")
+    BodyResponse(int statusCode, Void headers, Map<String, String> rawHeaders, TBody body) {
+        super(statusCode, headers, rawHeaders, body);
+    }
+
+    /**
+     * The deserialized body of the HTTP response.
+     * @return The deserialized body of the HTTP response.
+     */
+    public TBody body() {
+        return super.body();
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestResponse.java
@@ -6,11 +6,6 @@
 
 package com.microsoft.rest.v2;
 
-import io.reactivex.Flowable;
-import io.reactivex.FlowableSubscriber;
-import org.reactivestreams.Subscription;
-
-import java.io.Closeable;
 import java.util.Map;
 
 /**
@@ -18,7 +13,7 @@ import java.util.Map;
  * @param <THeaders> The deserialized type of the response headers.
  * @param <TBody> The deserialized type of the response body.
  */
-public class RestResponse<THeaders, TBody> implements Closeable {
+public class RestResponse<THeaders, TBody> {
     private final int statusCode;
     private final THeaders headers;
     private final Map<String, String> rawHeaders;
@@ -39,7 +34,6 @@ public class RestResponse<THeaders, TBody> implements Closeable {
     }
 
     /**
-     * The status code of the HTTP response.
      * @return The status code of the HTTP response.
      */
     public int statusCode() {
@@ -47,7 +41,6 @@ public class RestResponse<THeaders, TBody> implements Closeable {
     }
 
     /**
-     * The deserialized headers of the HTTP response.
      * @return The deserialized headers of the HTTP response.
      */
     public THeaders headers() {
@@ -55,7 +48,6 @@ public class RestResponse<THeaders, TBody> implements Closeable {
     }
 
     /**
-     * The raw HTTP response headers.
      * @return A Map containing the raw HTTP response headers.
      */
     public Map<String, String> rawHeaders() {
@@ -63,39 +55,9 @@ public class RestResponse<THeaders, TBody> implements Closeable {
     }
 
     /**
-     * The deserialized body of the HTTP response.
      * @return The deserialized body of the HTTP response.
      */
     public TBody body() {
         return body;
-    }
-
-    /**
-     * Closes the content stream associated with this RestResponse, if any.
-     */
-    public void close() {
-        if (body instanceof Flowable) {
-            ((Flowable<?>) body).subscribe(new FlowableSubscriber<Object>() {
-                @Override
-                public void onSubscribe(Subscription s) {
-                    s.cancel();
-                }
-
-                @Override
-                public void onNext(Object next) {
-                    // no-op
-                }
-
-                @Override
-                public void onError(Throwable ignored) {
-                    // May receive a "multiple subscription not allowed" error here, but we don't care
-                }
-
-                @Override
-                public void onComplete() {
-                    // no-op
-                }
-            });
-        }
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/StreamResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/StreamResponse.java
@@ -18,11 +18,11 @@ import java.util.Map;
  */
 public final class StreamResponse extends RestResponse<Void, Flowable<ByteBuffer>> implements Closeable {
     /**
-     * Create a StreamResponse.
+     * Creates a StreamResponse.
      *
-     * @param statusCode The status code of the HTTP response.
-     * @param rawHeaders The raw headers of the HTTP response.
-     * @param body      The streaming body.
+     * @param statusCode the status code of the HTTP response
+     * @param rawHeaders the raw headers of the HTTP response
+     * @param body the streaming body
      */
     public StreamResponse(int statusCode, Map<String, String> rawHeaders, Flowable<ByteBuffer> body) {
         super(statusCode, null, rawHeaders, body);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/StreamResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/StreamResponse.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.functions.Functions;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * A response to a REST call with a streaming body.
+ */
+public final class StreamResponse extends RestResponse<Void, Flowable<ByteBuffer>> implements Closeable {
+    /**
+     * Create a StreamResponse.
+     *
+     * @param statusCode The status code of the HTTP response.
+     * @param rawHeaders The raw headers of the HTTP response.
+     * @param body      The streaming body.
+     */
+    public StreamResponse(int statusCode, Map<String, String> rawHeaders, Flowable<ByteBuffer> body) {
+        super(statusCode, null, rawHeaders, body);
+    }
+
+    // Used for uniform reflective creation in RestProxy.
+    @SuppressWarnings("unused")
+    StreamResponse(int statusCode, Void headers, Map<String, String> rawHeaders, Flowable<ByteBuffer> body) {
+        super(statusCode, headers, rawHeaders, body);
+    }
+
+    /**
+     * Always returns null due to no headers type being defined in the service specification.
+     * Consider using {@link #rawHeaders()}.
+     *
+     * @return null
+     */
+    @Override
+    public Void headers() {
+        return super.headers();
+    }
+
+    /**
+     * @return the body content stream
+     */
+    @Override
+    public Flowable<ByteBuffer> body() {
+        return super.body();
+    }
+
+    /**
+     * Disposes of the connection associated with this StreamResponse.
+     */
+    @Override
+    public void close() {
+        body().subscribe(Functions.emptyConsumer(), Functions.<Throwable>emptyConsumer()).dispose();
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/SwaggerMethodParser.java
@@ -449,10 +449,10 @@ public class SwaggerMethodParser {
             if (syncReturnTypeToken.isSubtypeOf(Void.class)) {
                 result = false;
             } else if (syncReturnTypeToken.isSubtypeOf(RestResponse.class)) {
-                result = restResponseTypeExpectsBody((ParameterizedType) syncReturnType);
+                result = restResponseTypeExpectsBody((ParameterizedType) syncReturnTypeToken.getSupertype(RestResponse.class).getType());
             }
         } else if (returnTypeToken.isSubtypeOf(RestResponse.class)) {
-            result = restResponseTypeExpectsBody((ParameterizedType) returnType);
+            result = restResponseTypeExpectsBody((ParameterizedType) returnTypeToken.getSupertype(RestResponse.class).getType());
         }
 
         return result;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/VoidResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/VoidResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2;
+
+import java.util.Map;
+
+/**
+ * A response to a REST call containing only a status code and raw headers.
+ */
+public final class VoidResponse extends RestResponse<Void, Void> {
+    /**
+     * Create a StreamResponse.
+     *
+     * @param statusCode The status code of the HTTP response.
+     * @param rawHeaders The raw headers of the HTTP response.
+     */
+    public VoidResponse(int statusCode, Map<String, String> rawHeaders) {
+        super(statusCode, null, rawHeaders, null);
+    }
+
+    // Used for uniform reflective creation in RestProxy.
+    @SuppressWarnings("unused")
+    VoidResponse(int statusCode, Void headers, Map<String, String> rawHeaders, Void body) {
+        super(statusCode, headers, rawHeaders, body);
+    }
+
+    /**
+     * Always returns null due to no headers type being defined in the service specification. Consider using {@link #rawHeaders()}.
+     * @return null
+     */
+    @Override
+    public Void headers() {
+        return super.headers();
+    }
+
+    /**
+     * @return null due to no body type being defined in the service specification
+     */
+    @Override
+    public Void body() {
+        return super.body();
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/VoidResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/VoidResponse.java
@@ -13,10 +13,10 @@ import java.util.Map;
  */
 public final class VoidResponse extends RestResponse<Void, Void> {
     /**
-     * Create a StreamResponse.
+     * Creates a StreamResponse.
      *
-     * @param statusCode The status code of the HTTP response.
-     * @param rawHeaders The raw headers of the HTTP response.
+     * @param statusCode the status code of the HTTP response
+     * @param rawHeaders the raw headers of the HTTP response
      */
     public VoidResponse(int statusCode, Map<String, String> rawHeaders) {
         super(statusCode, null, rawHeaders, null);
@@ -29,7 +29,9 @@ public final class VoidResponse extends RestResponse<Void, Void> {
     }
 
     /**
-     * Always returns null due to no headers type being defined in the service specification. Consider using {@link #rawHeaders()}.
+     * Always returns null due to no headers type being defined in the service specification.
+     * Consider using {@link #rawHeaders()}.
+     *
      * @return null
      */
     @Override

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
@@ -239,6 +239,7 @@ public final class HttpResponseDecoder {
                     RestResponse<?, ?> restResponse = (RestResponse<?, ?>) wireResponse;
                     Object wireResponseBody = restResponse.body();
 
+                    // FIXME: RestProxy is always in charge of creating RestResponse--so this doesn't seem right
                     Object resultBody = convertToResultType(wireResponseBody, getTypeArguments(resultType)[1], wireType);
                     if (wireResponseBody != resultBody) {
                         result = new RestResponse<>(restResponse.statusCode(), restResponse.headers(), restResponse.rawHeaders(), resultBody);
@@ -260,6 +261,7 @@ public final class HttpResponseDecoder {
         }
 
         if (token.isSubtypeOf(RestResponse.class)) {
+            token = token.getSupertype(RestResponse.class);
             token = TypeToken.of(getTypeArguments(token.getType())[1]);
         }
 
@@ -283,6 +285,7 @@ public final class HttpResponseDecoder {
         }
 
         if (token.isSubtypeOf(RestResponse.class)) {
+            token = token.getSupertype(RestResponse.class);
             headersType = getTypeArguments(token.getType())[0];
         }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -124,13 +124,13 @@ public final class FlowableUtil {
 
                     CompletionHandler<Integer, Object> onWriteCompleted = new CompletionHandler<Integer, Object>() {
                         @Override
-                        public void completed(Integer bytesRead, Object attachment) {
+                        public void completed(Integer bytesWritten, Object attachment) {
                             isWriting = false;
                             if (isCompleted) {
                                 emitter.onComplete();
                             }
                             //noinspection NonAtomicOperationOnVolatileField
-                            position += bytesRead;
+                            position += bytesWritten;
                             subscription.request(1);
                         }
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.rest.v2;
 
-import com.google.common.io.BaseEncoding;
 import com.microsoft.rest.v2.annotations.BodyParam;
 import com.microsoft.rest.v2.annotations.DELETE;
 import com.microsoft.rest.v2.annotations.ExpectedResponses;
@@ -29,15 +28,10 @@ import com.microsoft.rest.v2.policy.RequestPolicyOptions;
 import com.microsoft.rest.v2.util.FlowableUtil;
 import io.reactivex.Completable;
 import io.reactivex.CompletableSource;
-import io.reactivex.Emitter;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.SingleSource;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.BiConsumer;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
 import org.joda.time.DateTime;
@@ -48,7 +42,6 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.PeriodFormat;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.reactivestreams.Publisher;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
@@ -64,6 +57,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -264,7 +258,7 @@ public class RestProxyStressTests {
                     Flowable<ByteBuffer> stream = FlowableUtil.readFile(fileStream);
                     return service.upload100MB(String.valueOf(id), sas, "BlockBlob", stream, FILE_SIZE).flatMapCompletable(response -> {
                         String base64MD5 = response.rawHeaders().get("Content-MD5");
-                        byte[] receivedMD5 = BaseEncoding.base64().decode(base64MD5);
+                        byte[] receivedMD5 = Base64.getDecoder().decode(base64MD5);
                         assertArrayEquals(md5, receivedMD5);
                         return Completable.complete();
                     });
@@ -300,7 +294,7 @@ public class RestProxyStressTests {
                     Flowable<ByteBuffer> stream = FlowableUtil.split(fileStream.map(FileChannel.MapMode.READ_ONLY, 0, fileStream.size()), CHUNK_SIZE);
                     return service.upload100MB(String.valueOf(id), sas, "BlockBlob", stream, FILE_SIZE).flatMapCompletable(response -> {
                         String base64MD5 = response.rawHeaders().get("Content-MD5");
-                        byte[] receivedMD5 = BaseEncoding.base64().decode(base64MD5);
+                        byte[] receivedMD5 = Base64.getDecoder().decode(base64MD5);
                         assertArrayEquals(md5, receivedMD5);
                         return Completable.complete();
                     });
@@ -383,7 +377,7 @@ public class RestProxyStressTests {
                     return service.upload100MB("copy-" + integer, sas, "BlockBlob", downloadContent, FILE_SIZE)
                             .flatMapCompletable(uploadResponse -> {
                                 String base64MD5 = uploadResponse.rawHeaders().get("Content-MD5");
-                                byte[] uploadMD5 = BaseEncoding.base64().decode(base64MD5);
+                                byte[] uploadMD5 = Base64.getDecoder().decode(base64MD5);
                                 assertArrayEquals(diskMd5, uploadMD5);
                                 LoggerFactory.getLogger(getClass()).info("Finished upload and validation for id " + id);
                                 return Completable.complete();

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -89,6 +89,7 @@ public class RestProxyStressTests {
                     .withLocale(Locale.US);
 
             private final RequestPolicy next;
+
             AddDatePolicy(RequestPolicy next) {
                 this.next = next;
             }
@@ -149,20 +150,20 @@ public class RestProxyStressTests {
 
     @Host("https://javasdktest.blob.core.windows.net")
     interface IOService {
-        @ExpectedResponses({ 201 })
+        @ExpectedResponses({201})
         @PUT("/javasdktest/upload/100m-{id}.dat?{sas}")
-        Single<RestResponse<Void, Void>> upload100MB(@PathParam("id") String id, @PathParam(value = "sas", encoded = true) String sas, @HeaderParam("x-ms-blob-type") String blobType, @BodyParam(ContentType.APPLICATION_OCTET_STREAM) Flowable<ByteBuffer> stream, @HeaderParam("content-length") long contentLength);
+        Single<VoidResponse> upload100MB(@PathParam("id") String id, @PathParam(value = "sas", encoded = true) String sas, @HeaderParam("x-ms-blob-type") String blobType, @BodyParam(ContentType.APPLICATION_OCTET_STREAM) Flowable<ByteBuffer> stream, @HeaderParam("content-length") long contentLength);
 
         @GET("/javasdktest/upload/100m-{id}.dat?{sas}")
-        Single<RestResponse<Void, Flowable<ByteBuffer>>> download100M(@PathParam("id") String id, @PathParam(value = "sas", encoded = true) String sas);
+        Single<StreamResponse> download100M(@PathParam("id") String id, @PathParam(value = "sas", encoded = true) String sas);
 
-        @ExpectedResponses({ 201 })
+        @ExpectedResponses({201})
         @PUT("/testcontainer{id}?restype=container&{sas}")
-        Single<RestResponse<Void, Void>> createContainer(@PathParam("id") String id, @PathParam(value = "sas", encoded = true) String sas);
+        Single<VoidResponse> createContainer(@PathParam("id") String id, @PathParam(value = "sas", encoded = true) String sas);
 
-        @ExpectedResponses({ 202 })
+        @ExpectedResponses({202})
         @DELETE("/testcontainer{id}?restype=container&{sas}")
-        Single<RestResponse<Void, Void>> deleteContainer(@PathParam("id") String id, @PathParam(value = "sas", encoded = true) String sas);
+        Single<VoidResponse> deleteContainer(@PathParam("id") String id, @PathParam(value = "sas", encoded = true) String sas);
     }
 
     private static final Path TEMP_FOLDER_PATH = Paths.get("temp");
@@ -199,18 +200,10 @@ public class RestProxyStressTests {
      */
     @Test
     public void prepare100MFiles() throws Exception {
-        final Flowable<ByteBuffer> contentGenerator = Flowable.generate(new Callable<Random>() {
-            @Override
-            public Random call() throws Exception {
-                return new Random();
-            }
-        }, new BiConsumer<Random, Emitter<ByteBuffer>>() {
-            @Override
-            public void accept(Random random, Emitter<ByteBuffer> emitter) throws Exception {
-                ByteBuffer buf = ByteBuffer.allocate(CHUNK_SIZE);
-                random.nextBytes(buf.array());
-                emitter.onNext(buf);
-            }
+        final Flowable<ByteBuffer> contentGenerator = Flowable.generate(Random::new, (random, emitter) -> {
+            ByteBuffer buf = ByteBuffer.allocate(CHUNK_SIZE);
+            random.nextBytes(buf.array());
+            emitter.onNext(buf);
         });
 
         deleteRecursive(TEMP_FOLDER_PATH);
@@ -227,12 +220,9 @@ public class RestProxyStressTests {
                 final AsynchronousFileChannel file = AsynchronousFileChannel.open(filePath, StandardOpenOption.READ, StandardOpenOption.WRITE);
                 final MessageDigest messageDigest = MessageDigest.getInstance("MD5");
 
-                Flowable<ByteBuffer> fileContent = contentGenerator.take(CHUNKS_PER_FILE).doOnNext(new Consumer<ByteBuffer>() {
-                    @Override
-                    public void accept(ByteBuffer bytes) throws Exception {
-                        messageDigest.update(bytes.array());
-                    }
-                });
+                Flowable<ByteBuffer> fileContent = contentGenerator
+                        .take(CHUNKS_PER_FILE)
+                        .doOnNext(buf -> messageDigest.update(buf.array()));
 
                 return FlowableUtil.writeFile(fileContent, file).andThen(Completable.defer(new Callable<CompletableSource>() {
                     @Override
@@ -262,32 +252,23 @@ public class RestProxyStressTests {
         final IOService service = RestProxy.create(IOService.class, pipeline);
 
         List<byte[]> md5s = Flowable.range(0, NUM_FILES)
-                .map(new Function<Integer, byte[]>() {
-                    @Override
-                    public byte[] apply(Integer integer) throws Exception {
-                        final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
-                        return Files.readAllBytes(filePath);
-                    }
+                .map(integer -> {
+                    final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
+                    return Files.readAllBytes(filePath);
                 }).toList().blockingGet();
 
         Instant start = Instant.now();
         Flowable.range(0, NUM_FILES)
-                .zipWith(md5s, new BiFunction<Integer, byte[], Completable>() {
-                    @Override
-                    public Completable apply(Integer id, final byte[] md5) throws Exception {
-                        final AsynchronousFileChannel fileStream = AsynchronousFileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"));
-                        Flowable<ByteBuffer> stream = FlowableUtil.readFile(fileStream);
-                        return service.upload100MB(String.valueOf(id), sas, "BlockBlob", stream, FILE_SIZE).flatMapCompletable(new Function<RestResponse<Void, Void>, CompletableSource>() {
-                            @Override
-                            public CompletableSource apply(RestResponse<Void, Void> response) throws Exception {
-                                String base64MD5 = response.rawHeaders().get("Content-MD5");
-                                byte[] receivedMD5 = BaseEncoding.base64().decode(base64MD5);
-                                assertArrayEquals(md5, receivedMD5);
-                                return Completable.complete();
-                            }
-                        });
-                    }
-                }).flatMapCompletable(Functions.<Completable>identity(), false, 30).blockingAwait();
+                .zipWith(md5s, (id, md5) -> {
+                    final AsynchronousFileChannel fileStream = AsynchronousFileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"));
+                    Flowable<ByteBuffer> stream = FlowableUtil.readFile(fileStream);
+                    return service.upload100MB(String.valueOf(id), sas, "BlockBlob", stream, FILE_SIZE).flatMapCompletable(response -> {
+                        String base64MD5 = response.rawHeaders().get("Content-MD5");
+                        byte[] receivedMD5 = BaseEncoding.base64().decode(base64MD5);
+                        assertArrayEquals(md5, receivedMD5);
+                        return Completable.complete();
+                    });
+                }).flatMapCompletable(Functions.identity(), false, 30).blockingAwait();
         String timeTakenString = PeriodFormat.getDefault().print(new Duration(start, Instant.now()).toPeriod());
         LoggerFactory.getLogger(getClass()).info("Upload took " + timeTakenString);
     }
@@ -307,32 +288,23 @@ public class RestProxyStressTests {
         final IOService service = RestProxy.create(IOService.class, pipeline);
 
         List<byte[]> md5s = Flowable.range(0, NUM_FILES)
-                .map(new Function<Integer, byte[]>() {
-                    @Override
-                    public byte[] apply(Integer integer) throws Exception {
-                        final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
-                        return Files.readAllBytes(filePath);
-                    }
+                .map(integer -> {
+                    final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
+                    return Files.readAllBytes(filePath);
                 }).toList().blockingGet();
 
         Instant start = Instant.now();
         Flowable.range(0, NUM_FILES)
-                .zipWith(md5s, new BiFunction<Integer, byte[], Completable>() {
-                    @Override
-                    public Completable apply(Integer id, final byte[] md5) throws Exception {
-                        final FileChannel fileStream = FileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"), StandardOpenOption.READ);
-                        Flowable<ByteBuffer> stream = FlowableUtil.split(fileStream.map(FileChannel.MapMode.READ_ONLY, 0, fileStream.size()), CHUNK_SIZE);
-                        return service.upload100MB(String.valueOf(id), sas, "BlockBlob", stream, FILE_SIZE).flatMapCompletable(new Function<RestResponse<Void, Void>, CompletableSource>() {
-                            @Override
-                            public CompletableSource apply(RestResponse<Void, Void> response) throws Exception {
-                                String base64MD5 = response.rawHeaders().get("Content-MD5");
-                                byte[] receivedMD5 = BaseEncoding.base64().decode(base64MD5);
-                                assertArrayEquals(md5, receivedMD5);
-                                return Completable.complete();
-                            }
-                        });
-                    }
-                }).flatMapCompletable(Functions.<Completable>identity(), false, 30).blockingAwait();
+                .zipWith(md5s, (id, md5) -> {
+                    final FileChannel fileStream = FileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"), StandardOpenOption.READ);
+                    Flowable<ByteBuffer> stream = FlowableUtil.split(fileStream.map(FileChannel.MapMode.READ_ONLY, 0, fileStream.size()), CHUNK_SIZE);
+                    return service.upload100MB(String.valueOf(id), sas, "BlockBlob", stream, FILE_SIZE).flatMapCompletable(response -> {
+                        String base64MD5 = response.rawHeaders().get("Content-MD5");
+                        byte[] receivedMD5 = BaseEncoding.base64().decode(base64MD5);
+                        assertArrayEquals(md5, receivedMD5);
+                        return Completable.complete();
+                    });
+                }).flatMapCompletable(Functions.identity(), false, 30).blockingAwait();
         String timeTakenString = PeriodFormat.getDefault().print(new Duration(start, Instant.now()).toPeriod());
         LoggerFactory.getLogger(getClass()).info("Upload took " + timeTakenString);
     }
@@ -356,43 +328,25 @@ public class RestProxyStressTests {
         final IOService service = RestProxy.create(IOService.class, pipeline);
 
         List<byte[]> md5s = Flowable.range(0, NUM_FILES)
-                .map(new Function<Integer, byte[]>() {
-                    @Override
-                    public byte[] apply(Integer integer) throws Exception {
-                        final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
-                        return Files.readAllBytes(filePath);
-                    }
+                .map(integer -> {
+                    final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
+                    return Files.readAllBytes(filePath);
                 }).toList().blockingGet();
 
         Instant downloadStart = Instant.now();
         Flowable.range(0, NUM_FILES)
-                .zipWith(md5s, new BiFunction<Integer, byte[], Completable>() {
-                    @Override
-                    public Completable apply(final Integer integer, final byte[] md5) throws Exception {
-                        final int id = integer;
-                        return service.download100M(String.valueOf(id), sas).flatMapCompletable(new Function<RestResponse<Void, Flowable<ByteBuffer>>, CompletableSource>() {
-                            @Override
-                            public CompletableSource apply(RestResponse<Void, Flowable<ByteBuffer>> response) throws Exception {
-                                final MessageDigest messageDigest = MessageDigest.getInstance("MD5");
-                                Flowable<ByteBuffer> content = response.body().doOnNext(new Consumer<ByteBuffer>() {
-                                    @Override
-                                    public void accept(ByteBuffer bytes) throws Exception {
-                                        messageDigest.update(bytes);
-                                    }
-                                });
+                .zipWith(md5s, (id, md5) ->
+                        service.download100M(String.valueOf(id), sas).flatMapCompletable(response -> {
+                            final MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+                            Flowable<ByteBuffer> content = response.body().doOnNext(messageDigest::update);
 
-                                AsynchronousFileChannel file = AsynchronousFileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + integer + ".dat"), StandardOpenOption.WRITE);
-                                return FlowableUtil.writeFile(content, file).doOnComplete(new Action() {
-                                    @Override
-                                    public void run() throws Exception {
-                                        assertArrayEquals(md5, messageDigest.digest());
-                                        LoggerFactory.getLogger(getClass()).info("Finished downloading and MD5 validated for " + id);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                }).flatMapCompletable(Functions.<Completable>identity(), false, 30).blockingAwait();
+                            AsynchronousFileChannel file = AsynchronousFileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"), StandardOpenOption.WRITE);
+                            return FlowableUtil.writeFile(content, file).doOnComplete(() -> {
+                                assertArrayEquals(md5, messageDigest.digest());
+                                LoggerFactory.getLogger(getClass()).info("Finished downloading and MD5 validated for " + id);
+                            });
+                        }))
+                .flatMapCompletable(Functions.identity()).blockingAwait();
         String downloadTimeTakenString = PeriodFormat.getDefault().print(new Duration(downloadStart, Instant.now()).toPeriod());
         LoggerFactory.getLogger(getClass()).info("Download took " + downloadTimeTakenString);
     }
@@ -412,41 +366,29 @@ public class RestProxyStressTests {
         final IOService service = RestProxy.create(IOService.class, pipeline);
 
         List<byte[]> diskMd5s = Flowable.range(0, NUM_FILES)
-                .map(new Function<Integer, byte[]>() {
-                    @Override
-                    public byte[] apply(Integer integer) throws Exception {
-                        final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
-                        return Files.readAllBytes(filePath);
-                    }
+                .map(integer -> {
+                    final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
+                    return Files.readAllBytes(filePath);
                 }).toList().blockingGet();
 
         Instant downloadStart = Instant.now();
         Flowable.range(0, NUM_FILES)
-                .zipWith(diskMd5s, new BiFunction<Integer, byte[], Completable>() {
-                    @Override
-                    public Completable apply(final Integer integer, final byte[] diskMd5) throws Exception {
-                        final int id = integer;
-                        Flowable<ByteBuffer> downloadContent = service.download100M(String.valueOf(id), sas).flatMapPublisher(new Function<RestResponse<Void, Flowable<ByteBuffer>>, Publisher<? extends ByteBuffer>>() {
-                            @Override
-                            public Publisher<? extends ByteBuffer> apply(RestResponse<Void, Flowable<ByteBuffer>> response) throws Exception {
-                                // Ideally we would intercept this content to load an MD5 to check consistency between download and upload directly,
-                                // but it's sufficient to demonstrate that no corruption occurred between preparation->upload->download->upload.
-                                return response.body();
-                            }
-                        });
+                .zipWith(diskMd5s, (final Integer integer, final byte[] diskMd5) -> {
+                    final int id = integer;
+                    Flowable<ByteBuffer> downloadContent = service.download100M(String.valueOf(id), sas)
+                            // Ideally we would intercept this content to load an MD5 to check consistency between download and upload directly,
+                            // but it's sufficient to demonstrate that no corruption occurred between preparation->upload->download->upload.
+                            .flatMapPublisher(StreamResponse::body);
 
-                        return service.upload100MB("copy-" + integer, sas, "BlockBlob", downloadContent, FILE_SIZE).flatMapCompletable(new Function<RestResponse<Void, Void>, CompletableSource>() {
-                            @Override
-                            public CompletableSource apply(RestResponse<Void, Void> uploadResponse) throws Exception {
+                    return service.upload100MB("copy-" + integer, sas, "BlockBlob", downloadContent, FILE_SIZE)
+                            .flatMapCompletable(uploadResponse -> {
                                 String base64MD5 = uploadResponse.rawHeaders().get("Content-MD5");
                                 byte[] uploadMD5 = BaseEncoding.base64().decode(base64MD5);
                                 assertArrayEquals(diskMd5, uploadMD5);
                                 LoggerFactory.getLogger(getClass()).info("Finished upload and validation for id " + id);
                                 return Completable.complete();
-                            }
-                        });
-                    }
-                }).flatMapCompletable(Functions.<Completable>identity(), false, 30).blockingAwait();
+                    });
+                }).flatMapCompletable(Functions.identity(), false, 30).blockingAwait();
         String downloadTimeTakenString = PeriodFormat.getDefault().print(new Duration(downloadStart, Instant.now()).toPeriod());
         LoggerFactory.getLogger(getClass()).info("Download/upload took " + downloadTimeTakenString);
     }
@@ -466,25 +408,15 @@ public class RestProxyStressTests {
         final IOService service = RestProxy.create(IOService.class, pipeline);
 
         final Disposable d = Flowable.range(0, NUM_FILES)
-                .flatMap(new Function<Integer, Publisher<ByteBuffer>>() {
-                    @Override
-                    public Publisher<ByteBuffer> apply(Integer integer) throws Exception {
-                        return service.download100M(String.valueOf(integer), sas).flatMapPublisher(new Function<RestResponse<Void, Flowable<ByteBuffer>>, Publisher<ByteBuffer>>() {
-                            @Override
-                            public Publisher<ByteBuffer> apply(RestResponse<Void, Flowable<ByteBuffer>> response) throws Exception {
-                                return response.body();
-                            }
-                        });
-                    }
-                }).subscribe();
+                .flatMap(integer ->
+                        service.download100M(String.valueOf(integer), sas)
+                                .flatMapPublisher(RestResponse::body))
+                .subscribe();
 
         Completable.complete().delay(10, TimeUnit.SECONDS)
-                .andThen(Completable.defer(new Callable<CompletableSource>() {
-                    @Override
-                    public CompletableSource call() throws Exception {
-                        d.dispose();
-                        return Completable.complete();
-                    }
+                .andThen(Completable.defer(() -> {
+                    d.dispose();
+                    return Completable.complete();
                 })).blockingAwait();
 
         Thread.sleep(10000);
@@ -503,22 +435,24 @@ public class RestProxyStressTests {
 
         final IOService service = RestProxy.create(IOService.class, pipeline);
         Flowable.range(0, 10000)
-                .flatMapCompletable(new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer integer) throws Exception {
-                        return service.createContainer(integer.toString(), sas)
-                                .toCompletable()
-                                .onErrorResumeNext(new Function<Throwable, CompletableSource>() {
-                                    @Override
-                                    public CompletableSource apply(Throwable throwable) throws Exception {
-                                        if (throwable instanceof RestException && ((RestException) throwable).response().statusCode() == 409) {
-                                            return Completable.complete();
-                                        } else {
-                                            return Completable.error(throwable);
-                                        }
+                .flatMapCompletable(integer ->
+                        service.createContainer(integer.toString(), sas).toCompletable()
+                                .onErrorResumeNext(throwable -> {
+                                    if (throwable instanceof RestException && ((RestException) throwable).response().statusCode() == 409) {
+                                        return Completable.complete();
+                                    } else {
+                                        return Completable.error(throwable);
                                     }
-                                }).andThen(service.deleteContainer(integer.toString(), sas).toCompletable());
-                    }
-                }).blockingAwait();
+                                })
+                                .andThen(service.deleteContainer(integer.toString(), sas).toCompletable()
+                                        .onErrorResumeNext(throwable -> {
+                                            if (throwable instanceof RestException && ((RestException) throwable).response().statusCode() == 404) {
+                                                LoggerFactory.getLogger(getClass()).info("What?");
+                                                return Completable.complete();
+                                            } else {
+                                                return Completable.error(throwable);
+                                            }
+                                        })))
+                .blockingAwait();
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -502,7 +502,7 @@ public abstract class RestProxyTests {
     private interface Service10 {
         @HEAD("anything")
         @ExpectedResponses({200})
-        RestResponse<Void, Void> head();
+        VoidResponse head();
 
         @HEAD("anything")
         @ExpectedResponses({200})
@@ -514,7 +514,7 @@ public abstract class RestProxyTests {
 
         @HEAD("anything")
         @ExpectedResponses({200})
-        Single<RestResponse<Void, Void>> headAsync();
+        Single<VoidResponse> headAsync();
 
         @HEAD("anything")
         @ExpectedResponses({200})
@@ -1268,7 +1268,7 @@ public abstract class RestProxyTests {
     interface UnexpectedOKService {
         @GET("/bytes/1024")
         @ExpectedResponses({400})
-        RestResponse<Void, Flowable<byte[]>> getBytes();
+        StreamResponse getBytes();
     }
 
     @Test
@@ -1299,7 +1299,7 @@ public abstract class RestProxyTests {
     @Host("http://httpbin.org")
     interface DownloadService {
         @GET("/bytes/30720")
-        RestResponse<Void, Flowable<ByteBuffer>> getBytes();
+        StreamResponse getBytes();
 
         @GET("/bytes/30720")
         Flowable<ByteBuffer> getBytesFlowable();
@@ -1307,7 +1307,7 @@ public abstract class RestProxyTests {
 
     @Test
     public void SimpleDownloadTest() {
-        RestResponse<Void, Flowable<ByteBuffer>> response = createService(DownloadService.class).getBytes();
+        StreamResponse response = createService(DownloadService.class).getBytes();
         int count = 0;
         for (ByteBuffer bytes : response.body().blockingIterable()) {
             count += bytes.remaining();
@@ -1328,7 +1328,7 @@ public abstract class RestProxyTests {
     @Host("https://httpbin.org")
     interface FlowableUploadService {
         @PUT("/put")
-        RestResponse<Void, HttpBinJSON> put(@BodyParam("text/plain") Flowable<ByteBuffer> content, @HeaderParam("Content-Length") long contentLength);
+        BodyResponse<HttpBinJSON> put(@BodyParam("text/plain") Flowable<ByteBuffer> content, @HeaderParam("Content-Length") long contentLength);
     }
 
     @Test
@@ -1348,7 +1348,7 @@ public abstract class RestProxyTests {
     public void SegmentUploadTest() throws Exception {
         Path filePath = Paths.get(getClass().getClassLoader().getResource("upload.txt").toURI());
         AsynchronousFileChannel fileChannel = AsynchronousFileChannel.open(filePath, StandardOpenOption.READ);
-        RestResponse<Void, HttpBinJSON> response = createService(FlowableUploadService.class)
+        BodyResponse<HttpBinJSON> response = createService(FlowableUploadService.class)
                 .put(FlowableUtil.readFile(fileChannel, 4, 15), 15);
 
         assertEquals("quick brown fox", response.body().data);

--- a/pom.xml
+++ b/pom.xml
@@ -167,8 +167,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
           <compilerArgument>-Xlint:unchecked</compilerArgument>


### PR DESCRIPTION
This adds runtime support for concrete RestResponse subtypes.

The approach I'm using in the generator is basically thus:
- If a Headers type is defined, a Response type will be generated to contain the Headers and Body
- If no Headers type is defined, we will use `BodyResponse<TBody>`
- If only a `Flowable<ByteBuffer>` body is defined, we will use `StreamResponse`.
- If neither Headers or Body are defined we will use `VoidResponse`.

I've done a good amount of testing through autorest.java but will make sure to add some unit tests, perhaps updating RestProxyTests to use these new types before merging.