### PR TITLE
Add UnexpectedLengthException

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/UnexpectedLengthException.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/UnexpectedLengthException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.rest.v2.http;
+
+/**
+ * Indicates that a stream emitted an unexpected number of bytes.
+ */
+public class UnexpectedLengthException extends IllegalStateException {
+    private final long bytesRead;
+    private final long bytesExpected;
+
+    /**
+     * Creates an UnexpectedLengthException.
+     * @param message the message
+     * @param bytesRead the number of bytes actually read in the stream
+     * @param bytesExpected the number of bytes expected to be read in the stream
+     */
+    public UnexpectedLengthException(String message, long bytesRead, long bytesExpected) {
+        super(message);
+        this.bytesRead = bytesRead;
+        this.bytesExpected = bytesExpected;
+    }
+
+    /**
+     * @return the number of bytes actually read in the stream
+     */
+    public long bytesRead() {
+        return bytesRead;
+    }
+
+    /**
+     * @return the number of bytes expected to be read in the stream
+     */
+    public long bytesExpected() {
+        return bytesExpected;
+    }
+}

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/util/FlowableUtil.java
@@ -8,6 +8,7 @@ package com.microsoft.rest.v2.util;
 
 import com.google.common.reflect.TypeToken;
 
+import com.microsoft.rest.v2.http.UnexpectedLengthException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.reactivex.Completable;
@@ -89,14 +90,19 @@ public final class FlowableUtil {
                 return source.doOnNext(bb -> {
                     bytesRead += bb.remaining();
                     if (bytesRead > bytesExpected) {
-                        throw new IllegalArgumentException("Flowable<ByteBuffer> emitted more bytes than the expected " + bytesExpected);
+                        throw new UnexpectedLengthException(
+                                "Flowable<ByteBuffer> emitted more bytes than the expected " + bytesExpected,
+                                bytesRead,
+                                bytesExpected);
                     }
                 }).doOnComplete(() -> {
                     if (bytesRead != bytesExpected) {
-                        throw new IllegalArgumentException(
+                        throw new UnexpectedLengthException(
                                 String.format("Flowable<ByteBuffer> emitted %d bytes instead of the expected %d bytes.",
                                         bytesRead,
-                                        bytesExpected));
+                                        bytesExpected),
+                                bytesRead,
+                                bytesExpected);
                     }
                 });
             }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -19,6 +19,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
 
+import com.microsoft.rest.v2.http.UnexpectedLengthException;
 import io.reactivex.Flowable;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class FlowableUtilTests {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4));
         content.compose(ensureLength(8))
                 .test()
-                .assertError(IllegalArgumentException.class);
+                .assertError(UnexpectedLengthException.class);
     }
 
     @Test
@@ -40,7 +41,7 @@ public class FlowableUtilTests {
         Flowable<ByteBuffer> content = Flowable.just(ByteBuffer.allocate(4));
         content.compose(ensureLength(1))
                 .test()
-                .assertError(IllegalArgumentException.class);
+                .assertError(UnexpectedLengthException.class);
     }
 
 
@@ -50,7 +51,7 @@ public class FlowableUtilTests {
         content.compose(ensureLength(1))
                 .test()
                 .awaitDone(1, TimeUnit.SECONDS)
-                .assertError(IllegalArgumentException.class);
+                .assertError(UnexpectedLengthException.class);
     }
 
     @Test


### PR DESCRIPTION
@rickle-msft

This enables the consumer of the ensureLength error to consume and rethrow with a better contextual message (e.g. in the context of retries)