### PR TITLE
Fix tests based on httpbin changes and add proxy scheme support

### DIFF
--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyToRestProxyTests.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/AzureProxyToRestProxyTests.java
@@ -167,7 +167,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnything();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
     }
 
     @Test
@@ -175,7 +175,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithPlus();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with+plus", json.url);
+        assertEquals("https://httpbin.org/anything/with+plus", json.url);
     }
 
     @Test
@@ -183,7 +183,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithPathParam("withpathparam");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/withpathparam", json.url);
+        assertEquals("https://httpbin.org/anything/withpathparam", json.url);
     }
 
     @Test
@@ -191,7 +191,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithPathParam("with path param");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with path param", json.url);
+        assertEquals("https://httpbin.org/anything/with path param", json.url);
     }
 
     @Test
@@ -199,7 +199,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithPathParam("with+path+param");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with+path+param", json.url);
+        assertEquals("https://httpbin.org/anything/with+path+param", json.url);
     }
 
     @Test
@@ -207,7 +207,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithEncodedPathParam("withpathparam");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/withpathparam", json.url);
+        assertEquals("https://httpbin.org/anything/withpathparam", json.url);
     }
 
     @Test
@@ -215,7 +215,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithEncodedPathParam("with%20path%20param");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with path param", json.url);
+        assertEquals("https://httpbin.org/anything/with path param", json.url);
     }
 
     @Test
@@ -223,7 +223,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithEncodedPathParam("with+path+param");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with+path+param", json.url);
+        assertEquals("https://httpbin.org/anything/with+path+param", json.url);
     }
 
     @Test
@@ -232,7 +232,7 @@ public abstract class AzureProxyToRestProxyTests {
                 .getAnythingAsync()
                 .blockingGet();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
     }
 
     @Host("http://httpbin.org")
@@ -255,7 +255,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service6.class)
                 .getAnything("A", 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?a=A&b=15", json.url);
+        assertEquals("https://httpbin.org/anything?a=A&b=15", json.url);
     }
 
     @Test
@@ -263,7 +263,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service6.class)
                 .getAnything("A%20Z", 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?a=A%2520Z&b=15", json.url);
+        assertEquals("https://httpbin.org/anything?a=A%2520Z&b=15", json.url);
     }
 
     @Test
@@ -271,7 +271,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service6.class)
                 .getAnythingWithEncoded("x%20y", 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?a=x y&b=15", json.url);
+        assertEquals("https://httpbin.org/anything?a=x y&b=15", json.url);
     }
 
     @Test
@@ -280,7 +280,7 @@ public abstract class AzureProxyToRestProxyTests {
                 .getAnythingAsync("A", 15)
                 .blockingGet();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?a=A&b=15", json.url);
+        assertEquals("https://httpbin.org/anything?a=A&b=15", json.url);
     }
 
     @Host("http://httpbin.org")
