### PR TITLE
Upgrade adapter-rxjava to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
       <dependency>
         <groupId>com.squareup.retrofit2</groupId>
         <artifactId>adapter-rxjava</artifactId>
-        <version>2.4.0</version>
+        <version>2.6.2</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
- The version of adapter-rxjava that was used (2.4.0) was marked as vulnerable in 2 CVEs:  CVE-2018-1000844, CVE-2018-1000850