### PR TITLE
Update AsyncServiceClientCredentials to take HttpRequest

### DIFF
--- a/azure-common-auth/src/main/java/com/azure/common/auth/credentials/AzureTokenCredentials.java
+++ b/azure-common-auth/src/main/java/com/azure/common/auth/credentials/AzureTokenCredentials.java
@@ -9,6 +9,7 @@ package com.azure.common.auth.credentials;
 import com.azure.common.AzureEnvironment;
 import com.azure.common.AzureEnvironment.Endpoint;
 import com.azure.common.credentials.AsyncServiceClientCredentials;
+import com.azure.common.http.HttpRequest;
 import reactor.core.publisher.Mono;
 
 import java.net.MalformedURLException;
@@ -87,8 +88,8 @@ public abstract class AzureTokenCredentials implements AsyncServiceClientCredent
     public abstract Mono<String> getToken(String resource);
 
     @Override
-    public Mono<String> authorizationHeaderValueAsync(String uri) {
-        return getTokenFromUri(uri).map(token -> "Bearer " + token);
+    public Mono<String> authorizationHeaderValueAsync(HttpRequest request) {
+        return getTokenFromUri(request.url().toString()).map(token -> "Bearer " + token);
     }
 
     /**

--- a/azure-common-auth/src/main/java/com/azure/common/auth/credentials/AzureTokenCredentials.java
+++ b/azure-common-auth/src/main/java/com/azure/common/auth/credentials/AzureTokenCredentials.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * Resource management.
  */
 public abstract class AzureTokenCredentials implements AsyncServiceClientCredentials {
-    private static final String SCHEME = "Beareer";
+    private static final String SCHEME = "Bearer";
     private final AzureEnvironment environment;
     private final String domain;
     private String defaultSubscription;

--- a/azure-common-mgmt/src/main/java/com/azure/common/mgmt/policy/AsyncCredentialsPolicy.java
+++ b/azure-common-mgmt/src/main/java/com/azure/common/mgmt/policy/AsyncCredentialsPolicy.java
@@ -30,7 +30,7 @@ public class AsyncCredentialsPolicy implements HttpPipelinePolicy {
 
     @Override
     public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
-        return credentials.authorizationHeaderValueAsync(context.httpRequest().url().toString())
+        return credentials.authorizationHeaderValueAsync(context.httpRequest())
                 .flatMap(token -> {
                     context.httpRequest().headers().set("Authorization", token);
                     return next.process();

--- a/azure-common/src/main/java/com/azure/common/credentials/AsyncServiceClientCredentials.java
+++ b/azure-common/src/main/java/com/azure/common/credentials/AsyncServiceClientCredentials.java
@@ -10,10 +10,12 @@ import com.azure.common.http.HttpRequest;
 import reactor.core.publisher.Mono;
 
 /**
- * Provides credentials to be put in the HTTP Authorization header.
+ * Provides credentials for an HTTP request's 'Authorization' header.
  */
 public interface AsyncServiceClientCredentials {
     /**
+     * Given the {@param httpRequest}, generates a value for the 'Authorization' header.
+     *
      * @param httpRequest The HTTP request that requires an authorization header.
      * @return The value containing currently valid credentials to put in the HTTP header, 'Authorization'.
      */

--- a/azure-common/src/main/java/com/azure/common/credentials/AsyncServiceClientCredentials.java
+++ b/azure-common/src/main/java/com/azure/common/credentials/AsyncServiceClientCredentials.java
@@ -6,6 +6,7 @@
 
 package com.azure.common.credentials;
 
+import com.azure.common.http.HttpRequest;
 import reactor.core.publisher.Mono;
 
 /**
@@ -13,8 +14,8 @@ import reactor.core.publisher.Mono;
  */
 public interface AsyncServiceClientCredentials {
     /**
-     * @param uri The URI to which the request is being made.
-     * @return The value containing currently valid credentials to put in the HTTP header.
+     * @param httpRequest The HTTP request that requires an authorization header.
+     * @return The value containing currently valid credentials to put in the HTTP header, 'Authorization'.
      */
-    Mono<String> authorizationHeaderValueAsync(String uri);
+    Mono<String> authorizationHeaderValueAsync(HttpRequest httpRequest);
 }

--- a/azure-common/src/main/java/com/azure/common/http/policy/AsyncCredentialsPolicy.java
+++ b/azure-common/src/main/java/com/azure/common/http/policy/AsyncCredentialsPolicy.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.azure.common.http.policy;
+
+import com.azure.common.credentials.AsyncServiceClientCredentials;
+import com.azure.common.http.HttpPipelineCallContext;
+import com.azure.common.http.HttpPipelineNextPolicy;
+import com.azure.common.http.HttpResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+/**
+ * Creates a policy which adds credentials from {@link AsyncServiceClientCredentials} the 'Authorization' header of an
+ * HTTP request.
+ */
+public class AsyncCredentialsPolicy implements HttpPipelinePolicy {
+    private final AsyncServiceClientCredentials credentials;
+
+    /**
+     * Creates CredentialsPolicy.
+     *
+     * @param credentials The credentials to use for authentication.
+     */
+    public AsyncCredentialsPolicy(AsyncServiceClientCredentials credentials) {
+        Objects.requireNonNull(credentials);
+        this.credentials = credentials;
+    }
+
+    @Override
+    public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
+        return credentials.authorizationHeaderValueAsync(context.httpRequest())
+                .flatMap(token -> {
+                    context.httpRequest().headers().set("Authorization", token);
+                    return next.process();
+                });
+    }
+}

--- a/azure-common/src/main/java/com/azure/common/http/policy/AsyncCredentialsPolicy.java
+++ b/azure-common/src/main/java/com/azure/common/http/policy/AsyncCredentialsPolicy.java
@@ -15,14 +15,14 @@ import reactor.core.publisher.Mono;
 import java.util.Objects;
 
 /**
- * Creates a policy which adds credentials from {@link AsyncServiceClientCredentials} the 'Authorization' header of an
- * HTTP request.
+ * Creates a policy which adds credentials from {@link AsyncServiceClientCredentials} to the 'Authorization' header of
+ * each HTTP request.
  */
 public class AsyncCredentialsPolicy implements HttpPipelinePolicy {
     private final AsyncServiceClientCredentials credentials;
 
     /**
-     * Creates CredentialsPolicy.
+     * Creates an {@link AsyncCredentialsPolicy} that authenticates HTTP requests using the given {@param credentials}.
      *
      * @param credentials The credentials to use for authentication.
      */
@@ -31,6 +31,9 @@ public class AsyncCredentialsPolicy implements HttpPipelinePolicy {
         this.credentials = credentials;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
         return credentials.authorizationHeaderValueAsync(context.httpRequest())


### PR DESCRIPTION
There are auth schemes that require more information than just the service url. Example is the HMAC-SHA256 that the Azure Application Configuration team requires for their service. This requires us to construct a string from HttpHeaders in addition to the service url.