@@ -299,7 +299,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service7.class)
                 .getAnything("A", 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
         assertNotNull(json.headers);
         final HttpHeaders headers = new HttpHeaders(json.headers);
         assertEquals("A", headers.value("A"));
@@ -314,7 +314,7 @@ public abstract class AzureProxyToRestProxyTests {
                 .getAnythingAsync("A", 15)
                 .blockingGet();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
         assertNotNull(json.headers);
         final HttpHeaders headers = new HttpHeaders(json.headers);
         assertEquals("A", headers.value("A"));
@@ -540,7 +540,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON json = createService(Service13.class)
                 .get();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
         assertNotNull(json.headers);
         final HttpHeaders headers = new HttpHeaders(json.headers);
         assertEquals("MyHeaderValue", headers.value("MyHeader"));
@@ -555,7 +555,7 @@ public abstract class AzureProxyToRestProxyTests {
                 .getAsync()
                 .blockingGet();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
         assertNotNull(json.headers);
         final HttpHeaders headers = new HttpHeaders(json.headers);
         assertEquals("MyHeaderValue", headers.value("MyHeader"));
@@ -623,7 +623,7 @@ public abstract class AzureProxyToRestProxyTests {
         final Service16 service = createService(Service16.class);
         final HttpBinJSON result = service.put(new byte[] { 0, 1, 2, 3, 4, 5 });
         assertNotNull(result);
-        assertEquals("http://httpbin.org/put", result.url);
+        assertEquals("https://httpbin.org/put", result.url);
         assertTrue(result.data instanceof String);
         assertArrayEquals(new byte[] { 0, 1, 2, 3, 4, 5 }, ((String)result.data).getBytes());
     }
@@ -634,7 +634,7 @@ public abstract class AzureProxyToRestProxyTests {
         final HttpBinJSON result = service.putAsync(new byte[] { 0, 1, 2, 3, 4, 5 })
                 .blockingGet();
         assertNotNull(result);
-        assertEquals("http://httpbin.org/put", result.url);
+        assertEquals("https://httpbin.org/put", result.url);
         assertTrue(result.data instanceof String);
         assertArrayEquals(new byte[] { 0, 1, 2, 3, 4, 5 }, ((String)result.data).getBytes());
     }
@@ -655,7 +655,7 @@ public abstract class AzureProxyToRestProxyTests {
         final Service17 service17 = createService(Service17.class);
         final HttpBinJSON result = service17.get("http", "bin");
         assertNotNull(result);
-        assertEquals("http://httpbin.org/get", result.url);
+        assertEquals("https://httpbin.org/get", result.url);
     }
 
     @Test
@@ -663,7 +663,7 @@ public abstract class AzureProxyToRestProxyTests {
         final Service17 service17 = createService(Service17.class);
         final HttpBinJSON result = service17.getAsync("http", "bin").blockingGet();
         assertNotNull(result);
-        assertEquals("http://httpbin.org/get", result.url);
+        assertEquals("https://httpbin.org/get", result.url);
     }
 
     @Host("https://httpbin.org")

--- a/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpClient.java
+++ b/azure-client-runtime/src/test/java/com/microsoft/azure/v2/http/MockAzureHttpClient.java
@@ -72,7 +72,8 @@ public class MockAzureHttpClient extends HttpClient {
                         final HttpBinJSON json = new HttpBinJSON();
                         json.url = request.url().toString()
                                 // This is just to mimic the behavior we've seen with httpbin.org.
-                                .replace("%20", " ");
+                                .replace("%20", " ")
+                                .replace("http://", "https://");
                         json.headers = toMap(request.headers());
                         response = new MockAzureHttpResponse(200, responseHeaders(), json);
                     }
@@ -90,7 +91,8 @@ public class MockAzureHttpClient extends HttpClient {
                 }
                 else if (requestPathLower.equals("/get")) {
                     final HttpBinJSON json = new HttpBinJSON();
-                    json.url = request.url().toString();
+                    json.url = request.url().toString()
+                            .replace("http://", "https://");
                     json.headers = toMap(request.headers());
                     response = new MockAzureHttpResponse(200, responseHeaders(), json);
                 }
@@ -108,7 +110,8 @@ public class MockAzureHttpClient extends HttpClient {
                 }
                 else if (requestPathLower.equals("/put")) {
                     final HttpBinJSON json = new HttpBinJSON();
-                    json.url = request.url().toString();
+                    json.url = request.url().toString()
+                            .replace("http://", "https://");
                     json.data = bodyToString(request);
                     response = new MockAzureHttpResponse(200, responseHeaders(), json);
                 }

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientConfiguration.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientConfiguration.java
@@ -29,7 +29,7 @@ public class HttpClientConfiguration {
      * The scheme/protocol that will be used when sending the request to the proxy. If this is null, then the scheme
      * will be determined by the port of the proxy (80 will use 'http' and 443 will use 'https'). If the port of the
      * proxy isn't recognized (not 80 or 443), then the scheme of the final destination URI will be used.
-     * @return
+     * @return The proxy scheme that has been configured.
      */
     public String proxyScheme() {
         return proxyScheme;

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientConfiguration.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/HttpClientConfiguration.java
@@ -15,6 +15,7 @@ import java.net.Proxy;
  */
 public class HttpClientConfiguration {
     private final Proxy proxy;
+    private final String proxyScheme;
     private SharedChannelPoolOptions poolOptions;
 
     /**
@@ -25,11 +26,34 @@ public class HttpClientConfiguration {
     }
 
     /**
+     * The scheme/protocol that will be used when sending the request to the proxy. If this is null, then the scheme
+     * will be determined by the port of the proxy (80 will use 'http' and 443 will use 'https'). If the port of the
+     * proxy isn't recognized (not 80 or 443), then the scheme of the final destination URI will be used.
+     * @return
+     */
+    public String proxyScheme() {
+        return proxyScheme;
+    }
+
+    /**
      * Creates an HttpClientConfiguration.
      * @param proxy The optional proxy to use.
      */
     public HttpClientConfiguration(Proxy proxy) {
+        this(proxy, null);
+    }
+
+    /**
+     * Creates an HttpClientConfiguration.
+     * @param proxy The optional proxy to use.
+     * @param proxyScheme The scheme/protocol that will be used when sending the request to the proxy. If this is null,
+     *                    then the scheme will be determined by the port of the proxy (80 will use 'http' and 443 will
+     *                    use 'https'). If the port of the proxy isn't 80 or 443, then the scheme of the final
+     *                    destination URI will be used.
+     */
+    public HttpClientConfiguration(Proxy proxy, String proxyScheme) {
         this.proxy = proxy;
+        this.proxyScheme = proxyScheme;
         this.poolOptions = new SharedChannelPoolOptions();
     }
 

--- a/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/v2/http/NettyClient.java
@@ -190,7 +190,7 @@ public final class NettyClient extends HttpClient {
             return Single.create((SingleEmitter<HttpResponse> responseEmitter) -> {
                 AcquisitionListener listener = new AcquisitionListener(channelPool, request, responseEmitter);
                 responseEmitter.setDisposable(listener);
-                channelPool.acquire(request.url().toURI(), configuration.proxy()).addListener(listener);
+                channelPool.acquire(request.url().toURI(), configuration.proxyScheme(), configuration.proxy()).addListener(listener);
             });
         }
     }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/RestProxyTests.java
@@ -181,7 +181,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnything();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
     }
 
     @Test
@@ -189,7 +189,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithPlus();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with+plus", json.url);
+        assertEquals("https://httpbin.org/anything/with+plus", json.url);
     }
 
     @Test
@@ -197,7 +197,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithPathParam("withpathparam");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/withpathparam", json.url);
+        assertEquals("https://httpbin.org/anything/withpathparam", json.url);
     }
 
     @Test
@@ -205,7 +205,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithPathParam("with path param");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with path param", json.url);
+        assertEquals("https://httpbin.org/anything/with path param", json.url);
     }
 
     @Test
@@ -213,7 +213,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithPathParam("with+path+param");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with+path+param", json.url);
+        assertEquals("https://httpbin.org/anything/with+path+param", json.url);
     }
 
     @Test
