### PR TITLE
Added configurability of SSL Context

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -26,6 +26,8 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -149,7 +151,7 @@ public final class NettyClient extends HttpClient {
         }
 
         private static SharedChannelPool createChannelPool(Bootstrap bootstrap, TransportConfig config,
-                int poolSize) {
+                int poolSize, SslContext sslContext) {
             bootstrap.group(config.eventLoopGroup);
             bootstrap.channel(config.channelClass);
             bootstrap.option(ChannelOption.AUTO_READ, false);
@@ -163,19 +165,19 @@ public final class NettyClient extends HttpClient {
                     ch.pipeline().addLast("HttpClientCodec", new HttpClientCodec());
                     ch.pipeline().addLast("HttpClientInboundHandler", new HttpClientInboundHandler());
                 }
-            }, poolSize);
+            }, poolSize, new SharedChannelPoolOptions(), sslContext);
         }
 
         private NettyAdapter() {
             TransportConfig config = loadTransport(0);
             this.eventLoopGroup = config.eventLoopGroup;
-            this.channelPool = createChannelPool(new Bootstrap(), config, eventLoopGroup.executorCount() * 16);
+            this.channelPool = createChannelPool(new Bootstrap(), config, eventLoopGroup.executorCount() * 16, null);
         }
 
-        private NettyAdapter(Bootstrap baseBootstrap, int eventLoopGroupSize, int channelPoolSize) {
+        private NettyAdapter(Bootstrap baseBootstrap, int eventLoopGroupSize, int channelPoolSize, SslContext sslContext) {
             TransportConfig config = loadTransport(eventLoopGroupSize);
             this.eventLoopGroup = config.eventLoopGroup;
-            this.channelPool = createChannelPool(baseBootstrap, config, channelPoolSize);
+            this.channelPool = createChannelPool(baseBootstrap, config, channelPoolSize, sslContext);
         }
 
         private Single<HttpResponse> sendRequestInternalAsync(final HttpRequest request, final HttpClientConfiguration configuration) {
@@ -892,7 +894,8 @@ public final class NettyClient extends HttpClient {
     public static class Factory implements HttpClientFactory {
         private final NettyAdapter adapter;
 
-        /**
+
+		/**
          * Create a Netty client factory with default settings.
          */
         public Factory() {
@@ -911,14 +914,18 @@ public final class NettyClient extends HttpClient {
          *            the number of pooled channels (connections)
          */
         public Factory(Bootstrap baseBootstrap, int eventLoopGroupSize, int channelPoolSize) {
-            this.adapter = new NettyAdapter(baseBootstrap.clone(), eventLoopGroupSize, channelPoolSize);
+            this(baseBootstrap.clone(), eventLoopGroupSize, channelPoolSize, null);
         }
-
+        
+        public Factory(Bootstrap baseBootstrap, int eventLoopGroupSize, int channelPoolSize, SslContext sslContext) {
+            this.adapter = new NettyAdapter(baseBootstrap.clone(), eventLoopGroupSize, channelPoolSize, sslContext);
+        }
+        
         @Override
         public HttpClient create(final HttpClientConfiguration configuration) {
             return new NettyClient(configuration, adapter);
         }
-
+        
         @Override
         public void close() {
             adapter.shutdownGracefully().awaitUninterruptibly();

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -27,7 +27,6 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -895,7 +894,7 @@ public final class NettyClient extends HttpClient {
         private final NettyAdapter adapter;
 
 
-		/**
+        /**
          * Create a Netty client factory with default settings.
          */
         public Factory() {
@@ -917,6 +916,19 @@ public final class NettyClient extends HttpClient {
             this(baseBootstrap.clone(), eventLoopGroupSize, channelPoolSize, null);
         }
         
+        /**
+         * Create a Netty client factory, specifying the event loop group size and the
+         * channel pool size.
+         * 
+         * @param baseBootstrap
+         *          a channel Bootstrap to use as a basis for channel creation
+         * @param eventLoopGroupSize
+         *          the number of event loop executors
+         * @param channelPoolSize
+         *          the number of pooled channels (connections)
+         * @param sslContext
+         *          An SslContext, can be null.
+         */
         public Factory(Bootstrap baseBootstrap, int eventLoopGroupSize, int channelPoolSize, SslContext sslContext) {
             this.adapter = new NettyAdapter(baseBootstrap.clone(), eventLoopGroupSize, channelPoolSize, sslContext);
         }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/SharedChannelPool.java
@@ -92,11 +92,11 @@ class SharedChannelPool implements ChannelPool {
         this.available = new ConcurrentMultiHashMap<>();
         this.leased = new ConcurrentMultiHashMap<>();
         try {
-        	if(sslContext == null) {
-        		this.sslContext = SslContextBuilder.forClient().build();
-        	} else {
-        		this.sslContext = sslContext;
-        	}
+            if (sslContext == null) {
+                this.sslContext = SslContextBuilder.forClient().build();
+            } else {
+                this.sslContext = sslContext;
+            }
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This pull request is coming form Isobar  The modifications contained will enable us to utilize this latest (v2) version of the Azure Storage on the AF CCE project.    The actual  changes are simple and they enable passing in an SslContext to the underlying NettyClient implementation of HttpClient.  This was done via an overloaded constructor.  Existing constructor signatures were left and reference the new implementation by passing in null for the SslContext which will cause the SSL behavior to fallback to the previous (now default) behavior. 