### PR TITLE
Netty client rework 2

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -926,8 +926,6 @@ public final class NettyClient extends HttpClient {
                 // It doesn't seem like this should be possible since we set this volatile field
                 // before we begin writing request content, but it can happen under high load
                 contentEmitter.chunkCompleted();
-            } else {
-                LoggerFactory.getLogger(getClass()).warn("contentEmitter was null!");
             }
         }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -256,14 +256,7 @@ public final class NettyClient extends HttpClient {
         //synchronized by `state`
         private ResponseContentFlowable content;
         
-        private final AtomicInteger writing = new AtomicInteger();
         private volatile RequestSubscriber requestSubscriber;
-        
-        private static final int WRITE_COMPLETED_WRITABLE = 0;
-        private static final int WRITING_WRITABLE = 1;
-        private static final int WRITE_COMPLETED_NOT_WRITABLE = 2;
-        private static final int WRITING_NOT_WRITABLE = 3;
-        
 
         AcquisitionListener(SharedChannelPool channelPool, final HttpRequest request,
                 SingleEmitter<HttpResponse> responseEmitter) {

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -198,14 +198,6 @@ public final class NettyClient extends HttpClient {
                 AcquisitionListener listener = new AcquisitionListener(channelPool, request, responseEmitter);
                 responseEmitter.setDisposable(listener);
                 channelPool.acquire(channelAddress).addListener(listener);
-            }).onErrorResumeNext((Throwable throwable) -> {
-                if (throwable instanceof EncoderException) {
-                    LoggerFactory.getLogger(getClass()).warn("Got EncoderException: " + throwable.getMessage());
-                    //TODO what is this, a retry? Should have a time delay? Max number of retries?
-                    return sendRequestInternalAsync(request, proxy);
-                } else {
-                    return Single.error(throwable);
-                }
             });
         }
     }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -37,7 +37,6 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.pool.AbstractChannelPoolHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpClientCodec;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -137,14 +137,15 @@ public class SharedChannelPool implements ChannelPool {
                             channelFuture.channel().pipeline().addFirst(sslContext.newHandler(channelFuture.channel().alloc(), request.uri.getHost(), port));
                         }
 
+                        leased.put(request.uri, channelFuture.channel());
                         channelFuture.addListener(new GenericFutureListener<Future<? super Void>>() {
                             @Override
                             public void operationComplete(Future<? super Void> future) throws Exception {
                                 if (channelFuture.isSuccess()) {
                                     handler.channelAcquired(channelFuture.channel());
-                                    leased.put(request.uri, channelFuture.channel());
                                     request.promise.setSuccess(channelFuture.channel());
                                 } else {
+                                    leased.remove(request.uri, channelFuture.channel());
                                     request.promise.setFailure(channelFuture.cause());
                                 }
                             }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
@@ -51,7 +51,7 @@ public class MockServer {
                     // Appears to be necessary to read all the request content to prevent hangs
                     // Would like to be able to test scenarios where the server drops the connection
                     // when we're in the middle of sending request content.
-                    while (is.read(buf) != -1);
+                    while (is.read(buf) != -1) ;
 
                     return;
                 }
@@ -69,7 +69,13 @@ public class MockServer {
     }
 
     public static void main(String[] args) throws Exception {
-        Server server = new Server(11081);
+        int port = 8080;
+        String portString = System.getenv("JAVA_SDK_TEST_PORT");
+        if (portString != null) {
+            port = Integer.parseInt(portString, 10);
+        }
+
+        Server server = new Server(port);
         ResourceHandler resourceHandler = new ResourceHandler();
         resourceHandler.setDirectoriesListed(true);
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
@@ -65,6 +65,7 @@ public class MockServer {
                 response.setStatus(201);
             }
             response.setHeader("Content-MD5", encodedMD5);
+            LoggerFactory.getLogger(getClass()).info("Finished handling request " + baseRequest.getRequestURL());
         }
     }
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/MockServer.java
@@ -59,7 +59,11 @@ public class MockServer {
 
             byte[] md5Digest = md5.digest();
             String encodedMD5 = Base64.getEncoder().encodeToString(md5Digest);
-            response.setStatus(201);
+            if (request.getMethod().equals("DELETE")) {
+                response.setStatus(202);
+            } else {
+                response.setStatus(201);
+            }
             response.setHeader("Content-MD5", encodedMD5);
         }
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -81,7 +81,7 @@ public class RestProxyStressTests {
 
     @BeforeClass
     public static void setup() {
-//        ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
+        ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
         LoggerFactory.getLogger(RestProxyStressTests.class).info("ResourceLeakDetector level: " + ResourceLeakDetector.getLevel());
 
         HttpHeaders headers = new HttpHeaders()

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyStressTests.java
@@ -345,7 +345,7 @@ public class RestProxyStressTests {
                         assertArrayEquals(md5, receivedMD5);
                         return Completable.complete();
                     });
-                }).flatMapCompletable(Functions.identity(), false, 30).blockingAwait();
+                }).flatMapCompletable(Functions.identity(), false, 15).blockingAwait();
         long durationMilliseconds = Duration.between(start, Instant.now()).toMillis();
         LoggerFactory.getLogger(getClass()).info("Upload took " + durationMilliseconds + " milliseconds.");
     }


### PR DESCRIPTION
Essentially a continuation of #406 

- Adds `finishedWritingRequestBody` flag to determine whether a channel should be closed when a response body is finished reading. This lets us pass `RestProxyStressTests.testHighParallelism` in a reasonable amount of time (~5 seconds) instead of either running for about a minute or just failing due to being unable to open more ports.
  - This perhaps should be changed so that we just close the connection if the request hasn't been fully written at the time we receive the response status/headers.
- Other minor refinements/trimming dead code
- Attempting to make RestProxyStressTests easier to run automatically, with everything able to run against the local test server.
  - Trying to get the test server to spawn automatically with the tests, but it's introducing new hanging issues, so it's probably a stretch goal for another PR.