### PR TITLE
Add back apache commons for now

### DIFF
--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -72,6 +72,10 @@
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
         <version>2.8.11</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.4</version>
+      </dependency>
+      <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>adal4j</artifactId>
         <version>1.1.2</version>


### PR DESCRIPTION
I removed this dependency a little while back, but didn't actually stamp out its usages in the generated code, so I'm bringing it back until I can put in the time to remove it properly. This fixes build errors in some of our user's projects related to base64 encoding.