### PR TITLE
Add CountingOperator and tests

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.microsoft.rest.v2.util.FlowableUtil;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.LoggerFactory;
@@ -60,6 +59,8 @@ import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
 import io.reactivex.plugins.RxJavaPlugins;
+
+import static com.microsoft.rest.v2.util.FlowableUtil.ensureLength;
 
 /**
  * An HttpClient that is implemented using Netty.
@@ -301,7 +302,7 @@ public final class NettyClient extends HttpClient {
                     String contentLengthHeader = request.headers().value("content-length");
                     try {
                         long contentLength = Long.parseLong(contentLengthHeader);
-                        request.body().compose(self -> FlowableUtil.ensureLength(self, contentLength)).subscribe(requestSubscriber);
+                        request.body().compose(ensureLength(contentLength)).subscribe(requestSubscriber);
                     } catch (NumberFormatException e) {
                         String message = String.format(
                                 "Content-Length was expected to be a valid long but was \"%s\"", contentLengthHeader);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -301,7 +301,7 @@ public final class NettyClient extends HttpClient {
                     String contentLengthHeader = request.headers().value("content-length");
                     try {
                         long contentLength = Long.parseLong(contentLengthHeader);
-                        request.body().lift(FlowableUtil.countingOperator(contentLength)).subscribe(requestSubscriber);
+                        request.body().compose(self -> FlowableUtil.ensureLength(self, contentLength)).subscribe(requestSubscriber);
                     } catch (NumberFormatException e) {
                         String message = String.format(
                                 "Content-Length was expected to be a valid long but was \"%s\"", contentLengthHeader);

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -13,6 +13,7 @@ import io.netty.buffer.Unpooled;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableSubscriber;
+import io.reactivex.FlowableTransformer;
 import io.reactivex.Single;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.internal.util.BackpressureHelper;
@@ -132,12 +133,11 @@ public final class FlowableUtil {
     /**
      * Ensures the given Flowable emits the expected number of bytes.
      *
-     * @param source the Flowable to check
      * @param bytesExpected the number of bytes expected to be emitted
-     * @return the operator
+     * @return a Function which can be applied using {@link Flowable#compose}
      */
-    public static Flowable<ByteBuffer> ensureLength(Flowable<ByteBuffer> source, long bytesExpected) {
-        return new CountingFlowable(source, bytesExpected);
+    public static FlowableTransformer<ByteBuffer, ByteBuffer> ensureLength(long bytesExpected) {
+        return source -> new CountingFlowable(source, bytesExpected);
     }
 
     /**

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/NettyClientTests.java
@@ -138,6 +138,7 @@ public class NettyClientTests {
     public void testRequestBodyIsErrorShouldPropagateToResponse() {
         HttpClient client = HttpClient.createDefault();
         HttpRequest request = new HttpRequest("", HttpMethod.POST, url(server, "/shortPost"), null) //
+                .withHeader("Content-Length", "123") //
                 .withBody(Flowable.error(new RuntimeException("boo")));
         client.sendRequestAsync(request)
                 .test() //
@@ -149,9 +150,12 @@ public class NettyClientTests {
     @Test
     public void testRequestBodyEndsInErrorShouldPropagateToResponse() {
         HttpClient client = HttpClient.createDefault();
+        String contentChunk = "abcdefgh";
+        int repetitions = 1000;
         HttpRequest request = new HttpRequest("", HttpMethod.POST, url(server, "/shortPost"), null) //
-                .withBody(Flowable.just("abcdefgh") //
-                        .repeat(1000) //
+                .withHeader("Content-Length", String.valueOf(contentChunk.length() * repetitions)) //
+                .withBody(Flowable.just(contentChunk) //
+                        .repeat(repetitions) //
                         .map(NettyClientTests::toByteBuffer) //
                         .concatWith(Flowable.error(new RuntimeException("boo"))));
         client.sendRequestAsync(request)

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -1,5 +1,6 @@
 package com.microsoft.rest.v2.util;
 
+import static com.microsoft.rest.v2.util.FlowableUtil.ensureLength;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -29,7 +30,7 @@ public class FlowableUtilTests {
     @Test
     public void testCountingNotEnoughBytesEmitsError() {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4));
-        content.compose(self -> FlowableUtil.ensureLength(self, 8))
+        content.compose(ensureLength(8))
                 .test()
                 .assertError(IllegalArgumentException.class);
     }
@@ -37,7 +38,7 @@ public class FlowableUtilTests {
     @Test
     public void testCountingTooManyBytesEmitsError() {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4));
-        content.compose(self -> FlowableUtil.ensureLength(self, 1))
+        content.compose(ensureLength(1))
                 .test()
                 .assertError(IllegalArgumentException.class);
     }
@@ -46,7 +47,7 @@ public class FlowableUtilTests {
     @Test
     public void testCountingTooManyBytesCancelsSubscription() {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4)).concatWith(Flowable.never());
-        content.compose(self -> FlowableUtil.ensureLength(self, 1))
+        content.compose(ensureLength(1))
                 .test()
                 .awaitDone(1, TimeUnit.SECONDS)
                 .assertError(IllegalArgumentException.class);
@@ -55,7 +56,7 @@ public class FlowableUtilTests {
     @Test
     public void testCountingExpectedNumberOfBytesSucceeds() {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4));
-        content.compose(self -> FlowableUtil.ensureLength(self, 4))
+        content.compose(ensureLength(4))
                 .test()
                 .assertComplete();
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -29,7 +29,7 @@ public class FlowableUtilTests {
     @Test
     public void testCountingNotEnoughBytesEmitsError() {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4));
-        content.lift(FlowableUtil.countingOperator(8))
+        content.compose(self -> FlowableUtil.ensureLength(self, 8))
                 .test()
                 .assertError(IllegalArgumentException.class);
     }
@@ -37,7 +37,7 @@ public class FlowableUtilTests {
     @Test
     public void testCountingTooManyBytesEmitsError() {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4));
-        content.lift(FlowableUtil.countingOperator(1))
+        content.compose(self -> FlowableUtil.ensureLength(self, 1))
                 .test()
                 .assertError(IllegalArgumentException.class);
     }
@@ -46,7 +46,7 @@ public class FlowableUtilTests {
     @Test
     public void testCountingTooManyBytesCancelsSubscription() {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4)).concatWith(Flowable.never());
-        content.lift(FlowableUtil.countingOperator(1))
+        content.compose(self -> FlowableUtil.ensureLength(self, 1))
                 .test()
                 .awaitDone(1, TimeUnit.SECONDS)
                 .assertError(IllegalArgumentException.class);
@@ -55,7 +55,7 @@ public class FlowableUtilTests {
     @Test
     public void testCountingExpectedNumberOfBytesSucceeds() {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4));
-        content.lift(FlowableUtil.countingOperator(4))
+        content.compose(self -> FlowableUtil.ensureLength(self, 4))
                 .test()
                 .assertComplete();
     }


### PR DESCRIPTION
Based on a request from Storage that cases where we accidentally provide the wrong Content-Length should result in an error, not in a hang or in the HTTP request completing without sending all the bytes in the stream.

Fixes #395