### PR TITLE
Various minor improvements

### DIFF
--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -72,10 +72,6 @@
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
     </dependency>

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientFactory.java
@@ -6,12 +6,12 @@
 
 package com.microsoft.rest.v2.http;
 
-import io.reactivex.Completable;
+import java.io.Closeable;
 
 /**
  * Creates an HttpClient from a Configuration.
  */
-public interface HttpClientFactory {
+public interface HttpClientFactory extends Closeable {
     /**
      * Creates an HttpClient with the given Configuration.
      * @param configuration the configuration.
@@ -20,11 +20,8 @@ public interface HttpClientFactory {
     HttpClient create(HttpClientConfiguration configuration);
 
     /**
-     * Asynchronously awaits completion of in-flight requests,
-     * then closes shared resources associated with this HttpClient.Factory.
-     * After this Completable completes, HttpClients created from this Factory can no longer be used.
-     *
-     * @return a Completable which shuts down the factory when subscribed to.
+     * Awaits completion of in-flight requests, then closes shared resources associated with this HttpClient.Factory.
+     * After this method returns, HttpClients created from this Factory can no longer be used.
      */
-    Completable shutdown();
+    void close();
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -590,13 +590,8 @@ public final class NettyClient extends HttpClient {
         }
 
         @Override
-        public Completable shutdown() {
-            return Completable.defer(new Callable<CompletableSource>() {
-                @Override
-                public CompletableSource call() throws Exception {
-                    return Completable.fromFuture(adapter.shutdownGracefully());
-                }
-            });
+        public void close() {
+            adapter.shutdownGracefully().awaitUninterruptibly();
         }
     }
 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -32,8 +32,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import io.reactivex.Completable;
-import io.reactivex.CompletableSource;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableSubscriber;
 import io.reactivex.Scheduler;
@@ -54,7 +52,6 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Queue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -19,7 +19,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.reactivex.exceptions.Exceptions;
-import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
 import java.net.URI;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -44,7 +44,7 @@ public class SharedChannelPool implements ChannelPool {
     private final Queue<ChannelRequest> requests;
     private final ConcurrentMultiHashMap<URI, Channel> available;
     private final ConcurrentMultiHashMap<URI, Channel> leased;
-    private final Object sync = -1;
+    private final Object sync = new Object();
     private final SslContext sslContext;
     private final ExecutorService executor;
     private volatile boolean closed = false;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -18,16 +18,18 @@ import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
+import io.reactivex.exceptions.Exceptions;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Queue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadFactory;
 
 /**
  * A Netty channel pool implementation shared between multiple requests.
@@ -80,82 +82,77 @@ public class SharedChannelPool implements ChannelPool {
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }
-        this.executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r, "SharedChannelPool-worker");
-                thread.setDaemon(true);
-                return thread;
-            }
+        this.executor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "SharedChannelPool-worker");
+            thread.setDaemon(true);
+            return thread;
         });
 
-        executor.submit(new Runnable() {
-            @Override
-            public void run() {
-                while (!closed) {
-                    try {
-                        final ChannelRequest request;
-                        final ChannelFuture channelFuture;
-                        synchronized (requests) {
-                            while (requests.isEmpty() && !closed) {
-                                requests.wait();
-                            }
+        executor.submit(() -> {
+            while (!closed) {
+                try {
+                    final ChannelRequest request;
+                    final ChannelFuture channelFuture;
+                    // Synchronizing just to be notified when requests is non-empty
+                    synchronized (requests) {
+                        while (requests.isEmpty() && !closed) {
+                            requests.wait();
                         }
-                        request = requests.poll();
+                    }
+                    request = requests.poll();
 
-                        if (leased.size() >= poolSize && !closed) {
-                            synchronized (sync) {
-                                sync.wait();
-                            }
+                    synchronized (sync) {
+                        while (leased.size() >= poolSize && !closed) {
+                            sync.wait();
                         }
+
                         if (closed) {
                             break;
                         }
-                        synchronized (sync) {
-                            if (available.containsKey(request.uri)) {
-                                Channel channel = available.poll(request.uri);
-                                if (isChannelHealthy(channel)) {
-                                    handler.channelAcquired(channel);
-                                    request.promise.setSuccess(channel);
-                                    leased.put(request.uri, channel);
-                                    continue;
-                                }
-                            }
-                            // Create a new channel - remove an available one if size overflows
-                            if (available.size() > 0 && available.size() + leased.size() >= poolSize) {
-                                available.poll().close();
-                            }
-                            int port;
-                            if (request.uri.getPort() < 0) {
-                                port = "https".equals(request.uri.getScheme()) ? 443 : 80;
-                            } else {
-                                port = request.uri.getPort();
-                            }
-                            channelFuture = SharedChannelPool.this.bootstrap.clone().connect(request.uri.getHost(), port);
 
-                            channelFuture.channel().attr(CHANNEL_URI).set(request.uri);
-
-                            // Apply SSL handler for https connections
-                            if ("https".equalsIgnoreCase(request.uri.getScheme())) {
-                                channelFuture.channel().pipeline().addFirst(sslContext.newHandler(channelFuture.channel().alloc(), request.uri.getHost(), port));
+                        if (available.containsKey(request.uri)) {
+                            Channel channel = available.poll(request.uri);
+                            if (isChannelHealthy(channel)) {
+                                handler.channelAcquired(channel);
+                                request.promise.setSuccess(channel);
+                                leased.put(request.uri, channel);
+                                continue;
                             }
-
-                            channelFuture.addListener(new GenericFutureListener<Future<? super Void>>() {
-                                @Override
-                                public void operationComplete(Future<? super Void> future) throws Exception {
-                                    if (channelFuture.isSuccess()) {
-                                        handler.channelAcquired(channelFuture.channel());
-                                        leased.put(request.uri, channelFuture.channel());
-                                        request.promise.setSuccess(channelFuture.channel());
-                                    } else {
-                                        request.promise.setFailure(channelFuture.cause());
-                                    }
-                                }
-                            });
                         }
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
+                        // Create a new channel - remove an available one if size overflows
+                        if (available.size() > 0 && available.size() + leased.size() >= poolSize) {
+                            available.poll().close();
+                        }
+                        int port;
+                        if (request.uri.getPort() < 0) {
+                            port = "https".equals(request.uri.getScheme()) ? 443 : 80;
+                        } else {
+                            port = request.uri.getPort();
+                        }
+                        channelFuture = SharedChannelPool.this.bootstrap.clone().connect(request.uri.getHost(), port);
+
+                        channelFuture.channel().attr(CHANNEL_URI).set(request.uri);
+
+                        // Apply SSL handler for https connections
+                        if ("https".equalsIgnoreCase(request.uri.getScheme())) {
+                            channelFuture.channel().pipeline().addFirst(sslContext.newHandler(channelFuture.channel().alloc(), request.uri.getHost(), port));
+                        }
+
+                        channelFuture.addListener(new GenericFutureListener<Future<? super Void>>() {
+                            @Override
+                            public void operationComplete(Future<? super Void> future) throws Exception {
+                                if (channelFuture.isSuccess()) {
+                                    handler.channelAcquired(channelFuture.channel());
+                                    leased.put(request.uri, channelFuture.channel());
+                                    request.promise.setSuccess(channelFuture.channel());
+                                } else {
+                                    request.promise.setFailure(channelFuture.cause());
+                                }
+                            }
+                        });
                     }
+                } catch (Exception e) {
+                    throw Exceptions.propagate(e);
                 }
             }
         });
@@ -217,17 +214,12 @@ public class SharedChannelPool implements ChannelPool {
      * @return a Future representing the operation.
      */
     public Future<Void> closeAndRelease(final Channel channel) {
-        return channel.close().addListener(new GenericFutureListener<Future<? super Void>>() {
-            @Override
-            public void operationComplete(Future<? super Void> future) throws Exception {
-                release(channel);
-            }
-        });
+        return channel.close().addListener(future -> release(channel));
     }
 
     @Override
     public Future<Void> release(final Channel channel) {
-        return this.release(channel, this.bootstrap.config().group().next().<Void>newPromise());
+        return this.release(channel, this.bootstrap.config().group().next().newPromise());
     }
 
     @Override
@@ -251,6 +243,11 @@ public class SharedChannelPool implements ChannelPool {
     public void close() {
         closed = true;
         executor.shutdownNow();
+        synchronized (requests) {
+            while (!requests.isEmpty()) {
+                requests.remove().promise.setFailure(new CancellationException("Channel pool was closed"));
+            }
+        }
     }
 
     private static class ChannelRequest {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/CookiePolicyFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/CookiePolicyFactory.java
@@ -11,7 +11,6 @@ import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.net.CookieHandler;
@@ -53,7 +52,7 @@ public final class CookiePolicyFactory implements RequestPolicyFactory {
 
                 Map<String, List<String>> requestCookies = cookies.get(uri, cookieHeaders);
                 for (Map.Entry<String, List<String>> entry : requestCookies.entrySet()) {
-                    request.headers().set(entry.getKey(), StringUtils.join(entry.getValue(), ","));
+                    request.headers().set(entry.getKey(), String.join(",", entry.getValue()));
                 }
 
                 return next.sendAsync(request).map(new Function<HttpResponse, HttpResponse>() {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -404,7 +404,7 @@ public class RestProxyStressTests {
         final Disposable d = Flowable.range(0, NUM_FILES)
                 .flatMap(integer ->
                         service.download100M(String.valueOf(integer), sas)
-                                .flatMapPublisher(RestResponse::body))
+                                .flatMapPublisher(StreamResponse::body))
                 .subscribe();
 
         Completable.complete().delay(10, TimeUnit.SECONDS)
@@ -438,15 +438,7 @@ public class RestProxyStressTests {
                                         return Completable.error(throwable);
                                     }
                                 })
-                                .andThen(service.deleteContainer(integer.toString(), sas).toCompletable()
-                                        .onErrorResumeNext(throwable -> {
-                                            if (throwable instanceof RestException && ((RestException) throwable).response().statusCode() == 404) {
-                                                LoggerFactory.getLogger(getClass()).info("What?");
-                                                return Completable.complete();
-                                            } else {
-                                                return Completable.error(throwable);
-                                            }
-                                        })))
+                                .andThen(service.deleteContainer(integer.toString(), sas).toCompletable()))
                 .blockingAwait();
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -1,6 +1,5 @@
 package com.microsoft.rest.v2.http;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +41,6 @@ public class NettyClientTests {
     }
 
     @Test
-    @Ignore("Passes inconsistently due to race condition")
     public void testInFlightRequestSucceedsAfterCancellation() throws Exception {
         // Retry a few times in case shutdown begins before the request is submitted to Netty
         for (int i = 0; i < 3; i++) {
@@ -68,7 +66,7 @@ public class NettyClientTests {
             if (i == 2) {
                 fail();
             } else {
-                LoggerFactory.getLogger(getClass()).info("Shutdown started before sending request. Retry attempt " + i+1);
+                LoggerFactory.getLogger(getClass()).info("Shutdown started before sending request. Retry attempt " + (i+1));
             }
         }
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -20,7 +20,7 @@ public class NettyClientTests {
         HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
 
         client.sendRequestAsync(request).blockingGet();
-        factory.shutdown().blockingAwait();
+        factory.close();
     }
 
     @Test
@@ -30,7 +30,7 @@ public class NettyClientTests {
         HttpRequest request = new HttpRequest("", HttpMethod.GET, new URL("https://httpbin.org/get"), null);
 
         LoggerFactory.getLogger(getClass()).info("Closing factory");
-        factory.shutdown().blockingAwait();
+        factory.close();
 
         try {
             LoggerFactory.getLogger(getClass()).info("Sending request");
@@ -52,7 +52,7 @@ public class NettyClientTests {
 
             Future<HttpResponse> asyncResponse = client.sendRequestAsync(request).toFuture();
             Thread.sleep(100);
-            factory.shutdown().blockingAwait();
+            factory.close();
 
             boolean shouldRetry = false;
             try {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -1,5 +1,6 @@
 package com.microsoft.rest.v2.http;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,7 @@ public class NettyClientTests {
     }
 
     @Test
+    @Ignore("Fails intermittently due to race condition")
     public void testInFlightRequestSucceedsAfterCancellation() throws Exception {
         // Retry a few times in case shutdown begins before the request is submitted to Netty
         for (int i = 0; i < 3; i++) {

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
         <version>2.8.11</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.4</version>
-      </dependency>
-      <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>adal4j</artifactId>
         <version>1.1.2</version>


### PR DESCRIPTION
- Gets rid of Apache Commons, which we appear to only have ever used in one instance in the entire runtime. Using Java 8's String.join() instead.
- Changed `Completable HttpClientFactory.shutdown()` to `void HttpClientFactory.close()` as this is not a context where optimizing the utilization of threads is useful and it's better to have something straightforward that conforms to the `Closeable` interface