### PR TITLE
Ensure map key with dot is getting serialized correctly

### DIFF
--- a/client-runtime/src/test/java/com/microsoft/rest/FlatteningSerializerTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/FlatteningSerializerTests.java
@@ -31,9 +31,11 @@ public class FlatteningSerializerTests {
         foo.qux = new HashMap<>();
         foo.qux.put("hello", "world");
         foo.qux.put("a.b", "c.d");
+        foo.qux.put("bar.a", "ttyy");
+        foo.qux.put("bar.b", "uuzz");
 
         String serialized = new JacksonAdapter().serialize(foo);
-        Assert.assertEquals("{\"$type\":\"foo\",\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"a.b\":\"c.d\",\"hello\":\"world\"}}}}}", serialized);
+        Assert.assertEquals("{\"$type\":\"foo\",\"properties\":{\"bar\":\"hello.world\",\"props\":{\"baz\":[\"hello\",\"hello.world\"],\"q\":{\"qux\":{\"hello\":\"world\",\"a.b\":\"c.d\",\"bar.b\":\"uuzz\",\"bar.a\":\"ttyy\"}}}}}", serialized);
     }
 
     @JsonFlatten
@@ -57,5 +59,72 @@ public class FlatteningSerializerTests {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "$type")
     @JsonTypeName("foochild")
     private class FooChild extends Foo {
+    }
+
+    @Test
+    public void canSerializeMapKeysWithDotAndSlash() throws Exception {
+        String serialized = new JacksonAdapter().serialize(prepareSchoolModel());
+        Assert.assertEquals("{\"teacher\":{\"students\":{\"af.B/D\":{},\"af.B/C\":{}}},\"tags\":{\"foo.aa\":\"bar\",\"x.y\":\"zz\"},\"properties\":{\"name\":\"school1\"}}", serialized);
+    }
+
+    @JsonFlatten
+    private class School {
+        @JsonProperty(value = "teacher")
+        private Teacher teacher;
+
+        @JsonProperty(value = "properties.name")
+        private String name;
+
+        @JsonProperty(value = "tags")
+        private Map<String, String> tags;
+
+        public School withTeacher(Teacher teacher) {
+            this.teacher = teacher;
+            return this;
+        }
+
+        public School withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public School withTags(Map<String, String> tags) {
+            this.tags = tags;
+            return this;
+        }
+    }
+
+    private class Student {
+    }
+
+    private class Teacher {
+        @JsonProperty(value = "students")
+        private Map<String, Student> students;
+
+        public Teacher withStudents(Map<String, Student> students) {
+            this.students = students;
+            return this;
+        }
+    }
+
+    private School prepareSchoolModel() {
+        Teacher teacher = new Teacher();
+
+        Map<String, Student> students = new HashMap<String, Student>();
+        students.put("af.B/C", new Student());
+        students.put("af.B/D", new Student());
+
+        teacher.withStudents(students);
+
+        School school = new School().withName("school1");
+        school.withTeacher(teacher);
+
+        Map<String, String> schoolTags = new HashMap<String, String>();
+        schoolTags.put("foo.aa", "bar");
+        schoolTags.put("x.y", "zz");
+
+        school.withTags(schoolTags);
+
+        return school;
     }
 }


### PR DESCRIPTION
Repro --

```java
@JsonFlatten
public class School {
    @JsonProperty(value = "teacher")
    private Teacher teacher;

    public School withTeacher(Teacher teacher) {
        this.teacher = teacher;
        return this;
    }
}
```

```java
public class Teacher {
    @JsonProperty(value = "students")
    private Map<String, Student> students;

    public Teacher withStudents(Map<String, Student> students) {
        this.students = students;
        return this;
    }
}
```

```java
public class Student {
}
```

```java
    public static void main( String[] args ) throws IOException {

        Teacher teacher = new Teacher();


        Map<String, Student> students = new HashMap<String, Student>();
        students.put("af.B/C", new Student());
        students.put("af.B/D", new Student());

        teacher.withStudents(students);

        School inr = new School();
        inr.withTeacher(teacher);

        String serialized = new AzureJacksonAdapter().serialize(inr);
        System.out.println(serialized);
    }
```

output

```json
{"teacher":{"students":{"af":{"B/C":{},"B/D":{}}}}}
```

expected output

```json
{"teacher":{"students":{"af.B/C":{}}, {"af.B/D":{}}}}
```