### PR TITLE
Update dependencies

### DIFF
--- a/client-runtime-native/pom.xml
+++ b/client-runtime-native/pom.xml
@@ -22,6 +22,15 @@
     <properties>
         <netty-boringssl.version>2.0.7.Final</netty-boringssl.version>
     </properties>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
+    </build>
     <profiles>
         <profile>
             <id>boringssl</id>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </scm>
 
   <properties>
-    <netty.version>4.1.21.Final</netty.version>
+    <netty.version>4.1.23.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <legal><![CDATA[[INFO] Any downloads listed may be third party software.  Microsoft grants you no rights for third party software.]]></legal>
   </properties>
@@ -87,7 +87,7 @@
       <dependency>
         <groupId>io.reactivex.rxjava2</groupId>
         <artifactId>rxjava</artifactId>
-        <version>2.1.9</version>
+        <version>2.1.12</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -130,13 +130,6 @@
   </dependencyManagement>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
-      </extension>
-    </extensions>
 
     <plugins>
       <plugin>


### PR DESCRIPTION
- Update RxJava and Netty versions
- Move os-maven-plugin to client-runtime-native module. I think this was causing build-time issues when including client-runtime-native from maven central in other projects. Not totally sure what's going on--might have to eventually remove this module and point people in the README at the native modules we suggest they include instead--particularly the SSL modules which can make a big perf difference without appearing to cause any new issues of their own.