### PR TITLE
Fix HTTPS proxying

### DIFF
--- a/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/RefreshTokenClient.java
+++ b/azure-client-authentication/src/main/java/com/microsoft/azure/v2/credentials/RefreshTokenClient.java
@@ -48,7 +48,7 @@ final class RefreshTokenClient {
 
     private static HttpClient createHttpClient(Proxy proxy) {
         return new NettyClient.Factory()
-                .create(new HttpClientConfiguration(proxy, false));
+                .create(new HttpClientConfiguration(proxy));
     }
 
     AuthenticationResult refreshToken(String tenant, String clientId, String resource, String refreshToken, boolean isMultipleResoureRefreshToken) {

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyToRestProxyWithNettyTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyToRestProxyWithNettyTests.java
@@ -9,6 +9,6 @@ public class AzureProxyToRestProxyWithNettyTests extends AzureProxyToRestProxyTe
 
     @Override
     protected HttpClient createHttpClient() {
-        return nettyClientFactory.create(new HttpClientConfiguration(null, false));
+        return nettyClientFactory.create(new HttpClientConfiguration(null));
     }
 }

--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -57,6 +57,10 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
     </dependency>
     <dependency>

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientConfiguration.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientConfiguration.java
@@ -13,7 +13,6 @@ import java.net.Proxy;
  */
 public class HttpClientConfiguration {
     private final Proxy proxy;
-    private final boolean isProxyHTTPS;
 
     /**
      * @return The optional proxy to use.
@@ -23,21 +22,10 @@ public class HttpClientConfiguration {
     }
 
     /**
-     * Indicates whether the connection to the proxy is via HTTP or HTTPS.
-     * This is unrelated to whether the final resource being accessed is over HTTP or HTTPS.
-     * @return true if the proxy should be connected via HTTPS
-     */
-    public boolean isProxyHTTPS() {
-        return isProxyHTTPS;
-    }
-
-    /**
      * Creates an HttpClientConfiguration.
      * @param proxy The optional proxy to use.
-     * @param isProxyHTTPS true if the proxy should be connected via HTTPS
      */
-    public HttpClientConfiguration(Proxy proxy, boolean isProxyHTTPS) {
+    public HttpClientConfiguration(Proxy proxy) {
         this.proxy = proxy;
-        this.isProxyHTTPS = isProxyHTTPS;
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -1180,7 +1180,7 @@ public abstract class RestProxyTests {
         final HttpBinHeaders headers = response.headers();
         assertNotNull(headers);
         assertEquals(true, headers.accessControlAllowCredentials);
-        assertEquals("keep-alive", headers.connection);
+        assertEquals("keep-alive", headers.connection.toLowerCase());
         assertNotNull(headers.date);
         assertEquals("1.1 vegur", headers.via);
         assertNotEquals(0, headers.xProcessedTime);
@@ -1236,7 +1236,7 @@ public abstract class RestProxyTests {
         final HttpBinHeaders headers = response.headers();
         assertNotNull(headers);
         assertEquals(true, headers.accessControlAllowCredentials);
-        assertEquals("keep-alive", headers.connection);
+        assertEquals("keep-alive", headers.connection.toLowerCase());
         assertNotNull(headers.date);
         assertEquals("1.1 vegur", headers.via);
         assertNotEquals(0, headers.xProcessedTime);
@@ -1258,7 +1258,7 @@ public abstract class RestProxyTests {
         final HttpBinHeaders headers = response.headers();
         assertNotNull(headers);
         assertEquals(true, headers.accessControlAllowCredentials);
-        assertEquals("keep-alive", headers.connection);
+        assertEquals("keep-alive", headers.connection.toLowerCase());
         assertNotNull(headers.date);
         assertEquals("1.1 vegur", headers.via);
         assertNotEquals(0, headers.xProcessedTime);

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithHttpProxyNettyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithHttpProxyNettyTests.java
@@ -16,6 +16,6 @@ public class RestProxyWithHttpProxyNettyTests extends RestProxyTests {
     protected HttpClient createHttpClient() {
         InetSocketAddress address = new InetSocketAddress("127.0.0.1", 8888);
         Proxy proxy = new Proxy(Proxy.Type.HTTP, address);
-        return nettyClientFactory.create(new HttpClientConfiguration(proxy, false));
+        return nettyClientFactory.create(new HttpClientConfiguration(proxy));
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithNettyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyWithNettyTests.java
@@ -9,6 +9,6 @@ public class RestProxyWithNettyTests extends RestProxyTests {
 
     @Override
     protected HttpClient createHttpClient() {
-        return nettyClientFactory.create(new HttpClientConfiguration(null, false));
+        return nettyClientFactory.create(new HttpClientConfiguration(null));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
         <version>${netty.version}</version>
       </dependency>


### PR DESCRIPTION
Related to #451 

I've finally gotten a grip on [how HTTPs proxying actually works](https://github.com/netty/netty/blob/4.1/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java#L155) and am making changes as appropriate--including just relying on Netty's HttpProxyHandler to do the job.

This change seems like the right direction--we pass the destination address to channel.connect(), and pass the proxy address to HttpProxyHandler.

I've fixed the remaining issues by always using `HttpClientCodec` instead using of `HttpRequestEncoder` and `HttpResponseDecoder`. I think we were putting the pipeline in an inconsistent state by manipulating it from outside the event loop thread.