### PR TITLE
 Validator checks just accessible fields (#569)

### DIFF
--- a/client-runtime/pom.xml
+++ b/client-runtime/pom.xml
@@ -109,8 +109,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>9</source>
+          <target>9</target>
         </configuration>
       </plugin>
 

--- a/client-runtime/src/main/java/com/microsoft/rest/Validator.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/Validator.java
@@ -74,7 +74,10 @@ public final class Validator {
             return;
         }
         for (Field field : c.getDeclaredFields()) {
-            field.setAccessible(true);
+            // Skip private and default fields
+            if (!field.trySetAccessible()) {
+                continue;
+            }
             int mod = field.getModifiers();
             // Skip static fields since we don't have any, skip final fields since users can't modify them
             if (Modifier.isFinal(mod) || Modifier.isStatic(mod)) {

--- a/client-runtime/src/test/java/com/microsoft/rest/ValidatorTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/ValidatorTests.java
@@ -73,7 +73,6 @@ public class ValidatorTests {
 
     @Test
     public void validateList() throws Exception {
-        System.out.println("Validate List Test");
         ListWrapper body = new ListWrapper();
         try {
             body.list = null;

--- a/client-runtime/src/test/java/com/microsoft/rest/ValidatorTests.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/ValidatorTests.java
@@ -73,6 +73,7 @@ public class ValidatorTests {
 
     @Test
     public void validateList() throws Exception {
+        System.out.println("Validate List Test");
         ListWrapper body = new ListWrapper();
         try {
             body.list = null;
@@ -82,6 +83,7 @@ public class ValidatorTests {
             Assert.assertTrue(ex.getMessage().contains("list is required"));
         }
         body.list = new ArrayList<StringWrapper>();
+        Validator.validate(body.list); // warns illegal access
         Validator.validate(body); // pass
         StringWrapper wrapper = new StringWrapper();
         wrapper.value = "valid";


### PR DESCRIPTION
JVM 9+ raises the message "

> All illegal access operations will be denied in a future release

because of this statement the Validator needs to try to set true to field access mode, it avoids exceptions in environments running JVM with option --illegal-access=deny.
**The Method trySetAccessible is Java 9 API Level**.