### PR TITLE
run the delay on Schedulers.immediate

### DIFF
--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
@@ -133,7 +133,7 @@ public final class AzureClient extends AzureServiceClient {
                             return Observable.just(pollingState);
                         } else {
                             // initial delay
-                            return Observable.just(pollingState).delaySubscription(pollingState.delayInMilliseconds(), TimeUnit.MILLISECONDS);
+                            return Observable.just(pollingState).delaySubscription(pollingState.delayInMilliseconds(), TimeUnit.MILLISECONDS, Schedulers.immediate());
                         }
                     }
                 })

--- a/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
+++ b/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java
@@ -387,7 +387,7 @@ public final class AzureClient extends AzureServiceClient {
                             return Observable.just(pollingState);
                         } else {
                             // initial delay
-                            return Observable.just(pollingState).delaySubscription(pollingState.delayInMilliseconds(), TimeUnit.MILLISECONDS);
+                            return Observable.just(pollingState).delaySubscription(pollingState.delayInMilliseconds(), TimeUnit.MILLISECONDS, Schedulers.immediate());
                         }
                     }
                 })


### PR DESCRIPTION
Original `delaySubscription` without specifying a specific scheduler seems causing deadlock in replay mode on certain Linux version (ubuntu 18.04).

Now put it to `Schedulers.immediate()` similar to existing code, e.g. https://github.com/Azure/autorest-clientruntime-for-java/blob/master/azure-client-runtime/src/main/java/com/microsoft/azure/AzureClient.java#L258-L261

Replay sets to run on `Schedulers.trampoline()` (i.e., single thread), which might be the cause. But still not figured out why OS matters (there seems nothing for OS to schedule if that is already a single thread).