### PR TITLE
update readme to recommend libs on azure-sdk-for-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-[![Build Status](https://travis-ci.org/Azure/autorest-clientruntime-for-java.svg?branch=javavnext)](https://travis-ci.org/Azure/autorest-clientruntime-for-java)
+# It is highly recommended to use the new [Azure SDK for Java](https://github.com/Azure/azure-sdk-for-java)
+
+The AutoRest Client Runtimes for Java library was used as a dependency of older Azure client libraries, most of which was already deprecated.
+
+If you find that this library is included in dependencies though another Azure client library, please see whether there is new Azure client library available [here](https://azure.github.io/azure-sdk/releases/latest/#java).
+
+If you are directly using this library, please consider migrate to [azure-core libraries](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/core), or [azure-identity libraries](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/identity).
 
 # AutoRest Client Runtimes for Java
 The runtime libraries for [AutoRest](https://github.com/azure/autorest) generated Java clients. 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # It is highly recommended to use the new [Azure SDK for Java](https://github.com/Azure/azure-sdk-for-java)
 
-The AutoRest Client Runtimes for Java library was used as a dependency of older Azure client libraries, most of which was already deprecated.
+The AutoRest Client Runtime for Java library was used as a dependency of older Azure client libraries.
 
 If you find that this library is included in dependencies though another Azure client library, please see whether there is new Azure client library available [here](https://azure.github.io/azure-sdk/releases/latest/#java).
 
-If you are directly using this library, please consider migrate to [azure-core libraries](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/core), or [azure-identity libraries](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/identity).
+If you are directly using this library, please consider using new [azure-core libraries](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/core), or [azure-identity libraries](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/identity).
 
-# AutoRest Client Runtimes for Java
+# AutoRest Client Runtime for Java
 The runtime libraries for [AutoRest](https://github.com/azure/autorest) generated Java clients. 
 
 ## Usage
@@ -40,7 +40,7 @@ The runtime libraries for [AutoRest](https://github.com/azure/autorest) generate
 ### Create a RestClient
 
 ```java
-// For Java genenerator
+// For Java generator
 RestClient simpleClient = new RestClient.Builder()
     .withBaseUrl("http://localhost")
     .withResponseBuilderFactory(new ServiceResponseBuilder.Factory())


### PR DESCRIPTION
Not sure if we can deprecate this lib.

For now, at least we should discourage dev using this lib (whichever if they use it directly, or via transitive dependency).