### PR TITLE
Added volatile to ServiceFuture's valueSet flag

### DIFF
--- a/client-runtime/src/main/java/com/microsoft/rest/ServiceFuture.java
+++ b/client-runtime/src/main/java/com/microsoft/rest/ServiceFuture.java
@@ -25,7 +25,7 @@ public class ServiceFuture<T> extends AbstractFuture<T> {
      * The Retrofit method invocation.
      */
     private Subscription subscription;
-    private boolean valueSet = false;
+    private volatile boolean valueSet = false;
 
     protected ServiceFuture() {
     }


### PR DESCRIPTION
Added `volatile` to ServiceFuture's `valueSet` flag, so in case `isCancelled` gets called from a thread other than the subscribe thread the calling thread sees the value change. Based on @anuchandy's comment [here](https://github.com/Azure/autorest-clientruntime-for-java/pull/665#discussion_r421031830).