@@ -221,7 +221,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithEncodedPathParam("withpathparam");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/withpathparam", json.url);
+        assertEquals("https://httpbin.org/anything/withpathparam", json.url);
     }
 
     @Test
@@ -229,7 +229,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithEncodedPathParam("with%20path%20param");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with path param", json.url);
+        assertEquals("https://httpbin.org/anything/with path param", json.url);
     }
 
     @Test
@@ -237,7 +237,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service5.class)
                 .getAnythingWithEncodedPathParam("with+path+param");
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything/with+path+param", json.url);
+        assertEquals("https://httpbin.org/anything/with+path+param", json.url);
     }
 
     @Test
@@ -246,7 +246,7 @@ public abstract class RestProxyTests {
                 .getAnythingAsync()
                 .blockingGet();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
     }
 
     @Host("http://httpbin.org")
@@ -269,7 +269,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service6.class)
                 .getAnything("A", 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?a=A&b=15", json.url);
+        assertEquals("https://httpbin.org/anything?a=A&b=15", json.url);
     }
 
     @Test
@@ -277,7 +277,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service6.class)
                 .getAnything("A%20Z", 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?a=A%2520Z&b=15", json.url);
+        assertEquals("https://httpbin.org/anything?a=A%2520Z&b=15", json.url);
     }
 
     @Test
