### PR TITLE
Add additionalInfo to CloudError

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/CloudError.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/CloudError.java
@@ -9,6 +9,9 @@ package com.microsoft.azure;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.microsoft.azure.serializer.TypedErrorInfoDeserializer;
+
 /**
  * An instance of this class provides additional information about an http error response.
  */
@@ -32,6 +35,12 @@ public final class CloudError {
      * Details for the error.
      */
     private List<CloudError> details;
+    
+    /**
+     * Additional error information
+     */
+    @JsonDeserialize(contentUsing = TypedErrorInfoDeserializer.class)
+    private List<TypedErrorInfo> additionalInfo;
 
     /**
      * Initializes a new instance of CloudError.
@@ -99,5 +108,12 @@ public final class CloudError {
      */
     public List<CloudError> details() {
         return details;
+    }
+    
+    /**
+     * @return the additional error information
+     */
+    public List<TypedErrorInfo> additionalInfo() {
+        return additionalInfo;
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/CloudError.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/CloudError.java
@@ -37,7 +37,7 @@ public final class CloudError {
     private List<CloudError> details;
     
     /**
-     * Additional error information
+     * Additional error information.
      */
     @JsonDeserialize(contentUsing = TypedErrorInfoDeserializer.class)
     private List<TypedErrorInfo> additionalInfo;

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolation.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolation.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.azure.PolicyViolationErrorInfo;
+
+/**
+ * An instance of this class provides Azure policy violation information.
+ */
+public class PolicyViolation extends TypedErrorInfo {
+	/**
+	 * Policy violation error details.
+	 */
+	private PolicyViolationErrorInfo policyErrorInfo;
+	
+	/**
+	 * Initializes a new instance of PolicyViolation.
+	 * @param type the error type
+	 * @param policyErrorInfo the error details
+	 */
+	public PolicyViolation(String type, ObjectNode policyErrorInfo) throws JsonParseException, JsonMappingException, IOException {
+		super(type, policyErrorInfo);
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+		this.policyErrorInfo = objectMapper.readValue(policyErrorInfo.toString(), PolicyViolationErrorInfo.class);
+	}
+	
+	/**
+	 * @return the policy violation error details.
+	 */
+	public PolicyViolationErrorInfo policyErrorInfo() {
+		return policyErrorInfo;
+	}
+}

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolation.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolation.java
@@ -13,33 +13,35 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.microsoft.azure.PolicyViolationErrorInfo;
 
 /**
  * An instance of this class provides Azure policy violation information.
  */
 public class PolicyViolation extends TypedErrorInfo {
-	/**
-	 * Policy violation error details.
-	 */
-	private PolicyViolationErrorInfo policyErrorInfo;
-	
-	/**
-	 * Initializes a new instance of PolicyViolation.
-	 * @param type the error type
-	 * @param policyErrorInfo the error details
-	 */
-	public PolicyViolation(String type, ObjectNode policyErrorInfo) throws JsonParseException, JsonMappingException, IOException {
-		super(type, policyErrorInfo);
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
-		this.policyErrorInfo = objectMapper.readValue(policyErrorInfo.toString(), PolicyViolationErrorInfo.class);
-	}
-	
-	/**
-	 * @return the policy violation error details.
-	 */
-	public PolicyViolationErrorInfo policyErrorInfo() {
-		return policyErrorInfo;
-	}
+    /**
+     * Policy violation error details.
+     */
+    private PolicyViolationErrorInfo policyErrorInfo;
+    
+    /**
+     * Initializes a new instance of PolicyViolation.
+     * @param type the error type
+     * @param policyErrorInfo the error details
+     * @throws JsonParseException
+     * @throws JsonMappingException
+     * @throws IOException
+     */
+    public PolicyViolation(String type, ObjectNode policyErrorInfo) throws JsonParseException, JsonMappingException, IOException {
+        super(type, policyErrorInfo);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+        this.policyErrorInfo = objectMapper.readValue(policyErrorInfo.toString(), PolicyViolationErrorInfo.class);
+    }
+    
+    /**
+     * @return the policy violation error details.
+     */
+    public PolicyViolationErrorInfo policyErrorInfo() {
+        return policyErrorInfo;
+    }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolation.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolation.java
@@ -27,9 +27,9 @@ public class PolicyViolation extends TypedErrorInfo {
      * Initializes a new instance of PolicyViolation.
      * @param type the error type
      * @param policyErrorInfo the error details
-     * @throws JsonParseException
-     * @throws JsonMappingException
-     * @throws IOException
+     * @throws JsonParseException if the policyErrorInfo has invalid content.
+     * @throws JsonMappingException if the policyErrorInfo's JSON does not match the expected schema. 
+     * @throws IOException if an IO error occurs.
      */
     public PolicyViolation(String type, ObjectNode policyErrorInfo) throws JsonParseException, JsonMappingException, IOException {
         super(type, policyErrorInfo);

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolationErrorInfo.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolationErrorInfo.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure;
+
+import java.util.HashMap;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * An instance of this class provides Azure policy violation information.
+ */
+public class PolicyViolationErrorInfo {
+	/**
+	 * The policy definition id.
+	 */
+    private String policyDefinitionId;
+
+    /**
+     * The policy set definition id.
+     */
+    private String policySetDefinitionId;
+
+    /**
+     * The policy definition instance id inside a policy set.
+     */
+    private String policyDefinitionReferenceId;
+
+    /**
+     * The policy set definition name.
+     */
+    private String policySetDefinitionName;
+
+    /**
+     * The policy definition name.
+     */
+    private String policyDefinitionName;
+
+    /**
+     * The policy definition action.
+     */
+    private String policyDefinitionEffect;
+
+    /**
+     * The policy assignment id.
+     */
+    private String policyAssignmentId;
+
+    /**
+     * The policy assignment name.
+     */
+    private String policyAssignmentName;
+
+    /**
+     * The policy assignment display name.
+     */
+    private String policyAssignmentDisplayName;
+
+    /**
+     * The policy assignment scope.
+     */
+    private String policyAssignmentScope;
+
+    /**
+     * The policy assignment parameters.
+     */
+    private HashMap<String, PolicyParameter> policyAssignmentParameters;
+
+    /**
+     * The policy definition display name.
+     */
+    private String policyDefinitionDisplayName;
+
+    /**
+     * The policy set definition display name.
+     */
+    private String policySetDefinitionDisplayName;
+	
+    /**
+     * @return the policy definition id.
+     */
+    public String getPolicyDefinitionId() {
+    	return policyDefinitionId;
+    }
+
+    /**
+     * @return the policy set definition id.
+     */
+    public String getPolicySetDefinitionId() {
+    	return policySetDefinitionId;
+    }
+
+    /**
+     * @return the policy definition instance id inside a policy set.
+     */
+    public String getPolicyDefinitionReferenceId() {
+    	return policyDefinitionReferenceId;
+    }
+
+    /**
+     * @return the policy set definition name.
+     */
+    public String getPolicySetDefinitionName() {
+    	return policySetDefinitionName;
+    }
+
+    /**
+     * @return the policy definition name.
+     */
+    public String getPolicyDefinitionName() {
+    	return policyDefinitionName;
+    }
+
+    /**
+     * @return the policy definition action.
+     */
+    public String getPolicyDefinitionEffect() {
+    	return policyDefinitionEffect;
+    }
+
+    /**
+     * @return the policy assignment id.
+     */
+    public String getPolicyAssignmentId() {
+    	return policyAssignmentId;
+    }
+
+    /**
+     * @return the policy assignment name.
+     */
+    public String getPolicyAssignmentName() {
+    	return policyAssignmentName;
+    }
+
+    /**
+     * @return the policy assignment display name.
+     */
+    public String getPolicyAssignmentDisplayName() {
+    	return policyAssignmentDisplayName;
+    }
+
+    /**
+     * @return the policy assignment scope.
+     */
+    public String getPolicyAssignmentScope() {
+    	return policyAssignmentScope;
+    }
+
+    /**
+     * @return the policy assignment parameters.
+     */
+    public HashMap<String, PolicyParameter> getPolicyAssignmentParameters() {
+    	return policyAssignmentParameters;
+    }
+
+    /**
+     * @return the policy definition display name.
+     */
+    public String getPolicyDefinitionDisplayName() {
+    	return policyDefinitionDisplayName;
+    }
+
+    /**
+     * @return the policy set definition display name.
+     */
+    public String getPolicySetDefinitionDisplayName() {
+    	return policySetDefinitionDisplayName;
+    }
+
+    /**
+     * An instance of this class provides policy parameter value.
+     */
+    public static class PolicyParameter {
+    	private JsonNode value;
+    	
+    	public JsonNode getValue() {
+    		return value;
+    	}
+    }
+}

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolationErrorInfo.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/PolicyViolationErrorInfo.java
@@ -14,9 +14,9 @@ import com.fasterxml.jackson.databind.JsonNode;
  * An instance of this class provides Azure policy violation information.
  */
 public class PolicyViolationErrorInfo {
-	/**
-	 * The policy definition id.
-	 */
+    /**
+     * The policy definition id.
+     */
     private String policyDefinitionId;
 
     /**
@@ -78,106 +78,109 @@ public class PolicyViolationErrorInfo {
      * The policy set definition display name.
      */
     private String policySetDefinitionDisplayName;
-	
+    
     /**
      * @return the policy definition id.
      */
     public String getPolicyDefinitionId() {
-    	return policyDefinitionId;
+        return policyDefinitionId;
     }
 
     /**
      * @return the policy set definition id.
      */
     public String getPolicySetDefinitionId() {
-    	return policySetDefinitionId;
+        return policySetDefinitionId;
     }
 
     /**
      * @return the policy definition instance id inside a policy set.
      */
     public String getPolicyDefinitionReferenceId() {
-    	return policyDefinitionReferenceId;
+        return policyDefinitionReferenceId;
     }
 
     /**
      * @return the policy set definition name.
      */
     public String getPolicySetDefinitionName() {
-    	return policySetDefinitionName;
+        return policySetDefinitionName;
     }
 
     /**
      * @return the policy definition name.
      */
     public String getPolicyDefinitionName() {
-    	return policyDefinitionName;
+        return policyDefinitionName;
     }
 
     /**
      * @return the policy definition action.
      */
     public String getPolicyDefinitionEffect() {
-    	return policyDefinitionEffect;
+        return policyDefinitionEffect;
     }
 
     /**
      * @return the policy assignment id.
      */
     public String getPolicyAssignmentId() {
-    	return policyAssignmentId;
+        return policyAssignmentId;
     }
 
     /**
      * @return the policy assignment name.
      */
     public String getPolicyAssignmentName() {
-    	return policyAssignmentName;
+        return policyAssignmentName;
     }
 
     /**
      * @return the policy assignment display name.
      */
     public String getPolicyAssignmentDisplayName() {
-    	return policyAssignmentDisplayName;
+        return policyAssignmentDisplayName;
     }
 
     /**
      * @return the policy assignment scope.
      */
     public String getPolicyAssignmentScope() {
-    	return policyAssignmentScope;
+        return policyAssignmentScope;
     }
 
     /**
      * @return the policy assignment parameters.
      */
     public HashMap<String, PolicyParameter> getPolicyAssignmentParameters() {
-    	return policyAssignmentParameters;
+        return policyAssignmentParameters;
     }
 
     /**
      * @return the policy definition display name.
      */
     public String getPolicyDefinitionDisplayName() {
-    	return policyDefinitionDisplayName;
+        return policyDefinitionDisplayName;
     }
 
     /**
      * @return the policy set definition display name.
      */
     public String getPolicySetDefinitionDisplayName() {
-    	return policySetDefinitionDisplayName;
+        return policySetDefinitionDisplayName;
     }
 
     /**
      * An instance of this class provides policy parameter value.
      */
     public static class PolicyParameter {
-    	private JsonNode value;
-    	
-    	public JsonNode getValue() {
-    		return value;
-    	}
+        private JsonNode value;
+        
+        /**
+         * @return the parameter value.
+         */
+        public JsonNode getValue() {
+            return value;
+        }
     }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/TypedErrorInfo.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/TypedErrorInfo.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * An instance of this class provides Azure error type and information.
+ */
+public class TypedErrorInfo {
+	/**
+	 * The error type.
+	 */
+	private String type;
+	
+	/**
+	 * The error information.
+	 */
+	private ObjectNode info;
+	
+	/**
+	 * Initializes a new instance of TypedErrorInfo.
+	 * @param type the error type.
+	 * @param info the error information.
+	 */
+	public TypedErrorInfo(String type, ObjectNode info) {
+		this.type = type;
+		this.info = info;
+	}
+	
+	/**
+	 * @return the error type.
+	 */
+	public String type() {
+		return type;
+	}
+	
+	/**
+	 * @return the error information.
+	 */
+	public ObjectNode info() {
+		return info;
+	}
+}

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/TypedErrorInfo.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/TypedErrorInfo.java
@@ -12,37 +12,37 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * An instance of this class provides Azure error type and information.
  */
 public class TypedErrorInfo {
-	/**
-	 * The error type.
-	 */
-	private String type;
-	
-	/**
-	 * The error information.
-	 */
-	private ObjectNode info;
-	
-	/**
-	 * Initializes a new instance of TypedErrorInfo.
-	 * @param type the error type.
-	 * @param info the error information.
-	 */
-	public TypedErrorInfo(String type, ObjectNode info) {
-		this.type = type;
-		this.info = info;
-	}
-	
-	/**
-	 * @return the error type.
-	 */
-	public String type() {
-		return type;
-	}
-	
-	/**
-	 * @return the error information.
-	 */
-	public ObjectNode info() {
-		return info;
-	}
+    /**
+     * The error type.
+     */
+    private String type;
+    
+    /**
+     * The error information.
+     */
+    private ObjectNode info;
+    
+    /**
+     * Initializes a new instance of TypedErrorInfo.
+     * @param type the error type.
+     * @param info the error information.
+     */
+    public TypedErrorInfo(String type, ObjectNode info) {
+        this.type = type;
+        this.info = info;
+    }
+    
+    /**
+     * @return the error type.
+     */
+    public String type() {
+        return type;
+    }
+    
+    /**
+     * @return the error information.
+     */
+    public ObjectNode info() {
+        return info;
+    }
 }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.microsoft.azure.CloudError;
@@ -30,6 +31,7 @@ final class CloudErrorDeserializer extends JsonDeserializer<CloudError> {
      * @param mapper the object mapper for default deserializations.
      */
     private CloudErrorDeserializer(ObjectMapper mapper) {
+    	mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
         this.mapper = mapper;
     }
 
@@ -55,12 +57,8 @@ final class CloudErrorDeserializer extends JsonDeserializer<CloudError> {
         if (errorNode.get("error") != null) {
             errorNode = errorNode.get("error");
         }
-        String nodeContent = errorNode.toString();
-        nodeContent = nodeContent.replaceFirst("(?i)\"code\"", "\"code\"")
-                .replaceFirst("(?i)\"message\"", "\"message\"")
-                .replaceFirst("(?i)\"target\"", "\"target\"")
-                .replaceFirst("(?i)\"details\"", "\"details\"");
-        JsonParser parser = new JsonFactory().createParser(nodeContent);
+        
+        JsonParser parser = new JsonFactory().createParser(errorNode.toString());
         parser.setCodec(mapper);
         return parser.readValueAs(CloudError.class);
     }

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/CloudErrorDeserializer.java
@@ -31,7 +31,7 @@ final class CloudErrorDeserializer extends JsonDeserializer<CloudError> {
      * @param mapper the object mapper for default deserializations.
      */
     private CloudErrorDeserializer(ObjectMapper mapper) {
-    	mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+        mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
         this.mapper = mapper;
     }
 

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/TypedErrorInfoDeserializer.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/serializer/TypedErrorInfoDeserializer.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.microsoft.azure.CloudError;
 import com.microsoft.azure.PolicyViolation;
 import com.microsoft.azure.TypedErrorInfo;
 
@@ -23,47 +22,46 @@ import com.microsoft.azure.TypedErrorInfo;
  * Custom serializer for serializing {@link TypedErrorInfo} objects.
  */
 public class TypedErrorInfoDeserializer extends JsonDeserializer<TypedErrorInfo> {
-	private static final String TypeFieldName = "type";
-	
-	private static final String InfoFieldName = "info";
-	
-	@Override
-	public TypedErrorInfo deserialize(JsonParser p, DeserializationContext ctxt)
-			throws IOException, JsonProcessingException {
-		JsonNode errorInfoNode = p.readValueAsTree();
-		if (errorInfoNode == null) {
-			return null;
-	    }
-		
-		JsonNode typeNode = errorInfoNode.get(TypeFieldName);
-		JsonNode infoNode = errorInfoNode.get(InfoFieldName);
-		if (typeNode == null || infoNode == null) {
-			Iterator<String> fieldNames = errorInfoNode.fieldNames();
-			while (fieldNames.hasNext()) {
-				String fieldName = fieldNames.next();
-				if (typeNode == null && TypeFieldName.equalsIgnoreCase(fieldName)) {
-					typeNode = errorInfoNode.get(fieldName);
-					
-				}
-				
-				if (infoNode == null && InfoFieldName.equalsIgnoreCase(fieldName)) {
-					infoNode = errorInfoNode.get(fieldName);
-					
-				}
-			}	
-		}
-		
-		if (typeNode == null || infoNode == null || infoNode instanceof ObjectNode == false) {
-			return null;
-		}
-		
-		// deserialize to any strongly typed error defined
-		switch (typeNode.asText()) {
-			case "PolicyViolation":
-				return new PolicyViolation(typeNode.asText(), (ObjectNode)infoNode);
-				
-			default:
-				return new TypedErrorInfo(typeNode.asText(), (ObjectNode)infoNode);
-		}
-	}
+    private static final String TYPE_FIELD_NAME = "type";
+    private static final String INFO_FIELD_NAME = "info";
+    
+    @Override
+    public TypedErrorInfo deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        JsonNode errorInfoNode = p.readValueAsTree();
+        if (errorInfoNode == null) {
+            return null;
+        }
+        
+        JsonNode typeNode = errorInfoNode.get(TYPE_FIELD_NAME);
+        JsonNode infoNode = errorInfoNode.get(INFO_FIELD_NAME);
+        if (typeNode == null || infoNode == null) {
+            Iterator<String> fieldNames = errorInfoNode.fieldNames();
+            while (fieldNames.hasNext()) {
+                String fieldName = fieldNames.next();
+                if (typeNode == null && TYPE_FIELD_NAME.equalsIgnoreCase(fieldName)) {
+                    typeNode = errorInfoNode.get(fieldName);
+                    
+                }
+                
+                if (infoNode == null && INFO_FIELD_NAME.equalsIgnoreCase(fieldName)) {
+                    infoNode = errorInfoNode.get(fieldName);
+                    
+                }
+            }    
+        }
+        
+        if (typeNode == null || infoNode == null || !(infoNode instanceof ObjectNode)) {
+            return null;
+        }
+        
+        // deserialize to any strongly typed error defined
+        switch (typeNode.asText()) {
+            case "PolicyViolation":
+                return new PolicyViolation(typeNode.asText(), (ObjectNode) infoNode);
+                
+            default:
+                return new TypedErrorInfo(typeNode.asText(), (ObjectNode) infoNode);
+        }
+    }
 }

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/CloudErrorDeserializerTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/CloudErrorDeserializerTests.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.serializer.AzureJacksonAdapter;
+import com.microsoft.rest.protocol.SerializerAdapter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CloudErrorDeserializerTests {
+    @Test
+    public void cloudErrorDeserialization() throws Exception {
+        SerializerAdapter<ObjectMapper> serializerAdapter = new AzureJacksonAdapter();
+        String bodyString =
+            "{" +
+            "    \"error\": {" +
+            "        \"code\": \"BadArgument\"," +
+            "        \"message\": \"The provided database ‘foo’ has an invalid username.\"," +
+            "        \"target\": \"query\"," +
+            "        \"details\": [" +
+            "            {" +
+            "                \"code\": \"301\"," +
+            "                \"target\": \"$search\"," +
+            "                \"message\": \"$search query option not supported\"" +
+            "            }" +
+            "        ]," +
+            "        \"additionalInfo\": [" +
+            "            {" +
+            "                \"type\": \"SomeErrorType\"," +
+            "                \"info\": {" +
+            "                    \"someProperty\": \"SomeValue\"" +
+            "                }" +
+            "            }" +
+            "        ]" +
+            "    }" +
+            "}";
+        
+        CloudError cloudError = serializerAdapter.deserialize(bodyString, CloudError.class);
+
+        Assert.assertEquals("BadArgument", cloudError.code());
+        Assert.assertEquals("The provided database ‘foo’ has an invalid username.", cloudError.message());
+        Assert.assertEquals("query", cloudError.target());
+        Assert.assertEquals(1, cloudError.details().size());
+        Assert.assertEquals("301", cloudError.details().get(0).code());
+        Assert.assertEquals(1, cloudError.additionalInfo().size());
+        Assert.assertEquals("SomeErrorType", cloudError.additionalInfo().get(0).type());
+        Assert.assertEquals("SomeValue", cloudError.additionalInfo().get(0).info().get("someProperty").asText());
+    }
+    
+    @Test
+    public void cloudErrorWithPolicyViolationDeserialization() throws Exception {
+        SerializerAdapter<ObjectMapper> serializerAdapter = new AzureJacksonAdapter();
+        String bodyString =
+            "{" +
+            "    \"error\": {" +
+            "        \"code\": \"BadArgument\"," +
+            "        \"message\": \"The provided database ‘foo’ has an invalid username.\"," +
+            "        \"target\": \"query\"," +
+            "        \"details\": [" +
+            "        {" +
+            "            \"code\": \"301\"," +
+            "            \"target\": \"$search\"," +
+            "            \"message\": \"$search query option not supported\"," +
+            "            \"additionalInfo\": [" +
+            "            {" +
+            "                \"type\": \"PolicyViolation\"," +
+            "                \"info\": {" +
+            "                    \"policyDefinitionDisplayName\": \"Allowed locations\"," +
+            "                    \"policyDefinitionId\": \"testDefinitionId\"," +
+            "                    \"policyDefinitionName\": \"testDefinitionName\"," +
+            "                    \"policyDefinitionEffect\": \"deny\"," +
+            "                    \"policyAssignmentId\": \"testAssignmentId\"," +
+            "                    \"policyAssignmentName\": \"testAssignmentName\"," +
+            "                    \"policyAssignmentDisplayName\": \"test assignment\"," +
+            "                    \"policyAssignmentScope\": \"/subscriptions/testSubId/resourceGroups/jilimpolicytest2\"," +
+            "                    \"policyAssignmentParameters\": {" +
+            "                        \"listOfAllowedLocations\": {" +
+            "                            \"value\": [" +
+            "                                \"westus\"" +
+            "                	         ]" +
+            "                    	 }" +
+            "                    }" +            
+            "                }" +
+            "            }" +
+            "            ]" +
+            "        }" +
+            "        ]," +
+            "        \"additionalInfo\": [" +
+            "            {" +
+            "                \"type\": \"SomeErrorType\"," +
+            "                \"info\": {" +
+            "                    \"someProperty\": \"SomeValue\"" +
+            "                }" +
+            "            }" +
+            "        ]" +
+            "    }" +
+            "}";
+        
+        CloudError cloudError = serializerAdapter.deserialize(bodyString, CloudError.class);
+
+        Assert.assertEquals("BadArgument", cloudError.code());
+        Assert.assertEquals("The provided database ‘foo’ has an invalid username.", cloudError.message());
+        Assert.assertEquals("query", cloudError.target());
+        Assert.assertEquals(1, cloudError.details().size());
+        Assert.assertEquals("301", cloudError.details().get(0).code());
+        Assert.assertEquals(1, cloudError.additionalInfo().size());
+        Assert.assertEquals("SomeErrorType", cloudError.additionalInfo().get(0).type());
+        Assert.assertEquals("SomeValue", cloudError.additionalInfo().get(0).info().get("someProperty").asText());
+        Assert.assertEquals(1, cloudError.details().get(0).additionalInfo().size());
+        Assert.assertTrue(cloudError.details().get(0).additionalInfo().get(0) instanceof PolicyViolation);
+        
+        PolicyViolation policyViolation = (PolicyViolation)cloudError.details().get(0).additionalInfo().get(0);
+        
+        Assert.assertEquals("PolicyViolation", policyViolation.type());
+        Assert.assertEquals("Allowed locations", policyViolation.policyErrorInfo().getPolicyDefinitionDisplayName());
+        Assert.assertEquals("westus", policyViolation.policyErrorInfo().getPolicyAssignmentParameters().get("listOfAllowedLocations").getValue().elements().next().asText());
+    }
+    
+    @Test
+    public void cloudErrorWitDifferentCasing() throws Exception {
+        SerializerAdapter<ObjectMapper> serializerAdapter = new AzureJacksonAdapter();
+        String bodyString =
+            "{" +
+            "    \"error\": {" +
+            "        \"Code\": \"BadArgument\"," +
+            "        \"Message\": \"The provided database ‘foo’ has an invalid username.\"," +
+            "        \"Target\": \"query\"," +
+            "        \"Details\": [" +
+            "        {" +
+            "            \"Code\": \"301\"," +
+            "            \"Target\": \"$search\"," +
+            "            \"Message\": \"$search query option not supported\"," +
+            "            \"AdditionalInfo\": [" +
+            "            {" +
+            "                \"Type\": \"PolicyViolation\"," +
+            "                \"Info\": {" +
+            "                    \"PolicyDefinitionDisplayName\": \"Allowed locations\"," +
+            "                    \"PolicyAssignmentParameters\": {" +
+            "                        \"listOfAllowedLocations\": {" +
+            "                            \"Value\": [" +
+            "                                \"westus\"" +
+            "                	         ]" +
+            "                    	 }" +
+            "                    }" +            
+            "                }" +
+            "            }" +
+            "            ]" +
+            "        }" +
+            "        ]" +
+            "    }" +
+            "}";
+        
+        CloudError cloudError = serializerAdapter.deserialize(bodyString, CloudError.class);
+
+        Assert.assertEquals("BadArgument", cloudError.code());
+        Assert.assertEquals("The provided database ‘foo’ has an invalid username.", cloudError.message());
+        Assert.assertEquals("query", cloudError.target());
+        Assert.assertEquals(1, cloudError.details().size());
+        Assert.assertEquals("301", cloudError.details().get(0).code());
+        Assert.assertEquals(1, cloudError.details().get(0).additionalInfo().size());
+        Assert.assertTrue(cloudError.details().get(0).additionalInfo().get(0) instanceof PolicyViolation);
+        
+        PolicyViolation policyViolation = (PolicyViolation)cloudError.details().get(0).additionalInfo().get(0);
+        
+        Assert.assertEquals("PolicyViolation", policyViolation.type());
+        Assert.assertEquals("Allowed locations", policyViolation.policyErrorInfo().getPolicyDefinitionDisplayName());
+        Assert.assertEquals("westus", policyViolation.policyErrorInfo().getPolicyAssignmentParameters().get("listOfAllowedLocations").getValue().elements().next().asText());
+    }
+}


### PR DESCRIPTION
'additionalInfo', a new property added to ARM error contract, contains additional error information. For example, it will contain detailed policy violation error information when the request to ARM failed due to violation of Azure policies.

The changes are to allow deserializing additionalInfo in ARM error based on the error type.