### PR TITLE
Update adal4j to 1.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
       <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>adal4j</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.4</version>
       </dependency>
       <dependency>
         <groupId>io.reactivex</groupId>


### PR DESCRIPTION
To fix customer reported conflicts of oauth2-oidc-sdk dependency.