@@ -285,7 +285,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service6.class)
                 .getAnythingWithEncoded("x%20y", 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?a=x y&b=15", json.url);
+        assertEquals("https://httpbin.org/anything?a=x y&b=15", json.url);
     }
 
     @Test
@@ -294,7 +294,7 @@ public abstract class RestProxyTests {
                 .getAnythingAsync("A", 15)
                 .blockingGet();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?a=A&b=15", json.url);
+        assertEquals("https://httpbin.org/anything?a=A&b=15", json.url);
     }
 
     @Test
@@ -302,7 +302,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service6.class)
                 .getAnything(null, 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything?b=15", json.url);
+        assertEquals("https://httpbin.org/anything?b=15", json.url);
     }
 
     @Host("http://httpbin.org")
@@ -321,7 +321,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service7.class)
                 .getAnything("A", 15);
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
         assertNotNull(json.headers);
         final HttpHeaders headers = new HttpHeaders(json.headers);
         assertEquals("A", headers.value("A"));
@@ -336,7 +336,7 @@ public abstract class RestProxyTests {
                 .getAnythingAsync("A", 15)
                 .blockingGet();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
         assertNotNull(json.headers);
         final HttpHeaders headers = new HttpHeaders(json.headers);
         assertEquals("A", headers.value("A"));
@@ -642,7 +642,7 @@ public abstract class RestProxyTests {
         final HttpBinJSON json = createService(Service13.class)
                 .get();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
         assertNotNull(json.headers);
         final HttpHeaders headers = new HttpHeaders(json.headers);
         assertEquals("MyHeaderValue", headers.value("MyHeader"));
@@ -657,7 +657,7 @@ public abstract class RestProxyTests {
                 .getAsync()
                 .blockingGet();
         assertNotNull(json);
-        assertEquals("http://httpbin.org/anything", json.url);
+        assertEquals("https://httpbin.org/anything", json.url);
         assertNotNull(json.headers);
         final HttpHeaders headers = new HttpHeaders(json.headers);
         assertEquals("MyHeaderValue", headers.value("MyHeader"));
@@ -763,7 +763,7 @@ public abstract class RestProxyTests {
         final Service17 service17 = createService(Service17.class);
         final HttpBinJSON result = service17.get("http", "bin");
         assertNotNull(result);
-        assertEquals("http://httpbin.org/get", result.url);
+        assertEquals("https://httpbin.org/get", result.url);
     }
 
     @Test
@@ -771,7 +771,7 @@ public abstract class RestProxyTests {
         final Service17 service17 = createService(Service17.class);
         final HttpBinJSON result = service17.getAsync("http", "bin").blockingGet();
         assertNotNull(result);
-        assertEquals("http://httpbin.org/get", result.url);
+        assertEquals("https://httpbin.org/get", result.url);
     }
 
     @Host("https://httpbin.org")
@@ -1182,7 +1182,7 @@ public abstract class RestProxyTests {
         assertEquals(true, headers.accessControlAllowCredentials);
         assertEquals("keep-alive", headers.connection.toLowerCase());
         assertNotNull(headers.date);
-        assertEquals("1.1 vegur", headers.via);
+        assertEquals(null, headers.via);
         assertNotEquals(0, headers.xProcessedTime);
     }
 
@@ -1202,7 +1202,7 @@ public abstract class RestProxyTests {
         assertNotNull(headers);
         assertEquals(true, headers.accessControlAllowCredentials);
         assertNotNull(headers.date);
-        assertEquals("1.1 vegur", headers.via);
+        assertEquals(null, headers.via);
         assertNotEquals(0, headers.xProcessedTime);
     }
 
@@ -1238,7 +1238,7 @@ public abstract class RestProxyTests {
         assertEquals(true, headers.accessControlAllowCredentials);
         assertEquals("keep-alive", headers.connection.toLowerCase());
         assertNotNull(headers.date);
-        assertEquals("1.1 vegur", headers.via);
+        assertEquals(null, headers.via);
         assertNotEquals(0, headers.xProcessedTime);
     }
 
@@ -1252,7 +1252,7 @@ public abstract class RestProxyTests {
 
         final HttpBinJSON body = response.body();
         assertNotNull(body);
-        assertEquals("http://httpbin.org/put", body.url);
+        assertEquals("https://httpbin.org/put", body.url);
         assertEquals("body string", body.data);
 
         final HttpBinHeaders headers = response.headers();
@@ -1260,7 +1260,7 @@ public abstract class RestProxyTests {
         assertEquals(true, headers.accessControlAllowCredentials);
         assertEquals("keep-alive", headers.connection.toLowerCase());
         assertNotNull(headers.date);
-        assertEquals("1.1 vegur", headers.via);
+        assertEquals(null, headers.via);
         assertNotEquals(0, headers.xProcessedTime);
     }
 

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/MockHttpClient.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class MockHttpClient extends HttpClient {
     private static final HttpHeaders responseHeaders = new HttpHeaders()
             .set("Date", "Fri, 13 Oct 2017 20:33:09 GMT")
-            .set("Via", "1.1 vegur")
+            .set("Via", null)
             .set("Connection", "keep-alive")
             .set("X-Processed-Time", "1.0")
             .set("Access-Control-Allow-Credentials", "true")
@@ -53,7 +53,8 @@ public class MockHttpClient extends HttpClient {
                         final HttpBinJSON json = new HttpBinJSON();
                         json.url = request.url().toString()
                                 // This is just to mimic the behavior we've seen with httpbin.org.
-                                .replace("%20", " ");
+                                .replace("%20", " ")
+                                .replace("http://", "https://");
                         json.headers = toMap(request.headers());
                         response = new MockHttpResponse(200, json);
                     }
@@ -139,7 +140,8 @@ public class MockHttpClient extends HttpClient {
                 }
                 else if (requestPathLower.equals("/get")) {
                     final HttpBinJSON json = new HttpBinJSON();
-                    json.url = request.url().toString();
+                    json.url = request.url().toString()
+                            .replace("http://", "https://");
                     json.headers = toMap(request.headers());
                     response = new MockHttpResponse(200, json);
                 }
@@ -158,7 +160,8 @@ public class MockHttpClient extends HttpClient {
                 }
                 else if (requestPathLower.equals("/put")) {
                     final HttpBinJSON json = new HttpBinJSON();
-                    json.url = request.url().toString();
+                    json.url = request.url().toString()
+                            .replace("http://", "https://");
                     json.data = bodyToString(request);
                     json.headers = toMap(request.headers());
                     response = new MockHttpResponse(200, responseHeaders, json);

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/SharedChannelPoolTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/SharedChannelPoolTests.java
@@ -98,7 +98,7 @@ public class SharedChannelPoolTests {
         final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
         channelRequest.destinationURI = new URI("ftp://other.example.com");
         channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 80));
-        final URI expectedChannelUri = new URI("ftp://my.example.com:80");
+        final URI expectedChannelUri = new URI("http://my.example.com:80");
         assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
     }
 
@@ -116,7 +116,7 @@ public class SharedChannelPoolTests {
         final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
         channelRequest.destinationURI = new URI("https://other.example.com");
         channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 80));
-        final URI expectedChannelUri = new URI("https://my.example.com:80");
+        final URI expectedChannelUri = new URI("http://my.example.com:80");
         assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
     }
 
@@ -152,7 +152,7 @@ public class SharedChannelPoolTests {
         final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
         channelRequest.destinationURI = new URI("ftp://other.example.com");
         channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
-        final URI expectedChannelUri = new URI("ftp://my.example.com:443");
+        final URI expectedChannelUri = new URI("https://my.example.com:443");
         assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
     }
 
@@ -161,7 +161,7 @@ public class SharedChannelPoolTests {
         final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
         channelRequest.destinationURI = new URI("http://other.example.com");
         channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
-        final URI expectedChannelUri = new URI("http://my.example.com:443");
+        final URI expectedChannelUri = new URI("https://my.example.com:443");
         assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
     }
 
@@ -171,6 +171,96 @@ public class SharedChannelPoolTests {
         channelRequest.destinationURI = new URI("https://other.example.com");
         channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
         final URI expectedChannelUri = new URI("https://my.example.com:443");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort80AndProxySchemeSpamAndDestinationUriWithFtp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("ftp://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 80));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:80");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort80AndProxySchemeSpamAndDestinationUriWithHttp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("http://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 80));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:80");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort80AndProxySchemeSpamAndDestinationUriWithHttps() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("https://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 80));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:80");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort100AndProxySchemeSpamAndDestinationUriWithFtp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("ftp://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 100));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:100");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort100AndProxySchemeSpamAndDestinationUriWithHttp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("http://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 100));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:100");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort100AndProxySchemeSpamAndDestinationUriWithHttps() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("https://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 100));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:100");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort443AndProxySchemeSpamAndDestinationUriWithFtp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("ftp://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:443");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort443AndProxySchemeSpamAndDestinationUriWithHttp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("http://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:443");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort443AndProxySchemeSpamAndDestinationUriWithHttps() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("https://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
+        channelRequest.proxyScheme = "spam";
+        final URI expectedChannelUri = new URI("spam://my.example.com:443");
         assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/http/SharedChannelPoolTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/http/SharedChannelPoolTests.java
@@ -1,0 +1,176 @@
+package com.microsoft.rest.v2.http;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.*;
+
+public class SharedChannelPoolTests {
+    @Test
+    public void testGetChannelRequestPortWithNoPortInFtpURI() throws URISyntaxException {
+        final URI uri = new URI("ftp://example.com/path/to/file.html");
+        assertEquals(80, SharedChannelPool.getChannelRequestPort(uri));
+    }
+
+    @Test
+    public void testGetChannelRequestPortWithNoPortInHttpURI() throws URISyntaxException {
+        final URI uri = new URI("http://example.com/path/to/file.html");
+        assertEquals(80, SharedChannelPool.getChannelRequestPort(uri));
+    }
+
+    @Test
+    public void testGetChannelRequestPortWithNoPortInHttpsURI() throws URISyntaxException {
+        final URI uri = new URI("https://example.com/path/to/file.html");
+        assertEquals(443, SharedChannelPool.getChannelRequestPort(uri));
+    }
+
+    @Test
+    public void testGetChannelRequestPortWithPortInFtpURI() throws URISyntaxException {
+        final URI uri = new URI("ftp://example.com:1/path/to/file.html");
+        assertEquals(1, SharedChannelPool.getChannelRequestPort(uri));
+    }
+
+    @Test
+    public void testGetChannelRequestPortWithPortInHttpURI() throws URISyntaxException {
+        final URI uri = new URI("http://example.com:2/path/to/file.html");
+        assertEquals(2, SharedChannelPool.getChannelRequestPort(uri));
+    }
+
+    @Test
+    public void testGetChannelRequestPortWithPortInHttpsURI() throws URISyntaxException {
+        final URI uri = new URI("https://example.com:3/path/to/file.html");
+        assertEquals(3, SharedChannelPool.getChannelRequestPort(uri));
+    }
+
+    @Test
+    public void testGetChannelRequestDestinationURIWithSchemeAndHost() throws URISyntaxException {
+        final URI uri = new URI("http://example.com");
+        final int port = 4;
+        final URI expectedDestinationUri = new URI("http://example.com:4");
+        assertEquals(expectedDestinationUri, SharedChannelPool.getChannelRequestDestinationURI(uri, port));
+    }
+
+    @Test
+    public void testGetChannelRequestDestinationURIWithSchemeHostAndPort() throws URISyntaxException {
+        final URI uri = new URI("http://example.com:5");
+        final int port = 6;
+        final URI expectedDestinationUri = new URI("http://example.com:6");
+        assertEquals(expectedDestinationUri, SharedChannelPool.getChannelRequestDestinationURI(uri, port));
+    }
+
+    @Test
+    public void testGetChannelRequestDestinationURIWithSchemeHostAndPath() throws URISyntaxException {
+        final URI uri = new URI("http://example.com/path.html");
+        final int port = 7;
+        final URI expectedDestinationUri = new URI("http://example.com:7");
+        assertEquals(expectedDestinationUri, SharedChannelPool.getChannelRequestDestinationURI(uri, port));
+    }
+
+    @Test
+    public void testGetChannelRequestDestinationURIWithSchemeHostPortAndPath() throws URISyntaxException {
+        final URI uri = new URI("http://example.com:8/path.html");
+        final int port = 9;
+        final URI expectedDestinationUri = new URI("http://example.com:9");
+        assertEquals(expectedDestinationUri, SharedChannelPool.getChannelRequestDestinationURI(uri, port));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithNoProxyAndNoDestinationUri() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        final URI expectedChannelUri = null;
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithNoProxy() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("http://other.example.com");
+        final URI expectedChannelUri = new URI("http://other.example.com");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort80AndDestinationUriWithFtp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("ftp://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 80));
+        final URI expectedChannelUri = new URI("ftp://my.example.com:80");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort80AndDestinationUriWithHttp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("http://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 80));
+        final URI expectedChannelUri = new URI("http://my.example.com:80");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort80AndDestinationUriWithHttps() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("https://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 80));
+        final URI expectedChannelUri = new URI("https://my.example.com:80");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort100AndDestinationUriWithFtp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("ftp://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 100));
+        final URI expectedChannelUri = new URI("ftp://my.example.com:100");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort100AndDestinationUriWithHttp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("http://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 100));
+        final URI expectedChannelUri = new URI("http://my.example.com:100");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort100AndDestinationUriWithHttps() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("https://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 100));
+        final URI expectedChannelUri = new URI("https://my.example.com:100");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort443AndDestinationUriWithFtp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("ftp://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
+        final URI expectedChannelUri = new URI("ftp://my.example.com:443");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort443AndDestinationUriWithHttp() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("http://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
+        final URI expectedChannelUri = new URI("http://my.example.com:443");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+
+    @Test
+    public void testGetChannelRequestChannelURIWithProxyWithPort443AndDestinationUriWithHttps() throws URISyntaxException {
+        final SharedChannelPool.ChannelRequest channelRequest = new SharedChannelPool.ChannelRequest();
+        channelRequest.destinationURI = new URI("https://other.example.com");
+        channelRequest.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("my.example.com", 443));
+        final URI expectedChannelUri = new URI("https://my.example.com:443");
+        assertEquals(expectedChannelUri, SharedChannelPool.getChannelRequestChannelURI(channelRequest));
+    }
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/v2/util/FlowableUtilTests.java
@@ -81,8 +81,9 @@ public class FlowableUtilTests {
                     .collectInto(new ByteArrayOutputStream(), OutputStream::write) //
                     .blockingGet().toByteArray();
             assertEquals(0, bytes.length);
+        } finally {
+            file.deleteOnExit();
         }
-        assertTrue(file.delete());
     }
 
     @Test
@@ -100,8 +101,9 @@ public class FlowableUtilTests {
                     .blockingGet() //
                     .toByteArray();
             assertEquals("hello there", new String(bytes, StandardCharsets.UTF_8));
+        } finally {
+            file.deleteOnExit();
         }
-        assertTrue(file.delete());
     }
 
     private static final int NUM_CHUNKS_IN_LONG_INPUT = 10_000_000;


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-storage-java/issues/445.
This PR fixes some stale tests and also adds proxy scheme support. Previously the scheme/protocol that was used to communicate with a proxy server was the same as the scheme for the final destination URL. There are some situations where a customer doesn't want that to be the case, though. In the referenced issue, the customer wants to use HTTP to communicate with their proxy server, but then they want the proxy server to use HTTPS to send the final request. This PR enables that.