### PR TITLE
Updating Flattening encoder-decoder to handle JsonTypeInfo

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/serializer/FlatteningDeserializer.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/serializer/FlatteningDeserializer.java
@@ -7,6 +7,7 @@
 package com.microsoft.rest.serializer;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.BeanDescription;
@@ -16,9 +17,11 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializer;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.reflect.TypeToken;
@@ -66,10 +69,12 @@ public final class FlatteningDeserializer extends StdDeserializer<Object> implem
         module.setDeserializerModifier(new BeanDeserializerModifier() {
             @Override
             public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
-                if (beanDesc.getBeanClass().getAnnotation(JsonFlatten.class) != null) {
+                if (BeanDeserializer.class.isAssignableFrom(deserializer.getClass())) {
+                    // Apply flattening deserializer on all POJO types.
                     return new FlatteningDeserializer(beanDesc.getBeanClass(), deserializer, mapper);
+                } else {
+                    return deserializer;
                 }
-                return deserializer;
             }
         });
         return module;
@@ -77,40 +82,153 @@ public final class FlatteningDeserializer extends StdDeserializer<Object> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-        JsonNode root = mapper.readTree(jp);
+    public Object deserializeWithType(JsonParser jp, DeserializationContext cxt, TypeDeserializer tDeserializer) throws IOException {
+        // This method will be called by Jackson for each "Json object with TypeId" in the input wire stream
+        // it is trying to deserialize.
+        // The below variable 'currentJsonNode' will hold the JsonNode corresponds to current
+        // Json object this method is called to handle.
+        //
+        JsonNode currentJsonNode = mapper.readTree(jp);
         final Class<?> tClass = this.defaultDeserializer.handledType();
         for (Class<?> c : TypeToken.of(tClass).getTypes().classes().rawTypes()) {
-            // Ignore checks for Object type.
             if (c.isAssignableFrom(Object.class)) {
                 continue;
-            }
-            for (Field field : c.getDeclaredFields()) {
-                JsonNode node = root;
-                JsonProperty property = field.getAnnotation(JsonProperty.class);
-                if (property != null) {
-                    String value = property.value();
-                    if (value.matches(".+[^\\\\]\\..+")) {
-                        String[] values = value.split("((?<!\\\\))\\.");
-                        for (String val : values) {
-                            val = val.replace("\\.", ".");
-                            node = node.get(val);
-                            if (node == null) {
-                                break;
-                            }
+            } else {
+                final JsonTypeInfo typeInfo = c.getAnnotation(com.fasterxml.jackson.annotation.JsonTypeInfo.class);
+                if (typeInfo != null) {
+                    String typeId = typeInfo.property();
+                    if (containsDot(typeId)) {
+                        final String typeIdOnWire = unescapeEscapedDots(typeId);
+                        JsonNode typeIdValue = ((ObjectNode) currentJsonNode).remove(typeIdOnWire);
+                        if (typeIdValue != null) {
+                            ((ObjectNode) currentJsonNode).put(typeId, typeIdValue);
                         }
-                        ((ObjectNode) root).put(value, node);
                     }
                 }
             }
         }
-        JsonParser parser = new JsonFactory().createParser(root.toString());
-        parser.nextToken();
-        return defaultDeserializer.deserialize(parser, ctxt);
+        return tDeserializer.deserializeTypedFromAny(newJsonParserForNode(currentJsonNode), cxt);
     }
 
     @Override
-    public void resolve(DeserializationContext ctxt) throws JsonMappingException {
-        ((ResolvableDeserializer) defaultDeserializer).resolve(ctxt);
+    public Object deserialize(JsonParser jp, DeserializationContext cxt) throws IOException {
+        // This method will be called by Jackson for each "Json object" in the input wire stream
+        // it is trying to deserialize.
+        // The below variable 'currentJsonNode' will hold the JsonNode corresponds to current
+        // Json object this method is called to handle.
+        //
+        JsonNode currentJsonNode = mapper.readTree(jp);
+        final Class<?> tClass = this.defaultDeserializer.handledType();
+        for (Class<?> c : TypeToken.of(tClass).getTypes().classes().rawTypes()) {
+            if (c.isAssignableFrom(Object.class)) {
+                continue;
+            } else {
+                for (Field classField : c.getDeclaredFields()) {
+                    handleFlatteningForField(classField, currentJsonNode);
+                }
+            }
+        }
+        return this.defaultDeserializer.deserialize(newJsonParserForNode(currentJsonNode), cxt);
+    }
+
+    @Override
+    public void resolve(DeserializationContext cxt) throws JsonMappingException {
+        ((ResolvableDeserializer) this.defaultDeserializer).resolve(cxt);
+    }
+
+    /**
+     * Given a field of a POJO class and JsonNode corresponds to the same POJO class,
+     * check field's {@link JsonProperty} has flattening dots in it if so
+     * flatten the nested child JsonNode corresponds to the field in the given JsonNode.
+     *
+     * @param classField the field in a POJO class
+     * @param jsonNode the json node corresponds to POJO class that field belongs to
+     */
+    @SuppressWarnings("unchecked")
+    private static void handleFlatteningForField(Field classField, JsonNode jsonNode) {
+        final JsonProperty jsonProperty = classField.getAnnotation(JsonProperty.class);
+        if (jsonProperty != null) {
+            final String jsonPropValue = jsonProperty.value();
+            if (containsFlatteningDots(jsonPropValue)) {
+                JsonNode childJsonNode = findNestedNode(jsonNode, jsonPropValue);
+                ((ObjectNode) jsonNode).put(jsonPropValue, childJsonNode);
+            }
+        }
+    }
+
+    /**
+     * Given a json node, find a nested node using given composed key.
+     *
+     * @param jsonNode the parent json node
+     * @param composedKey a key combines multiple keys using flattening dots.
+     *                    Flattening dots are dot character '.' those are not preceded by slash '\'
+     *                    Each flattening dot represents a level with following key as field key in that level
+     * @return nested json node located using given composed key
+     */
+    private static JsonNode findNestedNode(JsonNode jsonNode, String composedKey) {
+        String[] jsonNodeKeys = splitKeyByFlatteningDots(composedKey);
+        for (String jsonNodeKey : jsonNodeKeys) {
+            jsonNode = jsonNode.get(unescapeEscapedDots(jsonNodeKey));
+            if (jsonNode == null) {
+                return null;
+            }
+        }
+        return jsonNode;
+    }
+
+    /**
+     * Checks whether the given key has flattening dots in it.
+     * Flattening dots are dot character '.' those are not preceded by slash '\'
+     *
+     * @param key the key
+     * @return true if the key has flattening dots, false otherwise.
+     */
+    private static boolean containsFlatteningDots(String key) {
+        return key.matches(".+[^\\\\]\\..+");
+    }
+
+    /**
+     * Split the key by flattening dots.
+     * Flattening dots are dot character '.' those are not preceded by slash '\'
+     *
+     * @param key the key to split
+     * @return the array of sub keys
+     */
+    private static String[] splitKeyByFlatteningDots(String key) {
+        return key.split("((?<!\\\\))\\.");
+    }
+
+    /**
+     * Unescape the escaped dots in the key.
+     * Escaped dots are non-flattening dots those are preceded by slash '\'
+     *
+     * @param key the key unescape
+     * @return unescaped key
+     */
+    private static String unescapeEscapedDots(String key) {
+        // Replace '\.' with '.'
+        return key.replace("\\.", ".");
+    }
+
+    /**
+     * Checks the given string contains 0 or more dots.
+     *
+     * @param str the string to check
+     * @return true if at least one dot found
+     */
+    private static boolean containsDot(String str) {
+       return str != null && str != "" && str.contains(".");
+    }
+
+    /**
+     * Create a JsonParser for a given json node.
+     * @param jsonNode the json node
+     * @return the json parser
+     * @throws IOException
+     */
+    private static JsonParser newJsonParserForNode(JsonNode jsonNode) throws IOException {
+        JsonParser parser = new JsonFactory().createParser(jsonNode.toString());
+        parser.nextToken();
+        return parser;
     }
 }

--- a/client-runtime/src/test/java/com/microsoft/rest/AnimalShelter.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/AnimalShelter.java
@@ -1,0 +1,36 @@
+package com.microsoft.rest;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.microsoft.rest.serializer.JsonFlatten;
+
+import java.util.List;
+
+@JsonFlatten
+public class AnimalShelter {
+
+    @JsonProperty(value = "properties.description")
+    private String description;
+
+    @JsonProperty(value = "properties.animalsInfo", required = true)
+    private List<FlattenableAnimalInfo> animalsInfo;
+
+    public String description() {
+        return this.description;
+    }
+
+    public AnimalShelter withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public List<FlattenableAnimalInfo> animalsInfo() {
+        return this.animalsInfo;
+    }
+
+    public AnimalShelter withAnimalsInfo(List<FlattenableAnimalInfo> animalsInfo) {
+        this.animalsInfo = animalsInfo;
+        return this;
+    }
+
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/AnimalWithTypeIdContainingDot.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/AnimalWithTypeIdContainingDot.java
@@ -1,0 +1,16 @@
+package com.microsoft.rest;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@odata\\.type")
+@JsonTypeName("AnimalWithTypeIdContainingDot")
+@JsonSubTypes({
+        @JsonSubTypes.Type(name = "#Favourite.Pet.DogWithTypeIdContainingDot", value = DogWithTypeIdContainingDot.class),
+        @JsonSubTypes.Type(name = "#Favourite.Pet.CatWithTypeIdContainingDot", value = CatWithTypeIdContainingDot.class),
+        @JsonSubTypes.Type(name = "#Favourite.Pet.RabbitWithTypeIdContainingDot", value = RabbitWithTypeIdContainingDot.class)
+})
+public class AnimalWithTypeIdContainingDot {
+}
+

--- a/client-runtime/src/test/java/com/microsoft/rest/CatWithTypeIdContainingDot.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/CatWithTypeIdContainingDot.java
@@ -1,0 +1,21 @@
+package com.microsoft.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@odata\\.type")
+@JsonTypeName("#Favourite.Pet.CatWithTypeIdContainingDot")
+public class CatWithTypeIdContainingDot extends AnimalWithTypeIdContainingDot {
+    @JsonProperty(value = "breed", required = true)
+    private String breed;
+
+    public String breed() {
+        return this.breed;
+    }
+
+    public CatWithTypeIdContainingDot withBreed(String presetName) {
+        this.breed = presetName;
+        return this;
+    }
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/DogWithTypeIdContainingDot.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/DogWithTypeIdContainingDot.java
@@ -1,0 +1,34 @@
+package com.microsoft.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@odata\\.type")
+@JsonTypeName("#Favourite.Pet.DogWithTypeIdContainingDot")
+public class DogWithTypeIdContainingDot extends AnimalWithTypeIdContainingDot {
+    @JsonProperty(value = "breed")
+    private String breed;
+
+    // Flattenable property
+    @JsonProperty(value = "properties.cuteLevel")
+    private Integer cuteLevel;
+
+    public String breed() {
+        return this.breed;
+    }
+
+    public DogWithTypeIdContainingDot withBreed(String audioLanguage) {
+        this.breed = audioLanguage;
+        return this;
+    }
+
+    public Integer cuteLevel() {
+        return this.cuteLevel;
+    }
+
+    public DogWithTypeIdContainingDot withCuteLevel(Integer cuteLevel) {
+        this.cuteLevel = cuteLevel;
+        return this;
+    }
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/FlattenableAnimalInfo.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/FlattenableAnimalInfo.java
@@ -1,0 +1,31 @@
+package com.microsoft.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FlattenableAnimalInfo {
+
+    @JsonProperty(value = "home")
+    private String home;
+
+    @JsonProperty(value = "animal", required = true)
+    private AnimalWithTypeIdContainingDot animal;
+
+    public String home() {
+        return this.home;
+    }
+
+    public FlattenableAnimalInfo withHome(String home) {
+        this.home = home;
+        return this;
+    }
+
+    public AnimalWithTypeIdContainingDot animal() {
+        return this.animal;
+    }
+
+    public FlattenableAnimalInfo withAnimal(AnimalWithTypeIdContainingDot animal) {
+        this.animal = animal;
+        return this;
+    }
+
+}

--- a/client-runtime/src/test/java/com/microsoft/rest/RabbitWithTypeIdContainingDot.java
+++ b/client-runtime/src/test/java/com/microsoft/rest/RabbitWithTypeIdContainingDot.java
@@ -1,0 +1,35 @@
+package com.microsoft.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.List;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@odata\\.type")
+@JsonTypeName("#Favourite.Pet.RabbitWithTypeIdContainingDot")
+public class RabbitWithTypeIdContainingDot extends AnimalWithTypeIdContainingDot {
+    @JsonProperty(value = "tailLength")
+    private Integer tailLength;
+
+    @JsonProperty(value = "meals")
+    private List<String> meals;
+
+    public Integer filters() {
+        return this.tailLength;
+    }
+
+    public RabbitWithTypeIdContainingDot withTailLength(Integer tailLength) {
+        this.tailLength = tailLength;
+        return this;
+    }
+
+    public List<String> meals() {
+        return this.meals;
+    }
+
+    public RabbitWithTypeIdContainingDot withMeals(List<String> meals) {
+        this.meals = meals;
+        return this;
+    }
+}


### PR DESCRIPTION
1. Handle typeId (JsonTypeInfo) containing dots (Fixes: https://github.com/Azure/autorest-clientruntime-for-java/issues/598)
2. Handle escaped property key
3. Ensure all POJOs goes through flattening encoder and decoder (hence ignore JsonFlatten annotation)
4. TypeId related autorest PR https://github.com/Azure/autorest.java/pull/336