### PR TITLE
Fixes Key Vault default resource value

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/credentials/AzureTokenCredentials.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/credentials/AzureTokenCredentials.java
@@ -53,7 +53,7 @@ public abstract class AzureTokenCredentials extends TokenCredentials {
         for (Map.Entry<String, String> endpoint : environment().endpoints().entrySet()) {
             if (host.contains(endpoint.getValue())) {
                 if (endpoint.getKey().equals(Endpoint.KEYVAULT.identifier())) {
-                    resource = String.format("https://%s/", endpoint.getValue().replaceAll("^\\.*", ""));
+                    resource = String.format("https://%s", endpoint.getValue().replaceAll("^\\.*", ""));
                     break;
                 } else if (endpoint.getKey().equals(Endpoint.GRAPH.identifier())) {
                     resource = environment().graphEndpoint();


### PR DESCRIPTION
For requests to Key Vault (`*.vault.azure.net/...`), the current version of `AzureTokenCredentials.getToken(...)` will get an access token for the resource `https://vault.azure.net/` and include it in the request.

However, Key Vault only accepts `https://vault.azure.net` (without the trailing slash) as a valid audience in its access tokens, so this request will _always_ result in a 401 response. This results in at least one unnecessary token request (the initial token request for `https://vault.azure.net/`), and one failed request to Key Vault (followed by the subsequent successful request with the correct token).

(Things eventually work because following a 401 response, the library will retry the token request (now for the correct resource value, obtained from the `WWW-Authenticate` header), and retry the request to Key Vault, which usually succeeds.)

This PR fixes the logic so that requests to Key Vault use the correct resource from the beginning.