### PR TITLE
v2 NettyClient flowable rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ hs_err_pid*
 .idea
 *.iml
 .DS_Store
+**/temp/
 
 #eclipse
 .project

--- a/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/http/MockHttpResponse.java
+++ b/azure-client-authentication/src/test/java/com/microsoft/azure/v2/credentials/http/MockHttpResponse.java
@@ -71,17 +71,17 @@ public class MockHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Single<byte[]> bodyAsByteArrayAsync() {
+    public Single<byte[]> bodyAsByteArray() {
         return Single.just(byteArray);
     }
 
     @Override
-    public Flowable<ByteBuffer> streamBodyAsync() {
+    public Flowable<ByteBuffer> body() {
         return Flowable.just(ByteBuffer.wrap(byteArray));
     }
 
     @Override
-    public Single<String> bodyAsStringAsync() {
+    public Single<String> bodyAsString() {
         return Single.just(string);
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureAsyncOperationPollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureAsyncOperationPollStrategy.java
@@ -102,7 +102,7 @@ public final class AzureAsyncOperationPollStrategy extends PollStrategy {
                         Single<HttpResponse> result;
                         if (!data.pollingCompleted) {
                             final HttpResponse bufferedHttpPollResponse = response.buffer();
-                            result = bufferedHttpPollResponse.bodyAsStringAsync()
+                            result = bufferedHttpPollResponse.bodyAsString()
                                     .map(new Function<String, HttpResponse>() {
                                         @Override
                                         public HttpResponse apply(String bodyString) {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/AzureProxy.java
@@ -396,7 +396,7 @@ public final class AzureProxy extends RestProxy {
                     new CompletedPollStrategy.CompletedPollStrategyData(AzureProxy.this, methodParser, httpResponse)));
         } else {
             final HttpResponse bufferedOriginalHttpResponse = httpResponse.buffer();
-            result = bufferedOriginalHttpResponse.bodyAsStringAsync()
+            result = bufferedOriginalHttpResponse.bodyAsString()
                     .map(new Function<String, PollStrategy>() {
                         @Override
                         public PollStrategy apply(String originalHttpResponseBody) {

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/v2/ProvisioningStatePollStrategy.java
@@ -76,7 +76,7 @@ public final class ProvisioningStatePollStrategy extends PollStrategy {
                     @Override
                     public Single<HttpResponse> apply(HttpResponse response) {
                         final HttpResponse bufferedHttpPollResponse = response.buffer();
-                        return bufferedHttpPollResponse.bodyAsStringAsync()
+                        return bufferedHttpPollResponse.bodyAsString()
                                 .map(new Function<String, HttpResponse>() {
                                     @Override
                                     public HttpResponse apply(String responseBody) {

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpResponse.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpResponse.java
@@ -75,17 +75,17 @@ public class MockAzureHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Single<byte[]> bodyAsByteArrayAsync() {
+    public Single<byte[]> bodyAsByteArray() {
         return Single.just(bodyBytes);
     }
 
     @Override
-    public Flowable<ByteBuffer> streamBodyAsync() {
+    public Flowable<ByteBuffer> body() {
         return Flowable.just(ByteBuffer.wrap(bodyBytes));
     }
 
     @Override
-    public Single<String> bodyAsStringAsync() {
+    public Single<String> bodyAsString() {
         return Single.just(new String(bodyBytes, StandardCharsets.UTF_8));
     }
 

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -106,6 +106,18 @@
       <version>2.15.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+      <version>9.4.8.v20171121</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>9.4.8.v20171121</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -150,6 +162,21 @@
             <contextPath>/javasdktest/upload</contextPath>
           </webApp>
           <webAppSourceDirectory>temp/</webAppSourceDirectory>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <executions>
+          <execution>
+            <goals><goal>java</goal></goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>com.microsoft.rest.v2.MockServer</mainClass>
+          <classpathScope>test</classpathScope>
         </configuration>
       </plugin>
     </plugins>

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -137,6 +137,21 @@
 <br />*/</code>]]></bottom>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.3.22.v20171030</version>
+        <configuration>
+          <httpConnector>
+            <port>11081</port>
+          </httpConnector>
+          <webApp>
+            <contextPath>/javasdktest/upload</contextPath>
+          </webApp>
+          <webAppSourceDirectory>temp/</webAppSourceDirectory>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/RestProxy.java
@@ -363,7 +363,7 @@ public class RestProxy implements InvocationHandler {
         final int responseStatusCode = response.statusCode();
         final Single<HttpResponse> asyncResult;
         if (!methodParser.isExpectedResponseStatusCode(responseStatusCode, additionalAllowedStatusCodes)) {
-            asyncResult = response.bodyAsStringAsync().flatMap(new Function<String, Single<HttpResponse>>() {
+            asyncResult = response.bodyAsString().flatMap(new Function<String, Single<HttpResponse>>() {
                 @Override
                 public Single<HttpResponse> apply(String responseBody) throws Exception {
                     return Single.error(instantiateUnexpectedException(methodParser, response, responseBody));
@@ -420,7 +420,7 @@ public class RestProxy implements InvocationHandler {
 
                 final TypeToken bodyTypeToken = TypeToken.of(bodyType);
                 if (bodyTypeToken.isSubtypeOf(Void.class)) {
-                    asyncResult = response.streamBodyAsync().lastElement().ignoreElement()
+                    asyncResult = response.body().lastElement().ignoreElement()
                             .andThen(Single.just(responseConstructor.newInstance(responseStatusCode, deserializedHeaders, responseHeaders.toMap(), null)));
                 } else {
                     final Map<String, String> rawHeaders = responseHeaders.toMap();
@@ -455,7 +455,7 @@ public class RestProxy implements InvocationHandler {
             boolean isSuccess = (responseStatusCode / 100) == 2;
             asyncResult = Maybe.just(isSuccess);
         } else if (entityTypeToken.isSubtypeOf(byte[].class)) {
-            Maybe<byte[]> responseBodyBytesAsync = response.bodyAsByteArrayAsync().toMaybe();
+            Maybe<byte[]> responseBodyBytesAsync = response.bodyAsByteArray().toMaybe();
             if (returnValueWireType == Base64Url.class) {
                 responseBodyBytesAsync = responseBodyBytesAsync.map(new Function<byte[], byte[]>() {
                     @Override
@@ -466,7 +466,7 @@ public class RestProxy implements InvocationHandler {
             }
             asyncResult = responseBodyBytesAsync;
         } else if (FlowableUtil.isFlowableByteBuffer(entityTypeToken)) {
-            asyncResult = Maybe.just(response.streamBodyAsync());
+            asyncResult = Maybe.just(response.body());
         } else {
             Object result = response.deserializedBody();
             if (result == null) {
@@ -533,7 +533,7 @@ public class RestProxy implements InvocationHandler {
             result = asyncExpectedResponse.flatMapPublisher(new Function<HttpResponse, Publisher<?>>() {
                 @Override
                 public Publisher<?> apply(HttpResponse httpResponse) throws Exception {
-                    return httpResponse.streamBodyAsync();
+                    return httpResponse.body();
                 }
             });
         }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/BufferedHttpResponse.java
@@ -46,9 +46,9 @@ public final class BufferedHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Single<byte[]> bodyAsByteArrayAsync() {
+    public Single<byte[]> bodyAsByteArray() {
         if (body == null) {
-            body = innerHttpResponse.bodyAsByteArrayAsync()
+            body = innerHttpResponse.bodyAsByteArray()
                     .map(new Function<byte[], byte[]>() {
                         @Override
                         public byte[] apply(byte[] bytes) {
@@ -61,8 +61,8 @@ public final class BufferedHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Flowable<ByteBuffer> streamBodyAsync() {
-        return bodyAsByteArrayAsync().flatMapPublisher(new Function<byte[], Publisher<? extends ByteBuffer>>() {
+    public Flowable<ByteBuffer> body() {
+        return bodyAsByteArray().flatMapPublisher(new Function<byte[], Publisher<? extends ByteBuffer>>() {
             @Override
             public Publisher<? extends ByteBuffer> apply(byte[] bytes) throws Exception {
                 return Flowable.just(ByteBuffer.wrap(bytes));
@@ -71,8 +71,8 @@ public final class BufferedHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Single<String> bodyAsStringAsync() {
-        return bodyAsByteArrayAsync()
+    public Single<String> bodyAsString() {
+        return bodyAsByteArray()
                 .map(new Function<byte[], String>() {
                     @Override
                     public String apply(byte[] bytes) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpResponse.java
@@ -41,10 +41,33 @@ public abstract class HttpResponse implements Closeable {
     public abstract HttpHeaders headers();
 
     /**
-     * Stream this response's body content.
-     * @return This response's body as an asynchronous sequence of byte[].
+     * <p>
+     * Returns a stream of the response's body content. Emissions may occur on the
+     * Netty EventLoop threads which are shared across channels and should not be
+     * blocked. Blocking should be avoided as much as possible/practical in reactive
+     * programming but if you do use methods like {@code blockingSubscribe} or {@code blockingGet}
+     * on the stream then be sure to use {@code subscribeOn} and {@code observeOn}
+     * before the blocking call. For example:
+     * 
+     * <pre>
+     * {@code
+     *   response.body()
+     *     .map(bb -> bb.limit())
+     *     .reduce((x,y) -> x + y)
+     *     .subscribeOn(Schedulers.io())
+     *     .observeOn(Schedulers.io())
+     *     .blockingGet();
+     * }
+     * </pre>
+     * 
+     * <p>
+     * The above code is a simplistic example and would probably run fine without
+     * the `subscribeOn` and `observeOn` but should be considered a template for
+     * more complex situations.
+     * 
+     * @return The response's body as a stream of {@link ByteBuffer}.
      */
-    public abstract Flowable<ByteBuffer> streamBodyAsync();
+    public abstract Flowable<ByteBuffer> body();
 
     /**
      * Get this response object's body as a byte[]. If this response object doesn't have a body,
@@ -52,7 +75,7 @@ public abstract class HttpResponse implements Closeable {
      * @return This response object's body as a byte[]. If this response object doesn't have a body,
      * then null will be returned.
      */
-    public abstract Single<byte[]> bodyAsByteArrayAsync();
+    public abstract Single<byte[]> bodyAsByteArray();
 
     /**
      * Get this response object's body as a string. If this response object doesn't have a body,
@@ -60,7 +83,7 @@ public abstract class HttpResponse implements Closeable {
      * @return This response object's body as a string. If this response object doesn't have a body,
      * then null will be returned.
      */
-    public abstract Single<String> bodyAsStringAsync();
+    public abstract Single<String> bodyAsString();
 
     /**
      * Buffers the HTTP response body into memory, allowing the content to be inspected and replayed.

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -275,8 +275,6 @@ public final class NettyClient extends HttpClient {
                 if (transition(s, ACQUIRING_DISPOSED, CHANNEL_RELEASED)) {
                     channelPool.closeAndRelease(channel);
                     return;
-                } else if (transition(s, CHANNEL_RELEASED, CHANNEL_RELEASED)) {
-                    return;
                 } else if (transition(s, ACQUIRING_NOT_DISPOSED, ACQUIRED_CONTENT_NOT_SUBSCRIBED)) {
                     break;
                 } else if (state.compareAndSet(s,  s)) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -415,7 +415,7 @@ public final class NettyClient extends HttpClient {
                             break;
                         }
                     } else {
-                        break;
+                        throw new RuntimeException("unexpected!");
                     }
                 }
             }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -70,8 +71,11 @@ public final class NettyClient extends HttpClient {
 
     /**
      * Creates NettyClient.
-     * @param configuration the HTTP client configuration.
-     * @param adapter the adapter to Netty
+     * 
+     * @param configuration
+     *            the HTTP client configuration.
+     * @param adapter
+     *            the adapter to Netty
      */
     private NettyClient(HttpClientConfiguration configuration, NettyAdapter adapter) {
         this.adapter = adapter;
@@ -102,16 +106,19 @@ public final class NettyClient extends HttpClient {
             final MultithreadEventLoopGroup eventLoopGroup;
             final Class<? extends SocketChannel> channelClass;
 
-            private TransportConfig(MultithreadEventLoopGroup eventLoopGroup, Class<? extends SocketChannel> channelClass) {
+            private TransportConfig(MultithreadEventLoopGroup eventLoopGroup,
+                    Class<? extends SocketChannel> channelClass) {
                 this.eventLoopGroup = eventLoopGroup;
                 this.channelClass = channelClass;
             }
         }
 
-        private static MultithreadEventLoopGroup loadEventLoopGroup(String className, int size) throws ReflectiveOperationException {
+        private static MultithreadEventLoopGroup loadEventLoopGroup(String className, int size)
+                throws ReflectiveOperationException {
             Class<?> cls = Class.forName(className);
             ThreadFactory factory = new DefaultThreadFactory(cls, true);
-            MultithreadEventLoopGroup result = (MultithreadEventLoopGroup) cls.getConstructor(Integer.TYPE, ThreadFactory.class).newInstance(size, factory);
+            MultithreadEventLoopGroup result = (MultithreadEventLoopGroup) cls
+                    .getConstructor(Integer.TYPE, ThreadFactory.class).newInstance(size, factory);
             return result;
         }
 
@@ -121,12 +128,10 @@ public final class NettyClient extends HttpClient {
             try {
                 final String osName = System.getProperty("os.name");
                 if (osName.contains("Linux")) {
-                    result = new TransportConfig(
-                            loadEventLoopGroup(EPOLL_GROUP_CLASS_NAME, groupSize),
+                    result = new TransportConfig(loadEventLoopGroup(EPOLL_GROUP_CLASS_NAME, groupSize),
                             (Class<? extends SocketChannel>) Class.forName(EPOLL_SOCKET_CLASS_NAME));
                 } else if (osName.contains("Mac")) {
-                    result = new TransportConfig(
-                            loadEventLoopGroup(KQUEUE_GROUP_CLASS_NAME, groupSize),
+                    result = new TransportConfig(loadEventLoopGroup(KQUEUE_GROUP_CLASS_NAME, groupSize),
                             (Class<? extends SocketChannel>) Class.forName(KQUEUE_SOCKET_CLASS_NAME));
                 }
             } catch (Exception e) {
@@ -137,17 +142,21 @@ public final class NettyClient extends HttpClient {
                         message = cause.getMessage();
                     }
                 }
-                LoggerFactory.getLogger(NettyAdapter.class).debug("Exception when obtaining native EventLoopGroup and SocketChannel: " + message);
+                LoggerFactory.getLogger(NettyAdapter.class)
+                        .debug("Exception when obtaining native EventLoopGroup and SocketChannel: " + message);
             }
 
             if (result == null) {
-                result = new TransportConfig(new NioEventLoopGroup(groupSize, new DefaultThreadFactory(NioEventLoopGroup.class, true)), NioSocketChannel.class);
+                result = new TransportConfig(
+                        new NioEventLoopGroup(groupSize, new DefaultThreadFactory(NioEventLoopGroup.class, true)),
+                        NioSocketChannel.class);
             }
 
             return result;
         }
 
-        private static SharedChannelPool createChannelPool(final NettyAdapter adapter, TransportConfig config, int poolSize) {
+        private static SharedChannelPool createChannelPool(final NettyAdapter adapter, TransportConfig config,
+                int poolSize) {
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(config.eventLoopGroup);
             bootstrap.channel(config.channelClass);
@@ -183,156 +192,15 @@ public final class NettyClient extends HttpClient {
             } catch (URISyntaxException e) {
                 return Single.error(e);
             }
-            request.withHeader(io.netty.handler.codec.http.HttpHeaderNames.HOST.toString(), request.url().getHost());
-            request.withHeader(io.netty.handler.codec.http.HttpHeaderNames.CONNECTION.toString(), io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE.toString());
+            request.withHeader(io.netty.handler.codec.http.HttpHeaderNames.HOST.toString(), request.url().getHost())
+                    .withHeader(io.netty.handler.codec.http.HttpHeaderNames.CONNECTION.toString(),
+                            io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE.toString());
 
             // Creates cold observable from an emitter
             return Single.create((SingleEmitter<HttpResponse> responseEmitter) -> {
-                channelPool.acquire(channelAddress).addListener(new GenericFutureListener<Future<? super Channel>>() {
-                    private void emitErrorIfSubscribed(Throwable throwable) {
-                        if (!responseEmitter.isDisposed()) {
-                            responseEmitter.onError(throwable);
-                        }
-                    }
-
-                    @Override
-                    public void operationComplete(Future<? super Channel> cf) {
-                        if (!cf.isSuccess()) {
-                            emitErrorIfSubscribed(cf.cause());
-                            return;
-                        }
-
-                        final Channel channel = (Channel) cf.getNow();
-                        final HttpClientInboundHandler inboundHandler = channel.pipeline().get(HttpClientInboundHandler.class);
-
-                        if (responseEmitter.isDisposed()) {
-                            // We were cancelled before sending any data, so just return the channel to the pool.
-                            channelPool.release(channel);
-                            return;
-                        }
-
-                        // After this point, we're starting to send data, so if the Single<HttpResponse> gets canceled we need to close the channel.
-                        inboundHandler.httpResponseEmitted = false;
-                        inboundHandler.responseEmitter = responseEmitter;
-                        responseEmitter.setDisposable(new Disposable() {
-                            final AtomicBoolean disposed = new AtomicBoolean(false);
-                            @Override
-                            public void dispose() {
-                                if (disposed.compareAndSet(false, true)) {
-                                    if (!inboundHandler.httpResponseEmitted) {
-                                        channelPool.closeAndRelease(channel);
-                                    }
-                                }
-                            }
-
-                            @Override
-                            public boolean isDisposed() {
-                                return disposed.get();
-                            }
-                        });
-
-                        if (request.httpMethod() == com.microsoft.rest.v2.http.HttpMethod.HEAD) {
-                            // Use HttpClientCodec for HEAD operations
-                            if (channel.pipeline().get("HttpClientCodec") == null) {
-                                channel.pipeline().remove(HttpRequestEncoder.class);
-                                channel.pipeline().replace(HttpResponseDecoder.class, "HttpClientCodec", new HttpClientCodec());
-                            }
-                        } else {
-                            // Use HttpResponseDecoder for other operations
-                            if (channel.pipeline().get("HttpResponseDecoder") == null) {
-                                channel.pipeline().replace(HttpClientCodec.class, "HttpResponseDecoder", new HttpResponseDecoder());
-                                channel.pipeline().addAfter("HttpResponseDecoder", "HttpRequestEncoder", new HttpRequestEncoder());
-                            }
-                        }
-
-                        final DefaultHttpRequest raw = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                                HttpMethod.valueOf(request.httpMethod().toString()),
-                                request.url().toString());
-
-                        for (HttpHeader header : request.headers()) {
-                            raw.headers().add(header.name(), header.value());
-                        }
-
-                        try {
-                            channel.write(raw).addListener((Future<Void> future) -> {
-                                if (!future.isSuccess()) {
-                                    channelPool.closeAndRelease(channel);
-                                    emitErrorIfSubscribed(future.cause());
-                                }
-                            });
-
-                            if (request.body() == null) {
-                                channel.writeAndFlush(DefaultLastHttpContent.EMPTY_LAST_CONTENT)
-                                        .addListener((Future<Void> future) -> {
-                                            if (future.isSuccess()) {
-                                                channel.read();
-                                            } else {
-                                                channelPool.closeAndRelease(channel);
-                                                emitErrorIfSubscribed(future.cause());
-                                            }
-                                        });
-                            } else {
-                                request.body().subscribe(new FlowableSubscriber<ByteBuffer>() {
-                                    Subscription subscription;
-                                    @Override
-                                    public void onSubscribe(Subscription s) {
-                                        subscription = s;
-                                        inboundHandler.requestContentSubscription = subscription;
-                                        subscription.request(1);
-                                    }
-
-                                    GenericFutureListener<Future<Void>> onChannelWriteComplete = (Future<Void> future) -> {
-                                        if (!future.isSuccess()) {
-                                            subscription.cancel();
-                                            channelPool.closeAndRelease(channel);
-                                            emitErrorIfSubscribed(future.cause());
-                                        }
-                                    };
-
-                                    @Override
-                                    public void onNext(ByteBuffer buf) {
-                                        try {
-                                            channel.writeAndFlush(Unpooled.wrappedBuffer(buf))
-                                                    .addListener(onChannelWriteComplete);
-
-                                            if (channel.isWritable()) {
-                                                subscription.request(1);
-                                            }
-                                        } catch (Exception e) {
-                                            subscription.cancel();
-                                            emitErrorIfSubscribed(e);
-                                        }
-                                    }
-
-                                    @Override
-                                    public void onError(Throwable t) {
-                                        channelPool.closeAndRelease(channel);
-                                        emitErrorIfSubscribed(t);
-                                    }
-
-                                    @Override
-                                    public void onComplete() {
-                                        try {
-                                            channel.writeAndFlush(DefaultLastHttpContent.EMPTY_LAST_CONTENT)
-                                                    .addListener((Future<Void> future) -> {
-                                                        if (!future.isSuccess()) {
-                                                            channelPool.closeAndRelease(channel);
-                                                            emitErrorIfSubscribed(future.cause());
-                                                        } else {
-                                                            channel.read();
-                                                        }
-                                                    });
-                                        } catch (Exception e) {
-                                            emitErrorIfSubscribed(e);
-                                        }
-                                    }
-                                });
-                            }
-                        } catch (Exception e) {
-                            emitErrorIfSubscribed(e);
-                        }
-                    }
-                });
+                AcquisitionListener listener = new AcquisitionListener(channelPool, request, responseEmitter);
+                responseEmitter.setDisposable(listener);
+                channelPool.acquire(channelAddress).addListener(listener);
             }).onErrorResumeNext((Throwable throwable) -> {
                 if (throwable instanceof EncoderException) {
                     LoggerFactory.getLogger(getClass()).warn("Got EncoderException: " + throwable.getMessage());
@@ -342,16 +210,15 @@ public final class NettyClient extends HttpClient {
                 }
             });
         }
+
     }
-    
+
     private static URI getChannelAddress(final HttpRequest request, final Proxy proxy) throws URISyntaxException {
         if (proxy == null) {
             return request.url().toURI();
         } else if (proxy.address() instanceof InetSocketAddress) {
             InetSocketAddress address = (InetSocketAddress) proxy.address();
-            String scheme = address.getPort() == 443
-                    ? "https"
-                    : "http";
+            String scheme = address.getPort() == 443 ? "https" : "http";
 
             String channelAddressString = scheme + "://" + address.getHostString() + ":" + address.getPort();
             return new URI(channelAddressString);
@@ -361,28 +228,304 @@ public final class NettyClient extends HttpClient {
         }
     }
 
+    private static final class AcquisitionListener
+            implements GenericFutureListener<Future<? super Channel>>, Disposable {
+
+        private final SharedChannelPool channelPool;
+        private final HttpRequest request;
+        private final SingleEmitter<HttpResponse> responseEmitter;
+        private final AtomicInteger state = new AtomicInteger(ACQUIRING_CONTENT_NOT_SUBSCRIBED);
+
+        private static final int ACQUIRING_CONTENT_NOT_SUBSCRIBED = 0;
+        private static final int ACQUIRING_DISPOSED = 1;
+        // ACQUIRING_CONTENT_SUBSCRIBED = 1; is not possible
+        private static final int ACQUIRED_CONTENT_NOT_SUBSCRIBED = 2;
+        private static final int ACQUIRED_CONTENT_SUBSCRIBED = 3;
+        private static final int ACQUIRED_DISPOSED_CONTENT_SUBSCRIBED = 4;
+        private static final int ACQUIRED_CONTENT_DONE = 5;
+        private static final int CHANNEL_RELEASED = 6;
+
+        // synchronized by `state`
+        private Channel channel;
+        
+        //synchronized by `state`
+        private ResponseContentFlowable content;
+
+        AcquisitionListener(SharedChannelPool channelPool, final HttpRequest request,
+                SingleEmitter<HttpResponse> responseEmitter) {
+            this.channelPool = channelPool;
+            this.request = request;
+            this.responseEmitter = responseEmitter;
+        }
+
+        @Override
+        public void operationComplete(Future<? super Channel> cf) {
+            if (!cf.isSuccess()) {
+                emitErrorIfSubscribed(cf.cause());
+                return;
+            }
+
+            channel = (Channel) cf.getNow();
+            while (true) {
+                int s = state.get();
+                if (transition(s, ACQUIRING_DISPOSED, CHANNEL_RELEASED)) {
+                    channelPool.closeAndRelease(channel);
+                    return;
+                } else if (transition(s, ACQUIRING_CONTENT_NOT_SUBSCRIBED, ACQUIRED_CONTENT_NOT_SUBSCRIBED)) {
+                    break;
+                } else if (state.compareAndSet(s,  s)) {
+                    break;
+                }
+            }
+            
+            final HttpClientInboundHandler inboundHandler = channel.pipeline().get(HttpClientInboundHandler.class);
+            inboundHandler.responseEmitter = responseEmitter;
+            //TODO do we need a memory barrier here to ensure vis of responseEmitter in other threads?
+            
+            responseEmitter.setDisposable(createDisposable());
+
+            configurePipeline(channel, request);
+
+            final DefaultHttpRequest raw = createDefaultHttpRequest(request);
+
+            try {
+                writeRequest(raw);
+
+                if (request.body() == null) {
+                    writeEmptyBody();
+                } else {
+                    request.body().subscribe(createSubscriber(inboundHandler));
+                }
+            } catch (Exception e) {
+                emitErrorIfSubscribed(e);
+            }
+        }
+
+        private FlowableSubscriber<ByteBuffer> createSubscriber(final HttpClientInboundHandler inboundHandler) {
+            return new FlowableSubscriber<ByteBuffer>() {
+                Subscription subscription;
+
+                @Override
+                public void onSubscribe(Subscription s) {
+                    subscription = s;
+                    inboundHandler.requestContentSubscription = subscription;
+                    subscription.request(1);
+                }
+
+                GenericFutureListener<Future<Void>> onChannelWriteComplete = (Future<Void> future) -> {
+                    if (!future.isSuccess()) {
+                        subscription.cancel();
+                        channelPool.closeAndRelease(channel);
+                        emitErrorIfSubscribed(future.cause());
+                    }
+                };
+
+                @Override
+                public void onNext(ByteBuffer buf) {
+                    try {
+                        channel.writeAndFlush(Unpooled.wrappedBuffer(buf)).addListener(onChannelWriteComplete);
+
+                        if (channel.isWritable()) {
+                            subscription.request(1);
+                        }
+                    } catch (Exception e) {
+                        subscription.cancel();
+                        emitErrorIfSubscribed(e);
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    channelPool.closeAndRelease(channel);
+                    emitErrorIfSubscribed(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    try {
+                        channel.writeAndFlush(DefaultLastHttpContent.EMPTY_LAST_CONTENT)
+                                .addListener((Future<Void> future) -> {
+                                    if (!future.isSuccess()) {
+                                        channelPool.closeAndRelease(channel);
+                                        emitErrorIfSubscribed(future.cause());
+                                    } else {
+                                        channel.read();
+                                    }
+                                });
+                    } catch (Exception e) {
+                        emitErrorIfSubscribed(e);
+                    }
+                }
+            };
+        }
+
+        private void writeEmptyBody() {
+            channel.writeAndFlush(DefaultLastHttpContent.EMPTY_LAST_CONTENT)
+                    .addListener((Future<Void> future) -> {
+                        if (future.isSuccess()) {
+                            channel.read();
+                        } else {
+                            channelPool.closeAndRelease(channel);
+                            emitErrorIfSubscribed(future.cause());
+                        }
+                    });
+        }
+
+        private void writeRequest(final DefaultHttpRequest raw) {
+            channel.write(raw).addListener((Future<Void> future) -> {
+                if (!future.isSuccess()) {
+                    dispose();
+                    emitErrorIfSubscribed(future.cause());
+                }
+            });
+        }
+
+        private Disposable createDisposable() {
+            return new Disposable() {
+                
+                final AtomicBoolean disposed = new AtomicBoolean(false);
+
+                @Override
+                public void dispose() {
+                    if (disposed.compareAndSet(false, true)) {
+                        dispose();
+                    }
+                }
+
+                @Override
+                public boolean isDisposed() {
+                    return disposed.get();
+                }
+            };
+        }
+        
+        private boolean transition(int s, int from, int to) {
+            if (s == from) {
+                if (state.compareAndSet(s, to)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        private void emitErrorIfSubscribed(Throwable throwable) {
+            if (!responseEmitter.isDisposed()) {
+                responseEmitter.onError(throwable);
+            }
+        }
+        
+        /**
+         * Returns false if and only if content subscription should be immediately
+         * cancelled.
+         * 
+         * @param content
+         * @return false if and only if content subscription should be immediately
+         *     cancelled
+         */
+        boolean contentSubscribed(ResponseContentFlowable content) {
+            while (true) {
+                int s = state.get();
+                if (transition(s, ACQUIRED_CONTENT_NOT_SUBSCRIBED, ACQUIRED_CONTENT_SUBSCRIBED)) {
+                    this.content = content;
+                    return true;
+                } else if (state.compareAndSet(s, s)) {
+                    return false;
+                }
+            }
+        }
+        
+        /**
+         * Is called when content flowable terminates or is cancelled.
+         * 
+         **/
+        void contentDone() {
+            while (true) {
+                int s = state.get();
+                if (transition(s, ACQUIRED_CONTENT_SUBSCRIBED, ACQUIRED_CONTENT_DONE)) {
+                    //TODO is this valid? Even though we have received a complete ok response
+                    // from the request it is still possible that the request has not finished! Perhaps we should wait for the request to finish writing?
+                    channelPool.closeAndRelease(channel);
+                }
+            }
+        }
+
+        @Override
+        public void dispose() {
+            while (true) {
+                int s = state.get();
+                if (transition(s, ACQUIRING_CONTENT_NOT_SUBSCRIBED, ACQUIRING_DISPOSED)) {
+                    // haven't got the channel to be able to release it yet
+                    // but check in operationComplete will release it
+                    return;
+                } else if (transition(s, ACQUIRED_CONTENT_NOT_SUBSCRIBED, CHANNEL_RELEASED)) {
+                    channelPool.closeAndRelease(channel);
+                    return;
+                } else if (transition(s, ACQUIRED_CONTENT_DONE, CHANNEL_RELEASED)) {
+                    channelPool.closeAndRelease(channel);
+                    return;
+                } else if (transition(s, ACQUIRED_CONTENT_SUBSCRIBED, ACQUIRED_DISPOSED_CONTENT_SUBSCRIBED)) {
+                    return;
+                } else if (state.compareAndSet(s, s)) {
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return state.get() == CHANNEL_RELEASED;
+        }
+    }
+
+    private static void configurePipeline(Channel channel, HttpRequest request) {
+        if (request.httpMethod() == com.microsoft.rest.v2.http.HttpMethod.HEAD) {
+            // Use HttpClientCodec for HEAD operations
+            if (channel.pipeline().get("HttpClientCodec") == null) {
+                channel.pipeline().remove(HttpRequestEncoder.class);
+                channel.pipeline().replace(HttpResponseDecoder.class, "HttpClientCodec", new HttpClientCodec());
+            }
+        } else {
+            // Use HttpResponseDecoder for other operations
+            if (channel.pipeline().get("HttpResponseDecoder") == null) {
+                channel.pipeline().replace(HttpClientCodec.class, "HttpResponseDecoder", new HttpResponseDecoder());
+                channel.pipeline().addAfter("HttpResponseDecoder", "HttpRequestEncoder", new HttpRequestEncoder());
+            }
+        }
+    }
+
+    private static DefaultHttpRequest createDefaultHttpRequest(HttpRequest request) {
+        final DefaultHttpRequest raw = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.valueOf(request.httpMethod().toString()), request.url().toString());
+
+        for (HttpHeader header : request.headers()) {
+            raw.headers().add(header.name(), header.value());
+        }
+        return raw;
+    }
 
     /**
      * Emits HTTP response content from Netty.
      */
-    private static final class ResponseContentFlowable extends Flowable<ByteBuf>
-            implements Subscription {
+    private static final class ResponseContentFlowable extends Flowable<ByteBuf> implements Subscription {
 
         // single producer, single consumer queue
         private final SimplePlainQueue<HttpContent> queue = new SpscLinkedArrayQueue<>(16);
         private final Subscription channelSubscription;
         private final AtomicBoolean chunkRequested = new AtomicBoolean(true);
         private final AtomicLong requested = new AtomicLong();
-        
+
         // work-in-progress counter
-        private final AtomicInteger wip = new AtomicInteger(1); //set to 1 to disable drain till we are ready
-        
+        private final AtomicInteger wip = new AtomicInteger(1); // set to 1 to disable drain till we are ready
+
         // ensures one subscriber only
         private final AtomicBoolean once = new AtomicBoolean();
-        
+
         private Subscriber<? super ByteBuf> subscriber;
-        
-        // can be non-volatile because event methods onReceivedContent, 
+
+        // can be non-volatile because event methods onReceivedContent,
         // chunkComplete, onError are serialized and is only written and
         // read in those event methods
         private boolean done;
@@ -392,8 +535,10 @@ public final class NettyClient extends HttpClient {
         // must be volatile otherwise parts of Throwable might not be visible to drain
         // loop (or suffer from word tearing)
         private volatile Throwable err;
+        private final AcquisitionListener acquisitionListener;
 
-        ResponseContentFlowable(Subscription channelSubscription) {
+        ResponseContentFlowable(AcquisitionListener acquisitionListener, Subscription channelSubscription) {
+            this.acquisitionListener = acquisitionListener;
             this.channelSubscription = channelSubscription;
         }
 
@@ -403,19 +548,20 @@ public final class NettyClient extends HttpClient {
                 subscriber = s;
                 s.onSubscribe(this);
 
+                acquisitionListener.contentSubscribed(this);
+                
                 // now that subscriber has been set enable the drain loop
                 wip.lazySet(0);
 
-                // we call drain because requests could have happened asynchronously before 
+                // we call drain because requests could have happened asynchronously before
                 // wip was set to 0 (which enables the drain loop)
                 drain();
             } else {
                 s.onSubscribe(SubscriptionHelper.CANCELLED);
-                s.onError(new IllegalStateException(
-                        "Multiple subscriptions not allowed for response content"));
+                s.onError(new IllegalStateException("Multiple subscriptions not allowed for response content"));
             }
         }
-        
+
         @Override
         public void request(long n) {
             if (SubscriptionHelper.validate(n)) {
@@ -460,7 +606,6 @@ public final class NettyClient extends HttpClient {
             drain();
         }
 
-
         void onError(Throwable cause) {
             if (done) {
                 RxJavaPlugins.onError(cause);
@@ -469,7 +614,7 @@ public final class NettyClient extends HttpClient {
             err = cause;
             drain();
         }
-        
+
         void channelInactive() {
             if (!done) {
                 done = true;
@@ -485,21 +630,27 @@ public final class NettyClient extends HttpClient {
         private void requestChunkOfByteBufsFromUpstream() {
             channelSubscription.request(1);
         }
-        
+
         private void drain() {
-            // Below is a non-blocking technique to ensure serialization (in-order processing) of the block inside the if statement
-            // and also to ensure no race conditions exist where items on the queue would be missed.
+            // Below is a non-blocking technique to ensure serialization (in-order
+            // processing) of the block inside the if statement
+            // and also to ensure no race conditions exist where items on the queue would be
+            // missed.
             //
             // wip = `work in progress` and follows a naming convention in RxJava
             //
-            // `missed` is a clever little trick to ensure that we only do as many loops as actually required. If `drain` is called 
-            // say 10 times while the `drain` loop is active then we notice that there are possibly extra items on the queue that arrived
-            // just after we found none left (and before the method exits). We don't need to loop around ten times but only once because
-            // all items will be picked up from the queue in one additional polling loop. 
+            // `missed` is a clever little trick to ensure that we only do as many loops as
+            // actually required. If `drain` is called
+            // say 10 times while the `drain` loop is active then we notice that there are
+            // possibly extra items on the queue that arrived
+            // just after we found none left (and before the method exits). We don't need to
+            // loop around ten times but only once because
+            // all items will be picked up from the queue in one additional polling loop.
             if (wip.getAndIncrement() == 0) {
                 // need to check cancelled even if there are no requests
                 if (cancelled) {
                     releaseQueue();
+                    acquisitionListener.contentDone();
                     return;
                 }
                 int missed = 1;
@@ -507,14 +658,17 @@ public final class NettyClient extends HttpClient {
                 while (true) {
                     long e = 0;
                     while (e != r) {
-                        // Note that an error can shortcut the emission of content that is currently on the queue.
-                        // This is probably desirable generally because it prevents work that being done downstream 
-                        // that might be thrown away anyway due to the error. 
+                        // Note that an error can shortcut the emission of content that is currently on
+                        // the queue.
+                        // This is probably desirable generally because it prevents work that being done
+                        // downstream
+                        // that might be thrown away anyway due to the error.
                         Throwable error = err;
                         if (error != null) {
                             releaseQueue();
                             channelSubscription.cancel();
                             subscriber.onError(error);
+                            acquisitionListener.contentDone();
                             return;
                         }
                         HttpContent o = queue.poll();
@@ -525,7 +679,7 @@ public final class NettyClient extends HttpClient {
                             }
                         } else {
                             // queue is empty so lets see if we need to request another chunk
-                            // note that we can only request one chunk at a time because the 
+                            // note that we can only request one chunk at a time because the
                             // method channel.read() ignores calls if a read is pending
                             if (chunkRequested.compareAndSet(false, true)) {
                                 requestChunkOfByteBufsFromUpstream();
@@ -534,6 +688,7 @@ public final class NettyClient extends HttpClient {
                         }
                         if (cancelled) {
                             releaseQueue();
+                            acquisitionListener.contentDone();
                             return;
                         }
                     }
@@ -553,11 +708,12 @@ public final class NettyClient extends HttpClient {
         private boolean emitContent(HttpContent data) {
             subscriber.onNext(data.content());
             if (data instanceof LastHttpContent) {
-                // release queue defensively (event serialization and the done flag 
+                // release queue defensively (event serialization and the done flag
                 // should mean there are no more items on the queue)
                 releaseQueue();
                 channelSubscription.cancel();
                 subscriber.onComplete();
+                acquisitionListener.contentDone();
                 return true;
             } else {
                 return false;
@@ -579,12 +735,12 @@ public final class NettyClient extends HttpClient {
 
     private static final class HttpClientInboundHandler extends ChannelInboundHandlerAdapter {
         private SingleEmitter<HttpResponse> responseEmitter;
-        
-        //TODO does this need to be volatile
+
+        // TODO does this need to be volatile
         private ResponseContentFlowable contentEmitter;
+        private AcquisitionListener acquisitionListener;
         private Subscription requestContentSubscription;
         private final NettyAdapter adapter;
-        private volatile boolean httpResponseEmitted;
 
         private HttpClientInboundHandler(NettyAdapter adapter) {
             this.adapter = adapter;
@@ -595,8 +751,10 @@ public final class NettyClient extends HttpClient {
             adapter.channelPool.release(ctx.channel());
             if (contentEmitter != null) {
                 contentEmitter.onError(cause);
-            } else if (responseEmitter != null && !responseEmitter.isDisposed()) {
+            } else {
+                if (responseEmitter != null && !responseEmitter.isDisposed()) {
                 responseEmitter.onError(cause);
+            }
             }
         }
 
@@ -626,7 +784,7 @@ public final class NettyClient extends HttpClient {
                     return;
                 }
 
-                contentEmitter = new ResponseContentFlowable(new Subscription() {
+                contentEmitter = new ResponseContentFlowable(acquisitionListener, new Subscription() {
                     @Override
                     public void request(long n) {
                         Preconditions.checkArgument(n == 1, "requests must be one at a time!");
@@ -644,12 +802,8 @@ public final class NettyClient extends HttpClient {
                     }
                 });
 
-                // Prevents channel from being closed when the Single<HttpResponse> is disposed
-                httpResponseEmitted = true;
-
-                //Scheduler scheduler = Schedulers.from(ctx.channel().eventLoop());
-                responseEmitter.onSuccess(
-                        new NettyResponse(response, contentEmitter));
+                // Scheduler scheduler = Schedulers.from(ctx.channel().eventLoop());
+                responseEmitter.onSuccess(new NettyResponse(response, contentEmitter));
             }
 
             if (msg instanceof HttpContent) {
@@ -674,8 +828,7 @@ public final class NettyClient extends HttpClient {
             }
             super.channelInactive(ctx);
         }
-        
-        
+
     }
 
     /**

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -277,17 +277,17 @@ public final class NettyClient extends HttpClient {
                 } else if (transition(s, ACQUIRING_NOT_DISPOSED, ACQUIRED_CONTENT_NOT_SUBSCRIBED)) {
                     break;
                 } else if (state.compareAndSet(s,  s)) {
-                    break;
+                    return;
                 }
             }
             
-            final HttpClientInboundHandler inboundHandler = channel.pipeline().get(HttpClientInboundHandler.class);
+            final HttpClientInboundHandler inboundHandler = 
+                    channel.pipeline().get(HttpClientInboundHandler.class);
             inboundHandler.responseEmitter = responseEmitter;
             inboundHandler.acquisitionListener = this;
             //TODO do we need a memory barrier here to ensure vis of responseEmitter in other threads?
             
             responseEmitter.setDisposable(createDisposable());
-
             
             try {
                 configurePipeline(channel, request);
@@ -335,7 +335,9 @@ public final class NettyClient extends HttpClient {
                         return;
                     }
                     try {
-                        channel.writeAndFlush(Unpooled.wrappedBuffer(buf)).addListener(onChannelWriteComplete);
+                        channel
+                            .writeAndFlush(Unpooled.wrappedBuffer(buf))
+                            .addListener(onChannelWriteComplete);
 
                         if (channel.isWritable()) {
                             subscription.request(1);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -786,7 +786,8 @@ public final class NettyClient extends HttpClient {
         // TODO does this need to be volatile
         private ResponseContentFlowable contentEmitter;
         private AcquisitionListener acquisitionListener;
-        private Subscription requestContentSubscription;
+        //TODO may not need to be volatile, depends on eventLoop involvement
+        private volatile Subscription requestContentSubscription;
         private final NettyAdapter adapter;
 
         private HttpClientInboundHandler(NettyAdapter adapter) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -277,7 +277,7 @@ public final class NettyClient extends HttpClient {
                     return;
                 } else if (transition(s, ACQUIRING_NOT_DISPOSED, ACQUIRED_CONTENT_NOT_SUBSCRIBED)) {
                     break;
-                } else if (state.compareAndSet(s,  s)) {
+                } else {
                     return;
                 }
             }
@@ -440,7 +440,7 @@ public final class NettyClient extends HttpClient {
                     closeAndReleaseChannel();
                     responseEmitter.onError(throwable);
                     break;
-                } else if (state.compareAndSet(s, s)) {
+                } else {
                     break;
                 }
             }
@@ -463,7 +463,7 @@ public final class NettyClient extends HttpClient {
                 } else if (transition(s, ACQUIRED_DISPOSED_CONTENT_NOT_SUBSCRIBED, ACQUIRED_DISPOSED_CONTENT_SUBSCRIBED)) {
                     this.content = content;
                     return true;
-                } else if (state.compareAndSet(s, s)) {
+                } else {
                     return false;
                 }
             }
@@ -485,7 +485,7 @@ public final class NettyClient extends HttpClient {
                 } else if (transition(s, ACQUIRED_DISPOSED_CONTENT_SUBSCRIBED, CHANNEL_RELEASED)) {
                     closeAndReleaseChannel();
                     return;
-                } else if (state.compareAndSet(s, s)) {
+                } else {
                     return;
                 }
             }
@@ -506,7 +506,7 @@ public final class NettyClient extends HttpClient {
                     return;
                 } else if (transition(s, ACQUIRED_CONTENT_SUBSCRIBED, ACQUIRED_DISPOSED_CONTENT_SUBSCRIBED)) {
                     return;
-                } else if (state.compareAndSet(s, s)) {
+                } else {
                     return;
                 }
             }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -334,14 +334,12 @@ public final class NettyClient extends HttpClient {
                     subscription.cancel();
                     emitError(future.cause());
                 } else {
-                    System.out.println(Thread.currentThread().getName() + " requesting");
                     subscription.request(1);
                 }
             };
 
             @Override
             public void onNext(ByteBuffer buf) {
-                System.out.println(Thread.currentThread().getName() + " arrived");
                 if (done) {
                     return;
                 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -192,9 +192,7 @@ public final class NettyClient extends HttpClient {
             } catch (URISyntaxException e) {
                 return Single.error(e);
             }
-            request.withHeader(io.netty.handler.codec.http.HttpHeaderNames.HOST.toString(), request.url().getHost())
-                    .withHeader(io.netty.handler.codec.http.HttpHeaderNames.CONNECTION.toString(),
-                            io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE.toString());
+            addHeaders(request);
 
             // Creates cold observable from an emitter
             return Single.create((SingleEmitter<HttpResponse> responseEmitter) -> {
@@ -204,13 +202,19 @@ public final class NettyClient extends HttpClient {
             }).onErrorResumeNext((Throwable throwable) -> {
                 if (throwable instanceof EncoderException) {
                     LoggerFactory.getLogger(getClass()).warn("Got EncoderException: " + throwable.getMessage());
+                    //TODO what is this, a retry? Should have a time delay? Max number of retries?
                     return sendRequestInternalAsync(request, proxy);
                 } else {
                     return Single.error(throwable);
                 }
             });
         }
-
+    }
+    
+    private static  void addHeaders(final HttpRequest request) {
+        request.withHeader(io.netty.handler.codec.http.HttpHeaderNames.HOST.toString(), request.url().getHost())
+                .withHeader(io.netty.handler.codec.http.HttpHeaderNames.CONNECTION.toString(),
+                        io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE.toString());
     }
 
     private static URI getChannelAddress(final HttpRequest request, final Proxy proxy) throws URISyntaxException {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -286,7 +286,7 @@ public final class NettyClient extends HttpClient {
                                             }
                                         });
                             } else {
-                                request.body().observeOn(Schedulers.from(channel.eventLoop())).subscribe(new FlowableSubscriber<ByteBuffer>() {
+                                request.body().subscribe(new FlowableSubscriber<ByteBuffer>() {
                                     Subscription subscription;
                                     @Override
                                     public void onSubscribe(Subscription s) {
@@ -305,9 +305,6 @@ public final class NettyClient extends HttpClient {
 
                                     @Override
                                     public void onNext(ByteBuffer buf) {
-                                        if (!channel.eventLoop().inEventLoop()) {
-                                            throw new IllegalStateException("onNext must be called from the event loop managing the channel.");
-                                        }
                                         try {
                                             channel.writeAndFlush(Unpooled.wrappedBuffer(buf))
                                                     .addListener(onChannelWriteComplete);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -700,8 +700,8 @@ public final class NettyClient extends HttpClient {
                     return;
                 }
                 int missed = 1;
-                long r = requested.get();
                 while (true) {
+                    long r = requested.get();
                     long e = 0;
                     while (e != r) {
                         // Note that an error can shortcut the emission of content that is currently on
@@ -739,10 +739,8 @@ public final class NettyClient extends HttpClient {
                         }
                     }
                     if (e > 0) {
-                        r = BackpressureHelper.produced(requested, e);
-                    } else {
-                        r = requested.get();
-                    }
+                        BackpressureHelper.produced(requested, e);
+                    } 
                     missed = wip.addAndGet(-missed);
                     if (missed == 0) {
                         return;
@@ -872,10 +870,7 @@ public final class NettyClient extends HttpClient {
 
             if (msg instanceof LastHttpContent) {
                 acquisitionListener.contentDone();
-            } else {
-                // TODO Don't do this because doesn't respect backpressure
-                ctx.channel().read();
-            }
+            } 
         }
 
         @Override

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -873,7 +873,9 @@ public final class NettyClient extends HttpClient {
 
         @Override
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-            contentEmitter.channelInactive();
+            if (contentEmitter != null) {
+                contentEmitter.channelInactive();
+            }
             super.channelInactive(ctx);
         }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -740,6 +740,8 @@ public final class NettyClient extends HttpClient {
                     }
                     if (e > 0) {
                         r = BackpressureHelper.produced(requested, e);
+                    } else {
+                        r = requested.get();
                     }
                     missed = wip.addAndGet(-missed);
                     if (missed == 0) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -328,7 +328,14 @@ public final class NettyClient extends HttpClient {
 
             private final HttpClientInboundHandler inboundHandler;
             
+            /**
+             * Ensures that requests are only made of upstream once the last write has completed 
+             * and the channel can be written to synchronously (when isWritable is false writes
+             * are buffered). 
+             */
             private final AtomicInteger writing = new AtomicInteger();
+            
+            //states for `writing`
             private static final int WRITE_COMPLETED_WRITABLE = 0;
             private static final int WRITING_WRITABLE = 1;
             private static final int WRITE_COMPLETED_NOT_WRITABLE = 2;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -212,7 +212,7 @@ public final class NettyClient extends HttpClient {
     
     private static  void addHeaders(final HttpRequest request) {
         request.withHeader(io.netty.handler.codec.http.HttpHeaderNames.HOST.toString(), request.url().getHost())
-                .withHeader(io.netty.handler.codec.http.HttpHeaderNames.CONNECTION.toString(),
+               .withHeader(io.netty.handler.codec.http.HttpHeaderNames.CONNECTION.toString(),
                         io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE.toString());
     }
 
@@ -316,7 +316,7 @@ public final class NettyClient extends HttpClient {
 
             private final HttpClientInboundHandler inboundHandler;
             
-            public RequestSubscriber(HttpClientInboundHandler inboundHandler) {
+            RequestSubscriber(HttpClientInboundHandler inboundHandler) {
                 this.inboundHandler = inboundHandler;
             }
 
@@ -428,8 +428,6 @@ public final class NettyClient extends HttpClient {
         }
 
         void emitError(Throwable throwable) {
-//            System.out.println("emitting error " + throwable.getMessage());
-//            throwable.printStackTrace();
             while (true) {
                 int s = state.get();
                 if (transition(s, ACQUIRING_NOT_DISPOSED, ACQUIRING_DISPOSED)) {
@@ -495,7 +493,6 @@ public final class NettyClient extends HttpClient {
 
         @Override
         public void dispose() {
-//            System.out.println("disposed");
             while (true) {
                 int s = state.get();
                 if (transition(s, ACQUIRING_NOT_DISPOSED, ACQUIRING_DISPOSED)) {
@@ -679,19 +676,18 @@ public final class NettyClient extends HttpClient {
 
         private void drain() {
             // Below is a non-blocking technique to ensure serialization (in-order
-            // processing) of the block inside the if statement
-            // and also to ensure no race conditions exist where items on the queue would be
-            // missed.
+            // processing) of the block inside the if statement and also to ensure 
+            // no race conditions exist where items on the queue would be missed.
             //
             // wip = `work in progress` and follows a naming convention in RxJava
             //
-            // `missed` is a clever little trick to ensure that we only do as many loops as
-            // actually required. If `drain` is called
-            // say 10 times while the `drain` loop is active then we notice that there are
-            // possibly extra items on the queue that arrived
-            // just after we found none left (and before the method exits). We don't need to
-            // loop around ten times but only once because
-            // all items will be picked up from the queue in one additional polling loop.
+            // `missed` is a clever little trick to ensure that we only do as many 
+            // loops as actually required. If `drain` is called say 10 times while
+            // the `drain` loop is active then we notice that there are possibly 
+            // extra items on the queue that arrived just after we found none left
+            // (and before the method exits). We don't need to loop around ten times
+            // but only once because all items will be picked up from the queue in
+            // one additional polling loop.
             if (wip.getAndIncrement() == 0) {
                 // need to check cancelled even if there are no requests
                 if (cancelled) {
@@ -705,10 +701,8 @@ public final class NettyClient extends HttpClient {
                     long e = 0;
                     while (e != r) {
                         // Note that an error can shortcut the emission of content that is currently on
-                        // the queue.
-                        // This is probably desirable generally because it prevents work that being done
-                        // downstream
-                        // that might be thrown away anyway due to the error.
+                        // the queue. This is probably desirable generally because it prevents work that being done
+                        // downstream that might be thrown away anyway due to the error.
                         Throwable error = err;
                         if (error != null) {
                             releaseQueue();
@@ -795,7 +789,7 @@ public final class NettyClient extends HttpClient {
         public void request(long n) {
             Preconditions.checkArgument(n == 1, "requests must be one at a time!");
             Channel c = channel.get();
-            if (c!=null) {
+            if (c != null) {
                 c.read();
             }
         }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -236,11 +236,13 @@ public final class NettyClient extends HttpClient {
         private final SharedChannelPool channelPool;
         private final HttpRequest request;
         private final SingleEmitter<HttpResponse> responseEmitter;
+        
+        // state is tracked to ensure that any races between write, read, 
+        // disposal, cancel, and request are properly handled via a serialized state machine. 
         private final AtomicInteger state = new AtomicInteger(ACQUIRING_NOT_DISPOSED);
-
+        
         private static final int ACQUIRING_NOT_DISPOSED = 0;
         private static final int ACQUIRING_DISPOSED = 1;
-        // ACQUIRING_CONTENT_SUBSCRIBED = 1; is not possible
         private static final int ACQUIRED_CONTENT_NOT_SUBSCRIBED = 2;
         private static final int ACQUIRED_CONTENT_SUBSCRIBED = 3;
         private static final int ACQUIRED_DISPOSED_CONTENT_SUBSCRIBED = 4;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -450,7 +450,6 @@ public final class NettyClient extends HttpClient {
                     } else {
                         if (s == WRITE_COMPLETED_WRITABLE) {
                             if (writing.compareAndSet(s, WRITE_COMPLETED_NOT_WRITABLE)) {
-                                subscription.request(1);
                                 break;
                             }
                         } else if (s == WRITING_WRITABLE) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -579,6 +579,8 @@ public final class NettyClient extends HttpClient {
 
     private static final class HttpClientInboundHandler extends ChannelInboundHandlerAdapter {
         private SingleEmitter<HttpResponse> responseEmitter;
+        
+        //TODO does this need to be volatile
         private ResponseContentFlowable contentEmitter;
         private Subscription requestContentSubscription;
         private final NettyAdapter adapter;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -739,6 +739,9 @@ public final class NettyClient extends HttpClient {
                         }
                     }
                     if (e > 0) {
+                        // it's tempting to use the result of this method to avoid 
+                        // another volatile read of requested but to avoid race conditions 
+                        // it's essential that requested is read again AFTER wip is changed.
                         BackpressureHelper.produced(requested, e);
                     } 
                     missed = wip.addAndGet(-missed);
@@ -827,6 +830,7 @@ public final class NettyClient extends HttpClient {
 
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            // TODO can ctx.channel() return a different object at some point in the lifecycle?
             channel.set(ctx.channel());
         }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -415,12 +415,7 @@ public final class NettyClient extends HttpClient {
         
         private boolean transition(int s, int from, int to) {
             if (s == from) {
-                if (state.compareAndSet(s, to)) {
-//                    System.out.println("transited from " + from + " to " + to);
-                    return true;
-                } else {
-                    return false;
-                }
+                return state.compareAndSet(s, to);
             } else {
                 return false;
             }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyResponse.java
@@ -80,7 +80,7 @@ class NettyResponse extends HttpResponse {
     }
 
     @Override
-    public Single<byte[]> bodyAsByteArrayAsync() {
+    public Single<byte[]> bodyAsByteArray() {
         return collectContent().map(new Function<ByteBuf, byte[]>() {
             @Override
             public byte[] apply(ByteBuf byteBuf) throws Exception {
@@ -101,7 +101,7 @@ class NettyResponse extends HttpResponse {
     }
 
     @Override
-    public Flowable<ByteBuffer> streamBodyAsync() {
+    public Flowable<ByteBuffer> body() {
         return contentStream.map(new Function<ByteBuf, ByteBuffer>() {
             @Override
             public ByteBuffer apply(ByteBuf byteBuf) {
@@ -115,7 +115,7 @@ class NettyResponse extends HttpResponse {
     }
 
     @Override
-    public Single<String> bodyAsStringAsync() {
+    public Single<String> bodyAsString() {
         return collectContent().map(new Function<ByteBuf, String>() {
             @Override
             public String apply(ByteBuf byteBuf) throws Exception {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/policy/HttpLoggingPolicyFactory.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/policy/HttpLoggingPolicyFactory.java
@@ -178,7 +178,7 @@ public class HttpLoggingPolicyFactory implements RequestPolicyFactory {
                 if ((contentTypeHeader == null || !"application/octet-stream".equalsIgnoreCase(contentTypeHeader))
                         && contentLength != 0 && contentLength < MAX_BODY_LOG_SIZE) {
                     final HttpResponse bufferedResponse = response.buffer();
-                    return bufferedResponse.bodyAsStringAsync().map(new Function<String, HttpResponse>() {
+                    return bufferedResponse.bodyAsString().map(new Function<String, HttpResponse>() {
                         @Override
                         public HttpResponse apply(String s) {
                             s = prettyPrintIfNeeded(logger, contentTypeHeader, s);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/protocol/HttpResponseDecoder.java
@@ -92,7 +92,7 @@ public final class HttpResponseDecoder {
         Single<HttpResponse> result;
         if (isErrorStatus) {
             final HttpResponse bufferedResponse = response.buffer();
-            result = bufferedResponse.bodyAsStringAsync().map(new Function<String, HttpResponse>() {
+            result = bufferedResponse.bodyAsString().map(new Function<String, HttpResponse>() {
                 @Override
                 public HttpResponse apply(String bodyString) throws Exception {
                     bufferedResponse.withDeserializedHeaders(deserializedHeaders);
@@ -110,7 +110,7 @@ public final class HttpResponseDecoder {
             });
         } else if (isSerializableBody) {
             final HttpResponse bufferedResponse = response.buffer();
-            result = bufferedResponse.bodyAsStringAsync().map(new Function<String, HttpResponse>() {
+            result = bufferedResponse.bodyAsString().map(new Function<String, HttpResponse>() {
                 @Override
                 public HttpResponse apply(String bodyString) throws Exception {
                     try {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -316,12 +316,13 @@ public final class FlowableUtil {
                     if (bytesRead == -1) {
                         done = true;
                     } else {
+                        // use local variable to perform one less volatile read
                         long pos = position;
                         int bytesWanted = (int) Math.min(bytesRead, maxRequired(pos));
-                        // use local variable to perform one less volatile read
                         long position2 = pos + bytesWanted;
                         //noinspection NonAtomicOperationOnVolatileField
                         position = position2;
+                        buffer.position(bytesWanted);
                         buffer.flip();
                         next = buffer;
                         if (position2 >= offset + length) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -347,7 +347,7 @@ public final class FlowableUtil {
         return Flowable.generate(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return 0;
+                return whole.position();
             }
         }, new BiFunction<Integer, Emitter<ByteBuffer>, Integer>() {
             @Override

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -231,7 +231,7 @@ public final class FlowableUtil {
 
         private volatile boolean cancelled;
 
-        public FileReadSubscription2(AsynchronousFileChannel fileChannel, long offset, long length,
+        FileReadSubscription2(AsynchronousFileChannel fileChannel, long offset, long length,
                 Subscriber<? super ByteBuffer> subscriber) {
             this.position = NOT_SET;
             this.fileChannel = fileChannel;
@@ -296,7 +296,12 @@ public final class FlowableUtil {
         }
         
         private void doRead() {
-            ByteBuffer innerBuf = ByteBuffer.allocate(Math.min(CHUNK_SIZE, (int) (offset + length - position)));
+            int maxRequired = (int) (offset + length - position);
+            //check for overflow
+            if (maxRequired < 0) {
+                maxRequired = Integer.MAX_VALUE;
+            }
+            ByteBuffer innerBuf = ByteBuffer.allocate(Math.min(CHUNK_SIZE, maxRequired));
             fileChannel.read(innerBuf, position, innerBuf, onReadComplete);
         }
         

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -293,7 +293,6 @@ public final class FlowableUtil {
             }
         }
         
-        //must be called from the drain loop only for visibility of `position`
         private void doRead() {
             ByteBuffer innerBuf = ByteBuffer.allocate(Math.min(CHUNK_SIZE, (int) (offset + length - position)));
             fileChannel.read(innerBuf, position, innerBuf, onReadComplete);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -250,15 +250,15 @@ public final class FlowableUtil {
                         if (cancelled) {
                             return;
                         }
-                        boolean emitted = false;
                         if (requested.get() > 0) {
                             // read d before next to avoid race
                             boolean d = done;
                             ByteBuffer bb = next;
                             if (bb != null) {
-                                emitted = true;
                                 next = null;
                                 subscriber.onNext(bb);
+                                BackpressureHelper.produced(requested, 1);
+                                doRead();
                             } 
                             if (d) {
                                 if (error != null) {
@@ -272,10 +272,6 @@ public final class FlowableUtil {
                                 }
                             } 
                         } 
-                        if (emitted) {
-                            BackpressureHelper.produced(requested, 1);
-                            doRead();
-                        }
                         missed = addAndGet(-missed);
                         if (missed == 0) {
                             return;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -336,6 +336,8 @@ public final class FlowableUtil {
             @Override
             public void failed(Throwable exc, ByteBuffer attachment) {
                 if (!cancelled) {
+                    // must set error before setting done to true
+                    // so that is visible in drain loop
                     error = exc;
                     done = true;
                     drain();

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -316,7 +316,7 @@ public final class FlowableUtil {
                     if (bytesRead == -1) {
                         done = true;
                     } else {
-                        // use local variable to perform one less volatile read
+                        // use local variable to perform fewer volatile reads
                         long pos = position;
                         int bytesWanted = (int) Math.min(bytesRead, maxRequired(pos));
                         long position2 = pos + bytesWanted;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -207,6 +207,8 @@ public final class FlowableUtil {
     
     private static final class FileReadSubscription2  extends AtomicInteger implements Subscription {
 
+        private static final int NOT_SET = -1;
+
         private static final long serialVersionUID = -6831808726875304256L;
         
         private final AtomicLong requested = new AtomicLong();
@@ -231,7 +233,7 @@ public final class FlowableUtil {
 
         public FileReadSubscription2(AsynchronousFileChannel fileChannel, long offset, long length,
                 Subscriber<? super ByteBuffer> subscriber) {
-            this.position = -1;
+            this.position = NOT_SET;
             this.fileChannel = fileChannel;
             this.offset = offset;
             this.length = length;
@@ -250,7 +252,7 @@ public final class FlowableUtil {
             // the wip counter is `this` (a way of saving allocations)
             if (getAndIncrement() == 0) {
                 // on first drain (first request) we initiate the first read
-                if (position == -1) {
+                if (position == NOT_SET) {
                     position = offset;
                     doRead();
                 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
@@ -1,0 +1,67 @@
+package com.microsoft.rest.v2;
+
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class MockServer {
+    private static class TestHandler extends HandlerWrapper {
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+            byte[] buf = new byte[8192];
+            InputStream is = request.getInputStream();
+            MessageDigest md5;
+            try {
+                md5 = MessageDigest.getInstance("MD5");
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            }
+
+            while (true) {
+                int bytesRead = is.read(buf);
+                if (bytesRead == -1) {
+                    break;
+                }
+                md5.update(buf, 0, bytesRead);
+            }
+
+            byte[] md5Digest = md5.digest();
+            String encodedMD5 = Base64.getEncoder().encodeToString(md5Digest);
+            response.setStatus(201);
+            response.setHeader("Content-MD5", encodedMD5);
+            baseRequest.setHandled(true);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Server server = new Server(11081);
+        ResourceHandler resourceHandler = new ResourceHandler();
+        resourceHandler.setDirectoriesListed(true);
+        resourceHandler.setResourceBase("client-runtime/temp/");
+        ContextHandler ch = new ContextHandler("/javasdktest/upload");
+        ch.setHandler(resourceHandler);
+
+        HandlerList handlers = new HandlerList();
+        handlers.addHandler(ch);
+        handlers.addHandler(new TestHandler());
+
+        server.setHandler(handlers);
+
+        System.out.println("Starting MockServer");
+        server.start();
+        server.join();
+        System.out.println("Shutting down MockServer");
+    }
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
@@ -7,6 +7,7 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -15,11 +16,16 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.Random;
 
 public class MockServer {
     private static class TestHandler extends HandlerWrapper {
         @Override
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+            LoggerFactory.getLogger(getClass()).info("Received request for " + baseRequest.getRequestURL());
+            baseRequest.setHandled(true);
+            Random random = new Random();
+
             byte[] buf = new byte[8192];
             InputStream is = request.getInputStream();
             MessageDigest md5;
@@ -35,13 +41,26 @@ public class MockServer {
                     break;
                 }
                 md5.update(buf, 0, bytesRead);
+
+                int randomNumber = random.nextInt(100000);
+                if (randomNumber == 12345) {
+                    LoggerFactory.getLogger(getClass()).info("Server had a transient error.");
+                    response.setStatus(503);
+                    response.getWriter().println("Error! Please try again.");
+
+                    // Appears to be necessary to read all the request content to prevent hangs
+                    // Would like to be able to test scenarios where the server drops the connection
+                    // when we're in the middle of sending request content.
+                    while (is.read(buf) != -1);
+
+                    return;
+                }
             }
 
             byte[] md5Digest = md5.digest();
             String encodedMD5 = Base64.getEncoder().encodeToString(md5Digest);
             response.setStatus(201);
             response.setHeader("Content-MD5", encodedMD5);
-            baseRequest.setHandled(true);
         }
     }
 
@@ -49,7 +68,13 @@ public class MockServer {
         Server server = new Server(11081);
         ResourceHandler resourceHandler = new ResourceHandler();
         resourceHandler.setDirectoriesListed(true);
-        resourceHandler.setResourceBase("client-runtime/temp/");
+
+        String tempPath = System.getenv("JAVA_STRESS_TEST_TEMP_PATH");
+        if (tempPath == null || tempPath.isEmpty()) {
+            tempPath = "client-runtime/temp";
+        }
+
+        resourceHandler.setResourceBase(tempPath);
         ContextHandler ch = new ContextHandler("/javasdktest/upload");
         ch.setHandler(resourceHandler);
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -17,9 +17,11 @@ import com.microsoft.rest.v2.annotations.PathParam;
 import com.microsoft.rest.v2.http.ContentType;
 import com.microsoft.rest.v2.http.HttpHeaders;
 import com.microsoft.rest.v2.http.HttpPipeline;
+import com.microsoft.rest.v2.http.HttpPipelineBuilder;
 import com.microsoft.rest.v2.http.HttpRequest;
 import com.microsoft.rest.v2.http.HttpResponse;
 import com.microsoft.rest.v2.policy.AddHeadersPolicyFactory;
+import com.microsoft.rest.v2.policy.HostPolicyFactory;
 import com.microsoft.rest.v2.policy.HttpLogDetailLevel;
 import com.microsoft.rest.v2.policy.HttpLoggingPolicyFactory;
 import com.microsoft.rest.v2.policy.RequestPolicy;
@@ -34,6 +36,7 @@ import io.reactivex.SingleSource;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.Functions;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -68,6 +71,26 @@ import static org.junit.Assert.assertArrayEquals;
 
 @Ignore("Should only be run manually")
 public class RestProxyStressTests {
+    private static IOService service;
+
+    @BeforeClass
+    public static void setup() {
+        HttpHeaders headers = new HttpHeaders()
+                .set("x-ms-version", "2017-04-17");
+        HttpPipelineBuilder builder = new HttpPipelineBuilder()
+                .withRequestPolicy(new AddDatePolicyFactory())
+                .withRequestPolicy(new AddHeadersPolicyFactory(headers))
+                .withRequestPolicy(new ThrottlingRetryPolicyFactory());
+
+        String liveStressTests = System.getenv("JAVA_SDK_TEST_SAS");
+        if (liveStressTests == null || liveStressTests.isEmpty()) {
+            builder.withRequestPolicy(new HostPolicyFactory("http://localhost:11081"));
+        }
+
+        builder.withHttpLoggingPolicy(HttpLogDetailLevel.BASIC);
+
+        service = RestProxy.create(IOService.class, builder.build());
+    }
 
     private static final class AddDatePolicyFactory implements RequestPolicyFactory {
         @Override
@@ -233,17 +256,6 @@ public class RestProxyStressTests {
     @Test
     public void upload100MParallelTest() throws Exception {
         final String sas = System.getenv("JAVA_SDK_TEST_SAS");
-        HttpHeaders headers = new HttpHeaders()
-                .set("x-ms-version", "2017-04-17");
-
-        HttpPipeline pipeline = HttpPipeline.build(
-                new AddDatePolicyFactory(),
-                new AddHeadersPolicyFactory(headers),
-                new ThrottlingRetryPolicyFactory(),
-                new HttpLoggingPolicyFactory(HttpLogDetailLevel.BASIC));
-
-        final IOService service = RestProxy.create(IOService.class, pipeline);
-
         List<byte[]> md5s = Flowable.range(0, NUM_FILES)
                 .map(integer -> {
                     final Path filePath = TEMP_FOLDER_PATH.resolve("100m-" + integer + "-md5.dat");
@@ -308,17 +320,7 @@ public class RestProxyStressTests {
      */
     @Test
     public void download100MParallelTest() throws Exception {
-        final String sas = System.getenv("JAVA_SDK_TEST_SAS");
-        HttpHeaders headers = new HttpHeaders()
-                .set("x-ms-version", "2017-04-17");
-
-        HttpPipeline pipeline = HttpPipeline.build(
-                new AddDatePolicyFactory(),
-                new AddHeadersPolicyFactory(headers),
-                new ThrottlingRetryPolicyFactory(),
-                new HttpLoggingPolicyFactory(HttpLogDetailLevel.BASIC));
-
-        final IOService service = RestProxy.create(IOService.class, pipeline);
+        final String sas = System.getenv("JAVA_SDK_TEST_SAS") == null ? "" : System.getenv("JAVA_SDK_TEST_SAS");
 
         List<byte[]> md5s = Flowable.range(0, NUM_FILES)
                 .map(integer -> {
@@ -333,7 +335,7 @@ public class RestProxyStressTests {
                             final MessageDigest messageDigest = MessageDigest.getInstance("MD5");
                             Flowable<ByteBuffer> content = response.body().doOnNext(messageDigest::update);
 
-                            AsynchronousFileChannel file = AsynchronousFileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + ".dat"), StandardOpenOption.WRITE);
+                            AsynchronousFileChannel file = AsynchronousFileChannel.open(TEMP_FOLDER_PATH.resolve("100m-" + id + "-dl.dat"), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
                             return FlowableUtil.writeFile(content, file).doOnComplete(() -> {
                                 assertArrayEquals(md5, messageDigest.digest());
                                 LoggerFactory.getLogger(getClass()).info("Finished downloading and MD5 validated for " + id);

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
-//@Ignore("Should only be run manually")
+@Ignore("Should only be run manually")
 public class RestProxyStressTests {
     private static IOService service;
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
-@Ignore("Should only be run manually")
+//@Ignore("Should only be run manually")
 public class RestProxyStressTests {
     private static IOService service;
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -323,6 +323,7 @@ public class RestProxyStressTests {
      */
     @Test
     public void download100MParallelTest() {
+        while (true) {
         final String sas = System.getenv("JAVA_SDK_TEST_SAS") == null ? "" : System.getenv("JAVA_SDK_TEST_SAS");
 
         List<byte[]> md5s = Flowable.range(0, NUM_FILES)
@@ -353,6 +354,7 @@ public class RestProxyStressTests {
         assertTrue(result);
         long durationMilliseconds = Duration.between(downloadStart, Instant.now()).toMillis();
         LoggerFactory.getLogger(getClass()).info("Download took " + durationMilliseconds + " milliseconds.");
+        }
     }
 
     @Test

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpResponse.java
@@ -81,17 +81,17 @@ public class MockHttpResponse extends HttpResponse {
     }
 
     @Override
-    public Single<byte[]> bodyAsByteArrayAsync() {
+    public Single<byte[]> bodyAsByteArray() {
         return Single.just(bodyBytes);
     }
 
     @Override
-    public Flowable<ByteBuffer> streamBodyAsync() {
+    public Flowable<ByteBuffer> body() {
         return Flowable.just(ByteBuffer.wrap(bodyBytes));
     }
 
     @Override
-    public Single<String> bodyAsStringAsync() {
+    public Single<String> bodyAsString() {
         return Single.just(bodyBytes == null ? "" : new String(bodyBytes));
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -213,7 +213,7 @@ public class NettyClientTests {
             System.out.println("reading body");
             response.bodyAsByteArrayAsync() //
                     .test() //
-                    .awaitDone(1, TimeUnit.SECONDS) //
+                    .awaitDone(20, TimeUnit.SECONDS) //
                     .assertError(IOException.class) //
                     .assertErrorMessage("channel inactive");
         } finally {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -233,7 +233,8 @@ public class NettyClientTests {
                         .fromCallable(() -> getResponse("/long")) //
                         .flatMapPublisher(response -> response //
                                 .streamBodyAsync() //
-                                .map(bb -> new NumberedByteBuffer(n, bb))))
+                                .map(bb -> new NumberedByteBuffer(n, bb))
+                                .doOnComplete(() -> System.out.println("completed " + n))))
                 .sequential() //
                 // enable the doOnNext call to see request numbers and thread names
                 // .doOnNext(g -> System.out.println(g.n + " " + Thread.currentThread().getName())) //

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -264,7 +264,7 @@ public class NettyClientTests {
                 .get(0);
         t = System.currentTimeMillis() - t;
         System.out.println("totalBytesRead=" + numBytes / 1024 / 1024 + "MB in " + t / 1000.0 + "s");
-        assertTrue(numBytes > 0);
+        assertEquals(numRequests * LONG_BODY.getBytes(StandardCharsets.UTF_8).length, numBytes);
     }
 
     private static final class NumberedByteBuffer {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -223,6 +223,7 @@ public class NettyClientTests {
         long t = System.currentTimeMillis();
         int numRequests = 100; // 100 = 1GB of data read
         long timeoutSeconds = 60;
+        HttpClient client = HttpClient.createDefault();
         long numBytes = Flowable.range(1, numRequests) //
                 // Note that WireMock default threads for accepting connections is 10
                 // we start 10 different threads each of which will deal with the range
@@ -230,7 +231,7 @@ public class NettyClientTests {
                 .parallel(10) //
                 .runOn(Schedulers.io()) //
                 .flatMap(n -> Single //
-                        .fromCallable(() -> getResponse("/long")) //
+                        .fromCallable(() -> getResponse(client, "/long")) //
                         .flatMapPublisher(response -> response //
                                 .streamBodyAsync() //
                                 .map(bb -> new NumberedByteBuffer(n, bb))

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -242,7 +242,7 @@ public class NettyClientTests {
                                     .body() //
                                     .doOnNext(bb -> md.update(bb)) //
                                     .map(bb -> new NumberedByteBuffer(n, bb))
-                                    .doOnComplete(() -> System.out.println("completed " + n)) //
+//                                    .doOnComplete(() -> System.out.println("completed " + n)) //
                                     .doOnComplete(() -> Assert.assertArrayEquals("wrong digest!", expectedDigest,
                                             md.digest()));
                         }))

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -77,7 +77,7 @@ public class NettyClientTests {
     private void checkBodyReceived(String expectedBody, String path) {
         HttpClient client = HttpClient.createDefault();
         HttpResponse response = doRequest(client, path);
-        String s = new String(response.bodyAsByteArrayAsync().blockingGet(),
+        String s = new String(response.bodyAsByteArray().blockingGet(),
                 StandardCharsets.UTF_8);
         assertEquals(expectedBody, s);
     }
@@ -91,9 +91,9 @@ public class NettyClientTests {
     @Test
     public void testMultipleSubscriptionsEmitsError() {
         HttpResponse response = getResponse("/short");
-        response.bodyAsByteArrayAsync().blockingGet();
+        response.bodyAsByteArray().blockingGet();
         // subscribe again
-        response.bodyAsByteArrayAsync() //
+        response.bodyAsByteArray() //
                 .test() //
                 .awaitDone(20, TimeUnit.SECONDS) //
                 .assertNoValues() //
@@ -103,7 +103,7 @@ public class NettyClientTests {
     @Test
     public void testCancel() throws InterruptedException {
         HttpResponse response = getResponse("/long");
-        TestSubscriber<ByteBuffer> ts = response.streamBodyAsync() //
+        TestSubscriber<ByteBuffer> ts = response.body() //
                 .test(0) //
                 .requestMore(1) //
                 .awaitCount(1) //
@@ -121,7 +121,7 @@ public class NettyClientTests {
     public void testFlowableWhenServerReturnsBodyAndNoErrorsWhenHttp500Returned() {
         HttpResponse response = getResponse("/error");
         response //
-                .bodyAsStringAsync() //
+                .bodyAsString() //
                 .test() //
                 .awaitDone(20, TimeUnit.SECONDS) //
                 .assertValues("error") //
@@ -133,7 +133,7 @@ public class NettyClientTests {
     public void testFlowableBackpressure() {
         HttpResponse response = getResponse("/long");
         response //
-                .streamBodyAsync() //
+                .body() //
                 .test(0) //
                 .assertValueCount(0) //
                 .assertNoErrors() //
@@ -211,7 +211,7 @@ public class NettyClientTests {
             HttpResponse response = client.sendRequestAsync(request).blockingGet();
             assertEquals(200, response.statusCode());
             System.out.println("reading body");
-            response.bodyAsByteArrayAsync() //
+            response.bodyAsByteArray() //
                     .test() //
                     .awaitDone(20, TimeUnit.SECONDS) //
                     .assertError(IOException.class) //
@@ -239,7 +239,7 @@ public class NettyClientTests {
                         .flatMapPublisher(response -> {
                             MessageDigest md = MessageDigest.getInstance("MD5");
                             return response //
-                                    .streamBodyAsync() //
+                                    .body() //
                                     .doOnNext(bb -> md.update(bb)) //
                                     .map(bb -> new NumberedByteBuffer(n, bb))
                                     .doOnComplete(() -> System.out.println("completed " + n)) //

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -75,7 +75,7 @@ public class NettyClientTests {
         checkBodyReceived(LONG_BODY, "/long");
     }
 
-    
+
     @Test
     public void testMultipleSubscriptionsEmitsError() {
         HttpResponse response = getResponse("/short");
@@ -133,7 +133,7 @@ public class NettyClientTests {
                 .requestMore(Long.MAX_VALUE) //
                 .awaitDone(20, TimeUnit.SECONDS).assertComplete();
     }
-    
+
     @Test
     public void testRequestBodyIsErrorShouldPropagateToResponse() {
         HttpClient client = HttpClient.createDefault();
@@ -145,7 +145,7 @@ public class NettyClientTests {
                 .assertNoValues() //
                 .assertErrorMessage("boo");
     }
-    
+
     @Test
     public void testRequestBodyEndsInErrorShouldPropagateToResponse() {
         HttpClient client = HttpClient.createDefault();
@@ -160,8 +160,8 @@ public class NettyClientTests {
                 .assertNoValues() //
                 .assertErrorMessage("boo");
     }
-    
-    
+
+
     private static ByteBuffer toByteBuffer(String s) {
         return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
     }
@@ -240,7 +240,7 @@ public class NettyClientTests {
             ss.close();
         }
     }
-    
+
     @Test
     public void testConcurrentRequests() throws NoSuchAlgorithmException {
         long t = System.currentTimeMillis();
@@ -361,7 +361,7 @@ public class NettyClientTests {
         }
         return s.toString();
     }
-    
+
     private void checkBodyReceived(String expectedBody, String path) {
         HttpClient client = HttpClient.createDefault();
         HttpResponse response = doRequest(client, path);

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -44,7 +44,7 @@ public class NettyClientTests {
 
     @BeforeClass
     public static void beforeClass() {
-        server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        server = new WireMockServer(WireMockConfiguration.options().dynamicPort().disableRequestJournal());
         server.stubFor(
                 WireMock.get("/short").willReturn(WireMock.aResponse().withBody(SHORT_BODY)));
         server.stubFor(WireMock.get("/long").willReturn(WireMock.aResponse().withBody(LONG_BODY)));

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/policy/RequestIdPolicyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/policy/RequestIdPolicyTests.java
@@ -39,17 +39,17 @@ public class RequestIdPolicyTests {
         }
 
         @Override
-        public Single<byte[]> bodyAsByteArrayAsync() {
+        public Single<byte[]> bodyAsByteArray() {
             return Single.just(new byte[0]);
         }
 
         @Override
-        public Flowable<ByteBuffer> streamBodyAsync() {
+        public Flowable<ByteBuffer> body() {
             return Flowable.just(ByteBuffer.allocate(0));
         }
 
         @Override
-        public Single<String> bodyAsStringAsync() {
+        public Single<String> bodyAsString() {
             return Single.just("");
         }
     };

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -63,6 +63,7 @@ public class FlowableUtilTests {
                 .blockingGet() //
                 .toByteArray();
         assertEquals("hello there", new String(bytes, StandardCharsets.UTF_8));
+        file.delete();
     }
     
     private static final int NUM_CHUNKS_IN_LONG_INPUT = 10_000_000;
@@ -89,6 +90,7 @@ public class FlowableUtilTests {
                 .blockingForEach(bb -> digest.update(bb));
                 
         assertArrayEquals(expected, digest.digest());
+        file.delete();
     }
     
     @Test
@@ -123,6 +125,7 @@ public class FlowableUtilTests {
                 .assertComplete();
                 
         assertArrayEquals(expected, digest.digest());
+        file.delete();
     }
 
     private static byte[] toBytes(ByteBuffer bb) {

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -64,19 +64,21 @@ public class FlowableUtilTests {
                 .toByteArray();
         assertEquals("hello there", new String(bytes, StandardCharsets.UTF_8));
     }
+    
+    private static final int NUM_CHUNKS_IN_LONG_INPUT = 10_000_000;
 
     @Test
     public void testAsynchronyLongInput() throws IOException, NoSuchAlgorithmException {
         File file = new File("target/test4");
         byte[] array = "1234567690".getBytes(StandardCharsets.UTF_8);
-        int n = 1_000_000;
         MessageDigest digest = MessageDigest.getInstance("MD5");
         try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
-            for (int i = 0; i < 1_000_000; i++) {
+            for (int i = 0; i < NUM_CHUNKS_IN_LONG_INPUT; i++) {
                 out.write(array);
                 digest.update(array);
             }
         }
+        System.out.println("long input file size="+ file.length()/(1024*1024) + "MB");
         byte[] expected = digest.digest();
         digest.reset();
         AsynchronousFileChannel channel = AsynchronousFileChannel.open(file.toPath(), StandardOpenOption.READ);
@@ -93,10 +95,9 @@ public class FlowableUtilTests {
     public void testBackpressureLongInput() throws IOException, NoSuchAlgorithmException {
         File file = new File("target/test4");
         byte[] array = "1234567690".getBytes(StandardCharsets.UTF_8);
-        int n = 1_000_000;
         MessageDigest digest = MessageDigest.getInstance("MD5");
         try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
-            for (int i = 0; i < 1_000_000; i++) {
+            for (int i = 0; i < NUM_CHUNKS_IN_LONG_INPUT; i++) {
                 out.write(array);
                 digest.update(array);
             }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -72,7 +72,7 @@ public class FlowableUtilTests {
     public void testAsynchronyLongInput() throws IOException, NoSuchAlgorithmException {
         File file = new File("target/test4");
         byte[] array = "1234567690".getBytes(StandardCharsets.UTF_8);
-        MessageDigest digest = digest = MessageDigest.getInstance("MD5");
+        MessageDigest digest = MessageDigest.getInstance("MD5");
         try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
             for (int i = 0; i < NUM_CHUNKS_IN_LONG_INPUT; i++) {
                 out.write(array);
@@ -97,7 +97,7 @@ public class FlowableUtilTests {
     public void testBackpressureLongInput() throws IOException, NoSuchAlgorithmException {
         File file = new File("target/test4");
         byte[] array = "1234567690".getBytes(StandardCharsets.UTF_8);
-        MessageDigest digest = digest = MessageDigest.getInstance("MD5");
+        MessageDigest digest = MessageDigest.getInstance("MD5");
         try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
             for (int i = 0; i < NUM_CHUNKS_IN_LONG_INPUT; i++) {
                 out.write(array);

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -139,7 +139,9 @@ public class FlowableUtilTests {
         digest.update(bb);
         byte[] expected = digest.digest();
         for (int size=1; size<16; size++) {
+            System.out.println("size="+ size);
             digest.reset();
+            bb.position(0);
             FlowableUtil //
                 .split(bb, 3) //
                 .doOnNext(b -> digest.update(b)) //

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -1,0 +1,97 @@
+package com.microsoft.rest.v2.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.junit.Test;
+
+import com.google.common.io.Files;
+
+import io.reactivex.schedulers.Schedulers;
+
+public class FlowableUtilTests {
+
+    @Test
+    public void testCanReadSlice() throws IOException {
+        File file = new File("target/test1");
+        Files.write("hello there".getBytes(StandardCharsets.UTF_8), file);
+        AsynchronousFileChannel channel = AsynchronousFileChannel.open(file.toPath(), StandardOpenOption.READ);
+        byte[] bytes = FlowableUtil.readFile(channel, 1, 3) //
+                .map(bb -> toBytes(bb)) //
+                .collectInto(new ByteArrayOutputStream(), (bos, b) -> bos.write(b)) //
+                .blockingGet().toByteArray();
+        assertEquals("ell", new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testCanReadEmptyFile() throws IOException {
+        File file = new File("target/test2");
+        file.delete();
+        file.createNewFile();
+        AsynchronousFileChannel channel = AsynchronousFileChannel.open(file.toPath(), StandardOpenOption.READ);
+        byte[] bytes = FlowableUtil.readFile(channel, 1, 3) //
+                .map(bb -> toBytes(bb)) //
+                .collectInto(new ByteArrayOutputStream(), (bos, b) -> bos.write(b)) //
+                .blockingGet().toByteArray();
+        assertEquals(0, bytes.length);
+    }
+
+    @Test
+    public void testAsynchronyShortInput() throws IOException {
+        File file = new File("target/test3");
+        Files.write("hello there".getBytes(StandardCharsets.UTF_8), file);
+        AsynchronousFileChannel channel = AsynchronousFileChannel.open(file.toPath(), StandardOpenOption.READ);
+        byte[] bytes = FlowableUtil.readFile(channel) //
+                .map(bb -> toBytes(bb)) //
+                .rebatchRequests(1) //
+                .subscribeOn(Schedulers.io()) //
+                .observeOn(Schedulers.io()) //
+                .collectInto(new ByteArrayOutputStream(), (bos, b) -> bos.write(b)) //
+                .blockingGet() //
+                .toByteArray();
+        assertEquals("hello there", new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testAsynchronyLongInput() throws IOException, NoSuchAlgorithmException {
+        File file = new File("target/test4");
+        byte[] array = "1234567690".getBytes(StandardCharsets.UTF_8);
+        int n = 1_000_000;
+        MessageDigest digest = MessageDigest.getInstance("MD5");
+        try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
+            for (int i = 0; i < 1_000_000; i++) {
+                out.write(array);
+                digest.update(array);
+            }
+        }
+        byte[] expected = digest.digest();
+        digest.reset();
+        AsynchronousFileChannel channel = AsynchronousFileChannel.open(file.toPath(), StandardOpenOption.READ);
+        FlowableUtil.readFile(channel) //
+                .rebatchRequests(1) //
+                .subscribeOn(Schedulers.io()) //
+                .observeOn(Schedulers.io()) //
+                .blockingForEach(bb -> digest.update(bb));
+                
+        assertArrayEquals(expected, digest.digest());
+    }
+
+    private static byte[] toBytes(ByteBuffer bb) {
+        byte[] bytes = new byte[bb.remaining()];
+        bb.get(bytes);
+        return bytes;
+    }
+
+}


### PR DESCRIPTION
As promised in discussion in #402, this is a rework of `NettyClient.ResponseContentFlowable`.

The Flowable has been reworked to
* perform proper request accounting
* ensure reads are requested one at a time of upstream only on completion of last requested read (because `channel.read()` is ignored by Netty if a read is pending)
* buffer `ByteBuf`s as upstream delivers many items at a time (a *chunk*)
* release unused `ByteBuf`s on cancellation 
* handle asynchronous calls to `subscribeActual`, `request`, `cancel` with non-blocking techniques
* handle a connection failure by also propagating the `channelInactive` response to the Flowable (which emits an `IOException`)
* reject multiple subscriptions by emitting an error
* be compliant with reactive-streams contract (bad requests reported to RxJavaPlugins.onError)
* protect against events appearing unexpectedly after a final event (`done` flag)
* remove `eventLoop` usage because Netty does not require that for example `channel.read()` is called from the `eventLoop`.
* use *WireMock* in the unit tests to remove dependency on `httpbin.org`

Notes:
* `RestProxyWithNettyTests` are hanging because the `Future` returned by `channel.acquire` never completes (and the new `Flowable` does not get called at all). I'd like to hand that problem back to you as it appears to be independent of this change.
* There is a TODO in the `drain` method about whether we shortcut errors or not. Please read that.
* You may want to play with `ResourceLeakDetector`. Probably need a sleep at the end of tests to ensure that cancellation finishes.
* `NettyAdapter.sendRequestInternalAsync` is messy. I left it alone but for a couple of deprecation fixes and the reporting of `channelInactive`. I'd suggest a cleanup to reduce the method length and improve readability. If you go the extra mile to be friendly to users then you replace the anonymous classes (lambdas) with concrete classes to make stack traces easier to read.


