### PR TITLE
Update Netty and break apart large buffers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </scm>
 
   <properties>
-    <netty.version>4.1.25.Final</netty.version>
+    <netty.version>4.1.27.Final</netty.version>
     <jackson.version>2.8.11</jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <legal><![CDATA[[INFO] Any downloads listed may be third party software.  Microsoft grants you no rights for third party software.]]></legal>


### PR DESCRIPTION
- Update Netty version
- Use .split() to ensure we don't attempt to encode an excessively large buffer with SSL before sending
  - This magic number 8192 can be adjusted-- maybe 1024*64 is better?