### PR TITLE
Move groupId above parent groupId so publish tools can infer it

### DIFF
--- a/client-runtime-native/pom.xml
+++ b/client-runtime-native/pom.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <groupId>com.microsoft.rest.v2</groupId>
+    <artifactId>client-runtime-native</artifactId>
+
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>autorest-clientruntime-for-java</artifactId>
@@ -7,9 +10,6 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
-
-    <groupId>com.microsoft.rest.v2</groupId>
-    <artifactId>client-runtime-native</artifactId>
 
     <name>Native Modules for AutoRest Client Runtime for Java</name>
     <description>

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -5,16 +5,16 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.microsoft.rest.v2</groupId>
+  <artifactId>client-runtime</artifactId>
+  <packaging>jar</packaging>
+
   <parent>
     <groupId>com.microsoft.azure.v2</groupId>
     <artifactId>autorest-clientruntime-for-java</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-
-  <groupId>com.microsoft.rest.v2</groupId>
-  <artifactId>client-runtime</artifactId>
-  <packaging>jar</packaging>
 
   <name>Java Client Runtime for AutoRest</name>
   <description>This package contains the basic runtime for AutoRest generated Java clients.</description>


### PR DESCRIPTION
This is happening because we have automated tools which use a regex to look for the groupId in the pom. If we don't put the groupId for this package first, it'll pick up the wrong one. This is only necessary when we override the parent groupId for azure with the vanilla one.